### PR TITLE
Set home link to go to KG-Registry

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="container-fluid">
-        <a class="navbar-brand" href="/">
+        <a class="navbar-brand" href="/kg-registry/">
             KG-Registry
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"


### PR DESCRIPTION
The link at the upper left formerly went to kghub.org, not kghub.org/kg-registry.