### PR TITLE
Add EMI Knowledge Graph entry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2495,6 +2495,56 @@ resources:
   repository: http://purl.obolibrary.org/obo/ecosim.owl
 - activity_status: active
   category: KnowledgeGraph
+  contacts:
+  - category: Individual
+    contact_details:
+    - contact_type: github
+      value: tarcisiocsf
+    - contact_type: url
+      value: https://www.sib.swiss
+    label: Tarcisio Mendes de Farias
+    orcid: 0000-0002-3175-5372
+  - category: Organization
+    contact_details:
+    - contact_type: url
+      value: https://www.dbgi.org
+    label: Digital Botanical Gardens Initiative
+  description: A knowledge graph version of the Earth Metabolome Initiative (EMI)
+    Ontology, containing over 413 million triples derived from metabolomic datasets.
+    It provides a structured representation of metabolomic data within a semantic
+    framework.
+  domains:
+  - biological systems
+  - chemistry and biochemistry
+  homepage_url: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+  id: emikg
+  layout: resource_detail
+  license:
+    id: https://creativecommons.org/publicdomain/zero/1.0/
+    label: CC0 1.0
+    logo: http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png
+  name: EMI KG
+  products:
+  - category: GraphProduct
+    description: Graph version of the Earth Metabolome Initiative Ontology
+    format: kgx
+    id: emikg.kg
+    name: EMI Knowledge Graph
+    product_url: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+    repository: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+  - category: ProgrammingInterface
+    description: SPARQL endpoint for programmatic access to the EMI Knowledge Graph
+    format: http
+    id: emikg.sparql
+    name: EMI KG SPARQL Endpoint
+    product_url: https://biosoda.unil.ch/emi/sparql
+  - category: GraphicalInterface
+    description: Web-based SPARQL query editor for the EMI Knowledge Graph
+    id: emikg.web
+    name: EMI KG SPARQL Query Editor
+    product_url: https://sib-swiss.github.io/sparql-editor/dbgi
+- activity_status: active
+  category: KnowledgeGraph
   collection:
   - translator
   contacts:

--- a/registry/kgs.jsonld
+++ b/registry/kgs.jsonld
@@ -3383,6 +3383,77 @@
         {
             "activity_status": "active",
             "category": "KnowledgeGraph",
+            "contacts": [
+                {
+                    "category": "Individual",
+                    "contact_details": [
+                        {
+                            "contact_type": "github",
+                            "value": "tarcisiocsf"
+                        },
+                        {
+                            "contact_type": "url",
+                            "value": "https://www.sib.swiss"
+                        }
+                    ],
+                    "label": "Tarcisio Mendes de Farias",
+                    "orcid": "0000-0002-3175-5372"
+                },
+                {
+                    "category": "Organization",
+                    "contact_details": [
+                        {
+                            "contact_type": "url",
+                            "value": "https://www.dbgi.org"
+                        }
+                    ],
+                    "label": "Digital Botanical Gardens Initiative"
+                }
+            ],
+            "description": "A knowledge graph version of the Earth Metabolome Initiative (EMI) Ontology, containing over 413 million triples derived from metabolomic datasets. It provides a structured representation of metabolomic data within a semantic framework.",
+            "domains": [
+                "biological systems",
+                "chemistry and biochemistry"
+            ],
+            "homepage_url": "https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology",
+            "id": "emikg",
+            "layout": "resource_detail",
+            "license": {
+                "id": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "label": "CC0 1.0",
+                "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png"
+            },
+            "name": "EMI KG",
+            "products": [
+                {
+                    "category": "GraphProduct",
+                    "description": "Graph version of the Earth Metabolome Initiative Ontology",
+                    "format": "kgx",
+                    "id": "emikg.kg",
+                    "name": "EMI Knowledge Graph",
+                    "product_url": "https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology",
+                    "repository": "https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology"
+                },
+                {
+                    "category": "ProgrammingInterface",
+                    "description": "SPARQL endpoint for programmatic access to the EMI Knowledge Graph",
+                    "format": "http",
+                    "id": "emikg.sparql",
+                    "name": "EMI KG SPARQL Endpoint",
+                    "product_url": "https://biosoda.unil.ch/emi/sparql"
+                },
+                {
+                    "category": "GraphicalInterface",
+                    "description": "Web-based SPARQL query editor for the EMI Knowledge Graph",
+                    "id": "emikg.web",
+                    "name": "EMI KG SPARQL Query Editor",
+                    "product_url": "https://sib-swiss.github.io/sparql-editor/dbgi"
+                }
+            ]
+        },
+        {
+            "activity_status": "active",
+            "category": "KnowledgeGraph",
             "collection": [
                 "translator"
             ],

--- a/registry/kgs.yml
+++ b/registry/kgs.yml
@@ -2477,6 +2477,56 @@ resources:
   repository: http://purl.obolibrary.org/obo/ecosim.owl
 - activity_status: active
   category: KnowledgeGraph
+  contacts:
+  - category: Individual
+    contact_details:
+    - contact_type: github
+      value: tarcisiocsf
+    - contact_type: url
+      value: https://www.sib.swiss
+    label: Tarcisio Mendes de Farias
+    orcid: 0000-0002-3175-5372
+  - category: Organization
+    contact_details:
+    - contact_type: url
+      value: https://www.dbgi.org
+    label: Digital Botanical Gardens Initiative
+  description: A knowledge graph version of the Earth Metabolome Initiative (EMI)
+    Ontology, containing over 413 million triples derived from metabolomic datasets.
+    It provides a structured representation of metabolomic data within a semantic
+    framework.
+  domains:
+  - biological systems
+  - chemistry and biochemistry
+  homepage_url: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+  id: emikg
+  layout: resource_detail
+  license:
+    id: https://creativecommons.org/publicdomain/zero/1.0/
+    label: CC0 1.0
+    logo: http://mirrors.creativecommons.org/presskit/buttons/80x15/png/cc-zero.png
+  name: EMI KG
+  products:
+  - category: GraphProduct
+    description: Graph version of the Earth Metabolome Initiative Ontology
+    format: kgx
+    id: emikg.kg
+    name: EMI Knowledge Graph
+    product_url: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+    repository: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+  - category: ProgrammingInterface
+    description: SPARQL endpoint for programmatic access to the EMI Knowledge Graph
+    format: http
+    id: emikg.sparql
+    name: EMI KG SPARQL Endpoint
+    product_url: https://biosoda.unil.ch/emi/sparql
+  - category: GraphicalInterface
+    description: Web-based SPARQL query editor for the EMI Knowledge Graph
+    id: emikg.web
+    name: EMI KG SPARQL Query Editor
+    product_url: https://sib-swiss.github.io/sparql-editor/dbgi
+- activity_status: active
+  category: KnowledgeGraph
   collection:
   - translator
   contacts:

--- a/reports/metadata-grid.csv
+++ b/reports/metadata-grid.csv
@@ -30,6 +30,7 @@ ecid,active,PASS
 eco-kg,active,PASS
 ecocyc,active,PASS
 ecosim,active,PASS
+emikg,active,PASS
 genetics-kp,active,PASS
 genomickb,active,PASS
 glkb,active,PASS

--- a/resource/emikg/emikg.kg.md
+++ b/resource/emikg/emikg.kg.md
@@ -1,0 +1,10 @@
+---
+category: GraphProduct
+description: Graph version of the Earth Metabolome Initiative Ontology
+format: kgx
+id: emikg.kg
+name: EMI Knowledge Graph
+product_url: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+repository: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+layout: product_detail
+---

--- a/resource/emikg/emikg.md
+++ b/resource/emikg/emikg.md
@@ -1,0 +1,48 @@
+---
+activity_status: active
+category: KnowledgeGraph
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: github
+    value: tarcisiocsf
+  - contact_type: url
+    value: https://www.sib.swiss
+  label: Tarcisio Mendes de Farias
+  orcid: 0000-0002-3175-5372
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://www.dbgi.org
+  label: Digital Botanical Gardens Initiative
+description: A knowledge graph version of the Earth Metabolome Initiative (EMI) Ontology, containing over 413 million triples derived from metabolomic datasets. It provides a structured representation of metabolomic data within a semantic framework.
+domains:
+- biological systems
+- chemistry and biochemistry
+homepage_url: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+id: emikg
+layout: resource_detail
+license:
+  id: https://creativecommons.org/publicdomain/zero/1.0/
+  label: CC0 1.0
+name: EMI KG
+products:
+- category: GraphProduct
+  description: Graph version of the Earth Metabolome Initiative Ontology
+  format: kgx
+  id: emikg.kg
+  name: EMI Knowledge Graph
+  product_url: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+  repository: https://github.com/digital-botanical-gardens-initiative/earth_metabolome_ontology
+- category: ProgrammingInterface
+  description: SPARQL endpoint for programmatic access to the EMI Knowledge Graph
+  format: http
+  id: emikg.sparql
+  name: EMI KG SPARQL Endpoint
+  product_url: https://biosoda.unil.ch/emi/sparql
+- category: GraphicalInterface
+  description: Web-based SPARQL query editor for the EMI Knowledge Graph
+  id: emikg.web
+  name: EMI KG SPARQL Query Editor
+  product_url: https://sib-swiss.github.io/sparql-editor/dbgi
+---

--- a/resource/emikg/emikg.sparql.md
+++ b/resource/emikg/emikg.sparql.md
@@ -1,0 +1,9 @@
+---
+category: ProgrammingInterface
+description: SPARQL endpoint for programmatic access to the EMI Knowledge Graph
+format: http
+id: emikg.sparql
+name: EMI KG SPARQL Endpoint
+product_url: https://biosoda.unil.ch/emi/sparql
+layout: product_detail
+---

--- a/resource/emikg/emikg.web.md
+++ b/resource/emikg/emikg.web.md
@@ -1,0 +1,8 @@
+---
+category: GraphicalInterface
+description: Web-based SPARQL query editor for the EMI Knowledge Graph
+id: emikg.web
+name: EMI KG SPARQL Query Editor
+product_url: https://sib-swiss.github.io/sparql-editor/dbgi
+layout: product_detail
+---


### PR DESCRIPTION
Introduce the EMI Knowledge Graph, detailing its structure, products, and associated metadata, enhancing the registry of knowledge graphs.