### PR TITLE
Remove extra contact fields from DRKG entry

### DIFF
--- a/kgmetadata/drkg.md
+++ b/kgmetadata/drkg.md
@@ -9,8 +9,6 @@ preferredPrefix: http
 contact:
   orcid: 0000-0002-8367-0733
   github: https://github.com/bioannidis
-  email: 
-  label: 
 homepage: https://github.com/gnn4dr/DRKG
 tracker: https://github.com/gnn4dr/DRKG/issues
 repository: https://github.com/gnn4dr/DRKG


### PR DESCRIPTION
The build process doesn't work if fields are blank - it raises an error.
So this PR removes two empty fields from the DRKG entry.