### PR TITLE
Update license for Pheknowlator to Apache 2.0

### DIFF
--- a/resource/pheknowlator.md
+++ b/resource/pheknowlator.md
@@ -11,6 +11,9 @@ contacts:
   label: Tiffany Callahan
 homepage_url: https://github.com/callahantiff/PheKnowLator
 repository: https://github.com/callahantiff/PheKnowLator
+license:
+  label: Apache License 2.0
+  id: https://www.apache.org/licenses/LICENSE-2.0
 category: KnowledgeGraph
 ---
 


### PR DESCRIPTION
License for Pheknowator seems to be Apache 2.0:
https://github.com/callahantiff/PheKnowLator/blob/master/LICENSE

Currently license is not set in our registry:
https://github.com/Knowledge-Graph-Hub/kg-registry/blob/main/resource/pheknowlator.md