### PR TITLE
Update validator script to include inactive/unresponsive resources in build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9392,3 +9392,72 @@ resources:
     secondary_source:
     - obo-db-ingest
   repository: https://github.com/ZFIN/
+- activity_status: unresponsive
+  category: KnowledgeGraph
+  contacts:
+  - category: Individual
+    contact_details:
+    - contact_type: email
+      value: qnhu@sibs.ac.cn
+    label: Qian-Nan Hu
+  description: Rare Disease Bridge (RDBridge) offers search functions for genes, potential
+    drugs, pathways, literature, and medical imaging data that will support mechanistic
+    research, drug development, diagnosis, and treatment for rare diseases.
+  domains:
+  - health
+  - biomedical
+  - precision medicine
+  - clinical
+  homepage_url: http://rdb.lifesynther.com/
+  id: rdbridge
+  layout: resource_detail
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC BY 4.0
+    logo: http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png
+  name: RDBridge
+  products:
+  - category: GraphicalInterface
+    description: Graphical interface for exploring the RDBridge knowledge graph of
+      rare diseases
+    format: http
+    id: rdbridge.webinterface
+    is_public: true
+    name: RDBridge Web Interface
+    original_source:
+    - rdbridge
+    product_url: http://rdb.lifesynther.com/
+  - category: GraphProduct
+    description: Knowledge graph connecting rare diseases with genes, drugs, pathways,
+      and medical images
+    edge_count: 22293
+    id: rdbridge.graph
+    name: RDBridge Knowledge Graph
+    node_count: 11704
+    original_source:
+    - rdbridge
+  - category: Product
+    description: Curated collection of 235,631 scientific publications related to
+      rare diseases
+    format: http
+    id: rdbridge.literaturedatabase
+    name: RDBridge Literature Database
+    original_source:
+    - rdbridge
+  publications:
+  - authors:
+    - Xing H
+    - Zhang D
+    - Cai P
+    - Zhang R
+    - Hu QN
+    doi: doi:10.1093/bioinformatics/btad440
+    id: doi:10.1093/bioinformatics/btad440
+    journal: Bioinformatics
+    preferred: true
+    title: 'RDBridge: a knowledge graph of rare diseases based on large-scale text
+      mining'
+    year: '2023'
+  repository: http://rdb.lifesynther.com/
+  warnings:
+  - Homepage may be inaccessible (March 5 2025)

--- a/_includes/table_widget.html
+++ b/_includes/table_widget.html
@@ -41,26 +41,7 @@
                 <label class="form-check-label" for="groupByDomain">Group By Domain</label>
                 <label class="form-check-label" for="groupByDomain" data-bs-toggle="tooltip" title="Resources in multiple domains will appear in each domain section">(?)</label>
             </div>
-            <div class="form-group form-check mt-2">
-                <input
-                        type="checkbox"
-                        class="form-check-input"
-                        id="hideInactive"
-                        data-filter="activity_status"
-                        checked
-                />
-                <label class="form-check-label" for="hideInactive">Hide Inactive</label>
-            </div>
-            <div class="form-group form-check mt-2">
-                <input
-                        type="checkbox"
-                        class="form-check-input"
-                        id="hideObsolete"
-                        data-filter="is_obsolete"
-                        checked
-                />
-                <label class="form-check-label" for="hideObsolete">Hide Obsolete</label>
-            </div>
+
         </div>
     </div>
     <div class="search-result-wrapper ms-3 mt-2">

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -587,28 +587,9 @@ jQuery(document).ready(function () {
      */
     function applyFilters(data) {
         const selector = $("[data-filter]");
-        const domain = selector[0].checked;
-        const hideactive = selector[1].checked;
-        const hideObsolete = selector[2].checked;
+        const domain = selector[0] && selector[0].checked;
 
         let filteredData = data;
-
-        // Apply filters in a single pass
-        if (hideactive || hideObsolete) {
-            filteredData = data.filter(item => {
-                // Skip items that should be hidden by activity status
-                if (hideactive && item.activity_status !== "active") {
-                    return false;
-                }
-
-                // Skip obsolete items if requested
-                if (hideObsolete && item.is_obsolete === true) {
-                    return false;
-                }
-
-                return true;
-            });
-        }
 
         // Sort if domain grouping is requested
         if (domain) {

--- a/registry/kgs.jsonld
+++ b/registry/kgs.jsonld
@@ -12683,6 +12683,94 @@
                 }
             ],
             "repository": "https://github.com/ZFIN/"
+        },
+        {
+            "activity_status": "unresponsive",
+            "category": "KnowledgeGraph",
+            "contacts": [
+                {
+                    "category": "Individual",
+                    "contact_details": [
+                        {
+                            "contact_type": "email",
+                            "value": "qnhu@sibs.ac.cn"
+                        }
+                    ],
+                    "label": "Qian-Nan Hu"
+                }
+            ],
+            "description": "Rare Disease Bridge (RDBridge) offers search functions for genes, potential drugs, pathways, literature, and medical imaging data that will support mechanistic research, drug development, diagnosis, and treatment for rare diseases.",
+            "domains": [
+                "health",
+                "biomedical",
+                "precision medicine",
+                "clinical"
+            ],
+            "homepage_url": "http://rdb.lifesynther.com/",
+            "id": "rdbridge",
+            "layout": "resource_detail",
+            "license": {
+                "id": "https://creativecommons.org/licenses/by/4.0/",
+                "label": "CC BY 4.0",
+                "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png"
+            },
+            "name": "RDBridge",
+            "products": [
+                {
+                    "category": "GraphicalInterface",
+                    "description": "Graphical interface for exploring the RDBridge knowledge graph of rare diseases",
+                    "format": "http",
+                    "id": "rdbridge.webinterface",
+                    "is_public": true,
+                    "name": "RDBridge Web Interface",
+                    "original_source": [
+                        "rdbridge"
+                    ],
+                    "product_url": "http://rdb.lifesynther.com/"
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Knowledge graph connecting rare diseases with genes, drugs, pathways, and medical images",
+                    "edge_count": 22293,
+                    "id": "rdbridge.graph",
+                    "name": "RDBridge Knowledge Graph",
+                    "node_count": 11704,
+                    "original_source": [
+                        "rdbridge"
+                    ]
+                },
+                {
+                    "category": "Product",
+                    "description": "Curated collection of 235,631 scientific publications related to rare diseases",
+                    "format": "http",
+                    "id": "rdbridge.literaturedatabase",
+                    "name": "RDBridge Literature Database",
+                    "original_source": [
+                        "rdbridge"
+                    ]
+                }
+            ],
+            "publications": [
+                {
+                    "authors": [
+                        "Xing H",
+                        "Zhang D",
+                        "Cai P",
+                        "Zhang R",
+                        "Hu QN"
+                    ],
+                    "doi": "doi:10.1093/bioinformatics/btad440",
+                    "id": "doi:10.1093/bioinformatics/btad440",
+                    "journal": "Bioinformatics",
+                    "preferred": true,
+                    "title": "RDBridge: a knowledge graph of rare diseases based on large-scale text mining",
+                    "year": "2023"
+                }
+            ],
+            "repository": "http://rdb.lifesynther.com/",
+            "warnings": [
+                "Homepage may be inaccessible (March 5 2025)"
+            ]
         }
     ]
 }

--- a/registry/kgs.yml
+++ b/registry/kgs.yml
@@ -9374,3 +9374,72 @@ resources:
     secondary_source:
     - obo-db-ingest
   repository: https://github.com/ZFIN/
+- activity_status: unresponsive
+  category: KnowledgeGraph
+  contacts:
+  - category: Individual
+    contact_details:
+    - contact_type: email
+      value: qnhu@sibs.ac.cn
+    label: Qian-Nan Hu
+  description: Rare Disease Bridge (RDBridge) offers search functions for genes, potential
+    drugs, pathways, literature, and medical imaging data that will support mechanistic
+    research, drug development, diagnosis, and treatment for rare diseases.
+  domains:
+  - health
+  - biomedical
+  - precision medicine
+  - clinical
+  homepage_url: http://rdb.lifesynther.com/
+  id: rdbridge
+  layout: resource_detail
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC BY 4.0
+    logo: http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png
+  name: RDBridge
+  products:
+  - category: GraphicalInterface
+    description: Graphical interface for exploring the RDBridge knowledge graph of
+      rare diseases
+    format: http
+    id: rdbridge.webinterface
+    is_public: true
+    name: RDBridge Web Interface
+    original_source:
+    - rdbridge
+    product_url: http://rdb.lifesynther.com/
+  - category: GraphProduct
+    description: Knowledge graph connecting rare diseases with genes, drugs, pathways,
+      and medical images
+    edge_count: 22293
+    id: rdbridge.graph
+    name: RDBridge Knowledge Graph
+    node_count: 11704
+    original_source:
+    - rdbridge
+  - category: Product
+    description: Curated collection of 235,631 scientific publications related to
+      rare diseases
+    format: http
+    id: rdbridge.literaturedatabase
+    name: RDBridge Literature Database
+    original_source:
+    - rdbridge
+  publications:
+  - authors:
+    - Xing H
+    - Zhang D
+    - Cai P
+    - Zhang R
+    - Hu QN
+    doi: doi:10.1093/bioinformatics/btad440
+    id: doi:10.1093/bioinformatics/btad440
+    journal: Bioinformatics
+    preferred: true
+    title: 'RDBridge: a knowledge graph of rare diseases based on large-scale text
+      mining'
+    year: '2023'
+  repository: http://rdb.lifesynther.com/
+  warnings:
+  - Homepage may be inaccessible (March 5 2025)

--- a/reports/metadata-grid.csv
+++ b/reports/metadata-grid.csv
@@ -102,3 +102,4 @@ ubergraph,active,PASS
 uberon,active,PASS
 uniprot,active,PASS
 zfin,active,PASS
+rdbridge,unresponsive,PASS


### PR DESCRIPTION
This also removes the options to hide inactive and obsolete entries from the main page, as they aren't generally in use in this registry.