### PR TITLE
add Translator DISEASES ingest

### DIFF
--- a/resource/kg-jensenlab-diseases/kg-jensenlab-diseases.md
+++ b/resource/kg-jensenlab-diseases/kg-jensenlab-diseases.md
@@ -1,0 +1,40 @@
+---
+activity_status: active
+category: KnowledgeGraph
+collection:
+- translator
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: colxu@scripps.edu
+  - contact_type: github
+    value: colleenXu
+  label: "Colleen Xu"
+description: An ingest of Jensen Lab's DISEASES resource, for Translator use 
+  (NodeNormed, output in Translator standards)
+domains:
+- health
+id: kg-jensenlab-diseases
+layout: resource_detail
+name: JensenLab DISEASES KG
+products:
+- category: GraphProduct
+  description: KGX nodes file for JensenLab DISEASES KG
+  format: kgx-jsonl
+  id: kg-jensenlab-diseases_kgx-nodes
+  name: DISEASES KGX nodes
+  product_url: https://github.com/biothings/pending.api/blob/translator-output/plugins/DISEASES/DISEASES_kgx_nodes.jsonl
+- category: GraphProduct
+  description: KGX edges file for JensenLab DISEASES KG
+  format: kgx-jsonl
+  id: kg-jensenlab-diseases_kgx-edges
+  name: DISEASES KGX edges
+  product_url: https://github.com/biothings/pending.api/blob/translator-output/plugins/DISEASES/DISEASES_kgx_edges.jsonl
+- category: GraphProduct
+  description: TRAPI edges file for JensenLab DISEASES KG
+  format: jsonl
+  id: kg-jensenlab-diseases_trapi-edges
+  name: DISEASES TRAPI edges
+  product_url: https://github.com/biothings/pending.api/blob/translator-output/plugins/DISEASES/DISEASES_trapi_edges.jsonl
+---


### PR DESCRIPTION
During the current Translator ingest effort, our team created output files for the ingest of JensenLab's DISEASES resources. We'd like to see how easy it is to add this ingest's info and files to the KG-Hub Registry. 

I wrote this entry based on another Translator entry [Drug-Approvals KP](https://github.com/Knowledge-Graph-Hub/kg-registry/blob/main/resource/drug-approvals-kp/drug-approvals-kp.md?plain=1), trying to keep only the essential parts. I'd like an expert to review for any missing required data and provide feedback @caufieldjh @sierra-moxon 