### PR TITLE
Add schema slots for FAIRsharing ID and infores IDs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,30 +53,35 @@ resources:
   - category: GraphProduct
     description: CTD Automat
     id: ctd_automat
+    infores_id: automat-ctd
     is_kgx: true
     name: ctd_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/CTD_Automat/latest/kgx_files
   - category: GraphProduct
     description: DrugCentral Automat
     id: drugcentral_automat
+    infores_id: automat-drug-central
     is_kgx: true
     name: drugcentral_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/DrugCentral_Automat/latest/kgx_files
   - category: GraphProduct
     description: GTEx Automat
     id: gtex_automat
+    infores_id: automat-gtex
     is_kgx: true
     name: gtex_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/GTEx_Automat/latest/kgx_files
   - category: GraphProduct
     description: GtoPdb Automat
     id: gtopdb_automat
+    infores_id: automat-gtopdb
     is_kgx: true
     name: gtopdb_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/GtoPdb_Automat/latest/kgx_files
   - category: GraphProduct
     description: GWASCatalog Automat
     id: gwascatalog_automat
+    infores_id: automat-gwas-catalog
     is_kgx: true
     name: gwascatalog_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/GWASCatalog_Automat/latest/kgx_files
@@ -89,24 +94,28 @@ resources:
   - category: GraphProduct
     description: HGNC Automat
     id: hgnc_automat
+    infores_id: automat-hgnc
     is_kgx: true
     name: hgnc_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/HGNC_Automat/latest/kgx_files
   - category: GraphProduct
     description: HMDB Automat
     id: hmdb_automat
+    infores_id: automat-hmdb
     is_kgx: true
     name: hmdb_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/HMDB_Automat/latest/kgx_files
   - category: GraphProduct
     description: HumanGOA Automat
     id: humangoa_automat
+    infores_id: automat-human-goa
     is_kgx: true
     name: humangoa_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/HumanGOA_Automat/latest/kgx_files
   - category: GraphProduct
     description: IntAct Automat
     id: intact_automat
+    infores_id: automat-intact
     is_kgx: true
     name: intact_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/IntAct_Automat/latest/kgx_files
@@ -119,12 +128,14 @@ resources:
   - category: GraphProduct
     description: PANTHER Automat
     id: panther_automat
+    infores_id: automat-panther
     is_kgx: true
     name: panther_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/PANTHER_Automat/latest/kgx_files
   - category: GraphProduct
     description: PHAROS Automat
     id: pharos_automat
+    infores_id: automat-pharos
     is_kgx: true
     name: pharos_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/PHAROS_Automat/latest/kgx_files
@@ -367,7 +378,9 @@ resources:
     orcid: 0000-0003-4423-4370
   description: HUGO Gene Nomenclature Committee
   domain: biological systems
+  fairsharing_id: FAIRsharing.amcv1e
   id: hgnc
+  infores_id: hgnc
   layout: resource_detail
   name: hgnc
   products:

--- a/_layouts/resource_detail.html
+++ b/_layouts/resource_detail.html
@@ -224,12 +224,14 @@ page.is_obsolete %}
       </dd>
       {% endif %}
 
-      {% if page.mailing_list %}
-      <dt>Mailing List</dt>
+      {% if page.fairsharing_id %}
+      <dt>FAIRsharing ID</dt>
       <dd>
-        <a href="{{page.mailing_list}}">{{page.mailing_list}}</a>
+        <a href="https://fairsharing.org/{{page.fairsharing_id}}">{{page.fairsharing_id}}</a>
       </dd>
-      {% endif %} {% if page.taxon %}
+      {% endif %}
+      
+      {% if page.taxon %}
       <dt>Taxon</dt>
       <dd>
         <a href="http://amigo.geneontology.org/amigo/term/{{page.taxon.id}}"

--- a/_layouts/resource_detail.html
+++ b/_layouts/resource_detail.html
@@ -224,13 +224,20 @@ page.is_obsolete %}
       </dd>
       {% endif %}
 
+      {% if page.infores_id %}
+      <dt>Infores ID</dt>
+      <dd>
+        {{page.infores_id}}
+      </dd>
+      {% endif %}
+
       {% if page.fairsharing_id %}
       <dt>FAIRsharing ID</dt>
       <dd>
         <a href="https://fairsharing.org/{{page.fairsharing_id}}">{{page.fairsharing_id}}</a>
       </dd>
       {% endif %}
-      
+
       {% if page.taxon %}
       <dt>Taxon</dt>
       <dd>

--- a/_layouts/resource_detail.html
+++ b/_layouts/resource_detail.html
@@ -97,7 +97,7 @@ page.is_obsolete %}
             <td> KGX Available!</td>
             {% endif %}
             {% if p.infores_id %}
-            <td> {{p.infores_id}}</td>
+            <td> infores:{{p.infores_id}}</td>
             {% endif %}
           </tr>
           {% endfor %}
@@ -230,7 +230,7 @@ page.is_obsolete %}
       {% if page.infores_id %}
       <dt>Infores ID</dt>
       <dd>
-        {{page.infores_id}}
+        infores:{{page.infores_id}}
       </dd>
       {% endif %}
 

--- a/_layouts/resource_detail.html
+++ b/_layouts/resource_detail.html
@@ -96,6 +96,9 @@ page.is_obsolete %}
             {% if p.is_kgx %}
             <td> KGX Available!</td>
             {% endif %}
+            {% if p.infores_id %}
+            <td> {{p.infores_id}}</td>
+            {% endif %}
           </tr>
           {% endfor %}
         </tbody>

--- a/registry/kgs.jsonld
+++ b/registry/kgs.jsonld
@@ -47,6 +47,7 @@
                     "category": "GraphProduct",
                     "description": "CTD Automat",
                     "id": "ctd_automat",
+                    "infores_id": "automat-ctd",
                     "is_kgx": true,
                     "name": "ctd_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/CTD_Automat/latest/kgx_files"
@@ -55,6 +56,7 @@
                     "category": "GraphProduct",
                     "description": "DrugCentral Automat",
                     "id": "drugcentral_automat",
+                    "infores_id": "automat-drug-central",
                     "is_kgx": true,
                     "name": "drugcentral_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/DrugCentral_Automat/latest/kgx_files"
@@ -63,6 +65,7 @@
                     "category": "GraphProduct",
                     "description": "GTEx Automat",
                     "id": "gtex_automat",
+                    "infores_id": "automat-gtex",
                     "is_kgx": true,
                     "name": "gtex_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/GTEx_Automat/latest/kgx_files"
@@ -71,6 +74,7 @@
                     "category": "GraphProduct",
                     "description": "GtoPdb Automat",
                     "id": "gtopdb_automat",
+                    "infores_id": "automat-gtopdb",
                     "is_kgx": true,
                     "name": "gtopdb_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/GtoPdb_Automat/latest/kgx_files"
@@ -79,6 +83,7 @@
                     "category": "GraphProduct",
                     "description": "GWASCatalog Automat",
                     "id": "gwascatalog_automat",
+                    "infores_id": "automat-gwas-catalog",
                     "is_kgx": true,
                     "name": "gwascatalog_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/GWASCatalog_Automat/latest/kgx_files"
@@ -95,6 +100,7 @@
                     "category": "GraphProduct",
                     "description": "HGNC Automat",
                     "id": "hgnc_automat",
+                    "infores_id": "automat-hgnc",
                     "is_kgx": true,
                     "name": "hgnc_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/HGNC_Automat/latest/kgx_files"
@@ -103,6 +109,7 @@
                     "category": "GraphProduct",
                     "description": "HMDB Automat",
                     "id": "hmdb_automat",
+                    "infores_id": "automat-hmdb",
                     "is_kgx": true,
                     "name": "hmdb_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/HMDB_Automat/latest/kgx_files"
@@ -111,6 +118,7 @@
                     "category": "GraphProduct",
                     "description": "HumanGOA Automat",
                     "id": "humangoa_automat",
+                    "infores_id": "automat-human-goa",
                     "is_kgx": true,
                     "name": "humangoa_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/HumanGOA_Automat/latest/kgx_files"
@@ -119,6 +127,7 @@
                     "category": "GraphProduct",
                     "description": "IntAct Automat",
                     "id": "intact_automat",
+                    "infores_id": "automat-intact",
                     "is_kgx": true,
                     "name": "intact_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/IntAct_Automat/latest/kgx_files"
@@ -135,6 +144,7 @@
                     "category": "GraphProduct",
                     "description": "PANTHER Automat",
                     "id": "panther_automat",
+                    "infores_id": "automat-panther",
                     "is_kgx": true,
                     "name": "panther_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/PANTHER_Automat/latest/kgx_files"
@@ -143,6 +153,7 @@
                     "category": "GraphProduct",
                     "description": "PHAROS Automat",
                     "id": "pharos_automat",
+                    "infores_id": "automat-pharos",
                     "is_kgx": true,
                     "name": "pharos_automat",
                     "url": "https://stars.renci.org/var/plater/bl-3.1.2/PHAROS_Automat/latest/kgx_files"
@@ -481,7 +492,9 @@
             ],
             "description": "HUGO Gene Nomenclature Committee",
             "domain": "biological systems",
+            "fairsharing_id": "FAIRsharing.amcv1e",
             "id": "hgnc",
+            "infores_id": "hgnc",
             "layout": "resource_detail",
             "name": "hgnc",
             "products": [

--- a/registry/kgs.yml
+++ b/registry/kgs.yml
@@ -35,30 +35,35 @@ resources:
   - category: GraphProduct
     description: CTD Automat
     id: ctd_automat
+    infores_id: automat-ctd
     is_kgx: true
     name: ctd_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/CTD_Automat/latest/kgx_files
   - category: GraphProduct
     description: DrugCentral Automat
     id: drugcentral_automat
+    infores_id: automat-drug-central
     is_kgx: true
     name: drugcentral_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/DrugCentral_Automat/latest/kgx_files
   - category: GraphProduct
     description: GTEx Automat
     id: gtex_automat
+    infores_id: automat-gtex
     is_kgx: true
     name: gtex_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/GTEx_Automat/latest/kgx_files
   - category: GraphProduct
     description: GtoPdb Automat
     id: gtopdb_automat
+    infores_id: automat-gtopdb
     is_kgx: true
     name: gtopdb_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/GtoPdb_Automat/latest/kgx_files
   - category: GraphProduct
     description: GWASCatalog Automat
     id: gwascatalog_automat
+    infores_id: automat-gwas-catalog
     is_kgx: true
     name: gwascatalog_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/GWASCatalog_Automat/latest/kgx_files
@@ -71,24 +76,28 @@ resources:
   - category: GraphProduct
     description: HGNC Automat
     id: hgnc_automat
+    infores_id: automat-hgnc
     is_kgx: true
     name: hgnc_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/HGNC_Automat/latest/kgx_files
   - category: GraphProduct
     description: HMDB Automat
     id: hmdb_automat
+    infores_id: automat-hmdb
     is_kgx: true
     name: hmdb_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/HMDB_Automat/latest/kgx_files
   - category: GraphProduct
     description: HumanGOA Automat
     id: humangoa_automat
+    infores_id: automat-human-goa
     is_kgx: true
     name: humangoa_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/HumanGOA_Automat/latest/kgx_files
   - category: GraphProduct
     description: IntAct Automat
     id: intact_automat
+    infores_id: automat-intact
     is_kgx: true
     name: intact_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/IntAct_Automat/latest/kgx_files
@@ -101,12 +110,14 @@ resources:
   - category: GraphProduct
     description: PANTHER Automat
     id: panther_automat
+    infores_id: automat-panther
     is_kgx: true
     name: panther_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/PANTHER_Automat/latest/kgx_files
   - category: GraphProduct
     description: PHAROS Automat
     id: pharos_automat
+    infores_id: automat-pharos
     is_kgx: true
     name: pharos_automat
     url: https://stars.renci.org/var/plater/bl-3.1.2/PHAROS_Automat/latest/kgx_files
@@ -349,7 +360,9 @@ resources:
     orcid: 0000-0003-4423-4370
   description: HUGO Gene Nomenclature Committee
   domain: biological systems
+  fairsharing_id: FAIRsharing.amcv1e
   id: hgnc
+  infores_id: hgnc
   layout: resource_detail
   name: hgnc
   products:

--- a/resource/automat.md
+++ b/resource/automat.md
@@ -39,30 +39,35 @@ products:
   description: CTD Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/CTD_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-ctd
 - id: drugcentral_automat
   name: drugcentral_automat
   is_kgx: true
   description: DrugCentral Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/DrugCentral_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-drug-central
 - id: gtex_automat
   name: gtex_automat
   is_kgx: true
   description: GTEx Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/GTEx_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-gtex
 - id: gtopdb_automat
   name: gtopdb_automat
   is_kgx: true
   description: GtoPdb Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/GtoPdb_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-gtopdb
 - id: gwascatalog_automat
   name: gwascatalog_automat
   is_kgx: true
   description: GWASCatalog Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/GWASCatalog_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-gwas-catalog
 - id: hetio_automat
   name: hetio_automat
   is_kgx: true
@@ -75,24 +80,28 @@ products:
   description: HGNC Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/HGNC_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-hgnc
 - id: hmdb_automat
   name: hmdb_automat
   is_kgx: true
   description: HMDB Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/HMDB_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-hmdb
 - id: humangoa_automat
   name: humangoa_automat
   is_kgx: true
   description: HumanGOA Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/HumanGOA_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-human-goa
 - id: intact_automat
   name: intact_automat
   is_kgx: true
   description: IntAct Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/IntAct_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-intact
 - id: ontologicalhierarchy_automat
   name: ontologicalhierarchy_automat
   is_kgx: true
@@ -105,12 +114,14 @@ products:
   description: PANTHER Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/PANTHER_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-panther
 - id: pharos_automat
   name: pharos_automat
   is_kgx: true
   description: PHAROS Automat
   url: https://stars.renci.org/var/plater/bl-3.1.2/PHAROS_Automat/latest/kgx_files
   category: GraphProduct
+  infores_id: automat-pharos
 - id: stringdb_automat
   name: stringdb_automat
   is_kgx: true

--- a/resource/hgnc.md
+++ b/resource/hgnc.md
@@ -36,6 +36,8 @@ products:
   url: https://w3id.org/biopragmatics/resources/hgnc/hgnc.sssom
   category: MappingProduct
 category: DataGraph
+fairsharing_id: FAIRsharing.amcv1e
+infores_id: hgnc
 ---
 
 HUGO Gene Nomenclature Committee

--- a/src/kg_registry/kg_registry_schema/datamodel/kg_registry_schema.py
+++ b/src/kg_registry/kg_registry_schema/datamodel/kg_registry_schema.py
@@ -214,6 +214,8 @@ class Resource(ConfiguredBaseModel):
     publications: Optional[List[Publication]] = Field(default=None, description="""Publications associated with the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'publications', 'domain_of': ['Resource', 'Usage']} })
     category: str = Field(default=..., description="""The category of the resource. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     usages: Optional[List[Usage]] = Field(default=None, description="""The usage(s) of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'usages', 'domain_of': ['Resource']} })
+    fairsharing_id: Optional[str] = Field(default=None, description="""The FAIRsharing ID of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'fairsharing_id', 'domain_of': ['Resource']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the resource. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
     layout: Optional[str] = Field(default=None, description="""The layout of the resource. This is used to determine how to display the resource in the web interface. It should generally be 'resource_detail'.""", json_schema_extra = { "linkml_meta": {'alias': 'layout', 'domain_of': ['Resource']} })
 
 
@@ -253,6 +255,8 @@ class KnowledgeGraph(Resource):
     publications: Optional[List[Publication]] = Field(default=None, description="""Publications associated with the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'publications', 'domain_of': ['Resource', 'Usage']} })
     category: str = Field(default=..., description="""The category of the resource. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     usages: Optional[List[Usage]] = Field(default=None, description="""The usage(s) of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'usages', 'domain_of': ['Resource']} })
+    fairsharing_id: Optional[str] = Field(default=None, description="""The FAIRsharing ID of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'fairsharing_id', 'domain_of': ['Resource']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the resource. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
     layout: Optional[str] = Field(default=None, description="""The layout of the resource. This is used to determine how to display the resource in the web interface. It should generally be 'resource_detail'.""", json_schema_extra = { "linkml_meta": {'alias': 'layout', 'domain_of': ['Resource']} })
 
 
@@ -286,6 +290,8 @@ class DataGraph(Resource):
     publications: Optional[List[Publication]] = Field(default=None, description="""Publications associated with the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'publications', 'domain_of': ['Resource', 'Usage']} })
     category: str = Field(default=..., description="""The category of the resource. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     usages: Optional[List[Usage]] = Field(default=None, description="""The usage(s) of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'usages', 'domain_of': ['Resource']} })
+    fairsharing_id: Optional[str] = Field(default=None, description="""The FAIRsharing ID of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'fairsharing_id', 'domain_of': ['Resource']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the resource. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
     layout: Optional[str] = Field(default=None, description="""The layout of the resource. This is used to determine how to display the resource in the web interface. It should generally be 'resource_detail'.""", json_schema_extra = { "linkml_meta": {'alias': 'layout', 'domain_of': ['Resource']} })
 
 
@@ -318,6 +324,8 @@ class DataModel(Resource):
     publications: Optional[List[Publication]] = Field(default=None, description="""Publications associated with the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'publications', 'domain_of': ['Resource', 'Usage']} })
     category: str = Field(default=..., description="""The category of the resource. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     usages: Optional[List[Usage]] = Field(default=None, description="""The usage(s) of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'usages', 'domain_of': ['Resource']} })
+    fairsharing_id: Optional[str] = Field(default=None, description="""The FAIRsharing ID of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'fairsharing_id', 'domain_of': ['Resource']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the resource. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
     layout: Optional[str] = Field(default=None, description="""The layout of the resource. This is used to determine how to display the resource in the web interface. It should generally be 'resource_detail'.""", json_schema_extra = { "linkml_meta": {'alias': 'layout', 'domain_of': ['Resource']} })
 
 
@@ -350,6 +358,8 @@ class Mapping(Resource):
     publications: Optional[List[Publication]] = Field(default=None, description="""Publications associated with the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'publications', 'domain_of': ['Resource', 'Usage']} })
     category: str = Field(default=..., description="""The category of the resource. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     usages: Optional[List[Usage]] = Field(default=None, description="""The usage(s) of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'usages', 'domain_of': ['Resource']} })
+    fairsharing_id: Optional[str] = Field(default=None, description="""The FAIRsharing ID of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'fairsharing_id', 'domain_of': ['Resource']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the resource. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
     layout: Optional[str] = Field(default=None, description="""The layout of the resource. This is used to determine how to display the resource in the web interface. It should generally be 'resource_detail'.""", json_schema_extra = { "linkml_meta": {'alias': 'layout', 'domain_of': ['Resource']} })
 
 
@@ -382,6 +392,8 @@ class ProductionProcess(Resource):
     publications: Optional[List[Publication]] = Field(default=None, description="""Publications associated with the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'publications', 'domain_of': ['Resource', 'Usage']} })
     category: str = Field(default=..., description="""The category of the resource. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     usages: Optional[List[Usage]] = Field(default=None, description="""The usage(s) of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'usages', 'domain_of': ['Resource']} })
+    fairsharing_id: Optional[str] = Field(default=None, description="""The FAIRsharing ID of the resource.""", json_schema_extra = { "linkml_meta": {'alias': 'fairsharing_id', 'domain_of': ['Resource']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the resource. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
     layout: Optional[str] = Field(default=None, description="""The layout of the resource. This is used to determine how to display the resource in the web interface. It should generally be 'resource_detail'.""", json_schema_extra = { "linkml_meta": {'alias': 'layout', 'domain_of': ['Resource']} })
 
 
@@ -405,6 +417,7 @@ class Product(ConfiguredBaseModel):
     contacts: Optional[List[Contact]] = Field(default=None, description="""The contact points for the product. May be an individual or organization.""", json_schema_extra = { "linkml_meta": {'alias': 'contacts', 'domain_of': ['Resource', 'Product']} })
     category: str = Field(default=..., description="""The category of the product. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     tags: Optional[List[TagEnum]] = Field(default=None, description="""Tags associated with the product.""", json_schema_extra = { "linkml_meta": {'alias': 'tags', 'domain_of': ['Resource', 'Product']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the product. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
 
 
 class GraphProduct(Product):
@@ -431,6 +444,7 @@ class GraphProduct(Product):
     contacts: Optional[List[Contact]] = Field(default=None, description="""The contact points for the product. May be an individual or organization.""", json_schema_extra = { "linkml_meta": {'alias': 'contacts', 'domain_of': ['Resource', 'Product']} })
     category: str = Field(default=..., description="""The category of the product. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     tags: Optional[List[TagEnum]] = Field(default=None, description="""Tags associated with the product.""", json_schema_extra = { "linkml_meta": {'alias': 'tags', 'domain_of': ['Resource', 'Product']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the product. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
 
 
 class DataModelProduct(Product):
@@ -452,6 +466,7 @@ class DataModelProduct(Product):
     contacts: Optional[List[Contact]] = Field(default=None, description="""The contact points for the product. May be an individual or organization.""", json_schema_extra = { "linkml_meta": {'alias': 'contacts', 'domain_of': ['Resource', 'Product']} })
     category: str = Field(default=..., description="""The category of the product. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     tags: Optional[List[TagEnum]] = Field(default=None, description="""Tags associated with the product.""", json_schema_extra = { "linkml_meta": {'alias': 'tags', 'domain_of': ['Resource', 'Product']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the product. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
 
 
 class MappingProduct(Product):
@@ -473,6 +488,7 @@ class MappingProduct(Product):
     contacts: Optional[List[Contact]] = Field(default=None, description="""The contact points for the product. May be an individual or organization.""", json_schema_extra = { "linkml_meta": {'alias': 'contacts', 'domain_of': ['Resource', 'Product']} })
     category: str = Field(default=..., description="""The category of the product. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     tags: Optional[List[TagEnum]] = Field(default=None, description="""Tags associated with the product.""", json_schema_extra = { "linkml_meta": {'alias': 'tags', 'domain_of': ['Resource', 'Product']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the product. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
 
 
 class ProcessProduct(Product):
@@ -494,6 +510,7 @@ class ProcessProduct(Product):
     contacts: Optional[List[Contact]] = Field(default=None, description="""The contact points for the product. May be an individual or organization.""", json_schema_extra = { "linkml_meta": {'alias': 'contacts', 'domain_of': ['Resource', 'Product']} })
     category: str = Field(default=..., description="""The category of the product. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     tags: Optional[List[TagEnum]] = Field(default=None, description="""Tags associated with the product.""", json_schema_extra = { "linkml_meta": {'alias': 'tags', 'domain_of': ['Resource', 'Product']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the product. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
 
 
 class GraphicalInterface(Product):
@@ -515,6 +532,7 @@ class GraphicalInterface(Product):
     contacts: Optional[List[Contact]] = Field(default=None, description="""The contact points for the product. May be an individual or organization.""", json_schema_extra = { "linkml_meta": {'alias': 'contacts', 'domain_of': ['Resource', 'Product']} })
     category: str = Field(default=..., description="""The category of the product. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     tags: Optional[List[TagEnum]] = Field(default=None, description="""Tags associated with the product.""", json_schema_extra = { "linkml_meta": {'alias': 'tags', 'domain_of': ['Resource', 'Product']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the product. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
 
 
 class ProgrammingInterface(Product):
@@ -536,6 +554,7 @@ class ProgrammingInterface(Product):
     contacts: Optional[List[Contact]] = Field(default=None, description="""The contact points for the product. May be an individual or organization.""", json_schema_extra = { "linkml_meta": {'alias': 'contacts', 'domain_of': ['Resource', 'Product']} })
     category: str = Field(default=..., description="""The category of the product. This should be identical to its class name.""", json_schema_extra = { "linkml_meta": {'alias': 'category', 'domain_of': ['Resource', 'Product', 'Contact']} })
     tags: Optional[List[TagEnum]] = Field(default=None, description="""Tags associated with the product.""", json_schema_extra = { "linkml_meta": {'alias': 'tags', 'domain_of': ['Resource', 'Product']} })
+    infores_id: Optional[str] = Field(default=None, description="""The Infores ID of the product. Do not include the 'infores' prefix.""", json_schema_extra = { "linkml_meta": {'alias': 'infores_id', 'domain_of': ['Resource', 'Product']} })
 
 
 class Contact(ConfiguredBaseModel):

--- a/src/kg_registry/kg_registry_schema/kg_registry_schema.json
+++ b/src/kg_registry/kg_registry_schema/kg_registry_schema.json
@@ -58,6 +58,13 @@
                     "$ref": "#/$defs/DomainEnum",
                     "description": "The domain that the resource is relevant to. This is not multivalued."
                 },
+                "fairsharing_id": {
+                    "description": "The FAIRsharing ID of the resource.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "funding": {
                     "description": "The funding source(s) for the resource.",
                     "items": {
@@ -71,6 +78,13 @@
                 "id": {
                     "description": "The identifier of the resource. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the resource. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "language": {
                     "description": "The human language of the resource.",
@@ -215,6 +229,13 @@
                     "$ref": "#/$defs/DomainEnum",
                     "description": "The domain that the resource is relevant to. This is not multivalued."
                 },
+                "fairsharing_id": {
+                    "description": "The FAIRsharing ID of the resource.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "funding": {
                     "description": "The funding source(s) for the resource.",
                     "items": {
@@ -228,6 +249,13 @@
                 "id": {
                     "description": "The identifier of the resource. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the resource. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "language": {
                     "description": "The human language of the resource.",
@@ -361,6 +389,13 @@
                 "id": {
                     "description": "The identifier of the product. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the product. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "license": {
                     "anyOf": [
@@ -498,6 +533,13 @@
                     "description": "The identifier of the product. This is used to identify it within the registry.",
                     "type": "string"
                 },
+                "infores_id": {
+                    "description": "The Infores ID of the product. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "is_kgx": {
                     "description": "Whether the graph is in KGX format.",
                     "type": [
@@ -620,6 +662,13 @@
                 "id": {
                     "description": "The identifier of the product. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the product. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "license": {
                     "anyOf": [
@@ -794,6 +843,13 @@
                     "$ref": "#/$defs/DomainEnum",
                     "description": "The domain that the resource is relevant to. This is not multivalued."
                 },
+                "fairsharing_id": {
+                    "description": "The FAIRsharing ID of the resource.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "funding": {
                     "description": "The funding source(s) for the resource.",
                     "items": {
@@ -807,6 +863,13 @@
                 "id": {
                     "description": "The identifier of the resource. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the resource. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "language": {
                     "description": "The human language of the resource.",
@@ -970,6 +1033,13 @@
                     "$ref": "#/$defs/DomainEnum",
                     "description": "The domain that the resource is relevant to. This is not multivalued."
                 },
+                "fairsharing_id": {
+                    "description": "The FAIRsharing ID of the resource.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "funding": {
                     "description": "The funding source(s) for the resource.",
                     "items": {
@@ -983,6 +1053,13 @@
                 "id": {
                     "description": "The identifier of the resource. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the resource. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "language": {
                     "description": "The human language of the resource.",
@@ -1117,6 +1194,13 @@
                     "description": "The identifier of the product. This is used to identify it within the registry.",
                     "type": "string"
                 },
+                "infores_id": {
+                    "description": "The Infores ID of the product. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "license": {
                     "anyOf": [
                         {
@@ -1241,6 +1325,13 @@
                     "description": "The identifier of the product. This is used to identify it within the registry.",
                     "type": "string"
                 },
+                "infores_id": {
+                    "description": "The Infores ID of the product. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "license": {
                     "anyOf": [
                         {
@@ -1322,6 +1413,13 @@
                     "$ref": "#/$defs/DomainEnum",
                     "description": "The domain that the resource is relevant to. This is not multivalued."
                 },
+                "fairsharing_id": {
+                    "description": "The FAIRsharing ID of the resource.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "funding": {
                     "description": "The funding source(s) for the resource.",
                     "items": {
@@ -1335,6 +1433,13 @@
                 "id": {
                     "description": "The identifier of the resource. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the resource. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "language": {
                     "description": "The human language of the resource.",
@@ -1468,6 +1573,13 @@
                 "id": {
                     "description": "The identifier of the product. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the product. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "license": {
                     "anyOf": [
@@ -1603,6 +1715,13 @@
                     "$ref": "#/$defs/DomainEnum",
                     "description": "The domain that the resource is relevant to. This is not multivalued."
                 },
+                "fairsharing_id": {
+                    "description": "The FAIRsharing ID of the resource.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "funding": {
                     "description": "The funding source(s) for the resource.",
                     "items": {
@@ -1616,6 +1735,13 @@
                 "id": {
                     "description": "The identifier of the resource. This is used to identify it within the registry.",
                     "type": "string"
+                },
+                "infores_id": {
+                    "description": "The Infores ID of the resource. Do not include the 'infores' prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "language": {
                     "description": "The human language of the resource.",

--- a/src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml
+++ b/src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml
@@ -136,6 +136,10 @@ classes:
         description: >-
           The FAIRsharing ID of the resource.
         range: string
+      infores_id:
+        description: >-
+          The Infores ID of the resource.
+        range: string
       layout:
         description: >-
           The layout of the resource.

--- a/src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml
+++ b/src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml
@@ -132,6 +132,10 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
+      fairsharing_id:
+        description: >-
+          The FAIRsharing ID of the resource.
+        range: string
       layout:
         description: >-
           The layout of the resource.

--- a/src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml
+++ b/src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml
@@ -139,6 +139,7 @@ classes:
       infores_id:
         description: >-
           The Infores ID of the resource.
+          Do not include the 'infores' prefix.
         range: string
       layout:
         description: >-
@@ -278,6 +279,11 @@ classes:
         description: Tags associated with the product.
         range: TagEnum
         multivalued: true
+      infores_id:
+        description: >-
+          The Infores ID of the product.
+          Do not include the 'infores' prefix.
+        range: string
 
   GraphProduct:
     description: >-


### PR DESCRIPTION
Resources can have a `fairsharing_id`.
Resources and products can have `infores_id`.
All are shown on the detail page for each resource.