### PR TITLE
Add new provenance diagram on Product pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,9 @@
 <!-- bootstrap icons, see https://icons.getbootstrap.com/#install -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
 
+<!-- D3.js Provenance Diagram styles -->
+<link rel="stylesheet" href="/kg-registry/assets/css/provenance-diagram.css" />
+
 {% feed_meta %}
 
 <style>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -8,23 +8,67 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', function () {
-        renderProvenanceDiagrams();
+        // Call the async function without waiting for it
+        renderProvenanceDiagrams().catch(console.error);
 
         // Add window resize listener to adjust diagrams on window resize
         window.addEventListener('resize', function () {
             // Debounce the resize event
             if (this.resizeTimeout) clearTimeout(this.resizeTimeout);
             this.resizeTimeout = setTimeout(function () {
-                renderProvenanceDiagrams();
+                renderProvenanceDiagrams().catch(console.error);
             }, 200);
         });
     });
 
-    // D3.js Provenance Diagram renderer
-    function renderProvenanceDiagrams() {
-        const provenanceContainers = document.querySelectorAll('.provenance-diagram');
+    // Function to fetch resource category and icon
+    async function fetchCategoryIcon(resourceId) {
+        try {
+            const response = await fetch(`/kg-registry/resource/${resourceId}/${resourceId}.html`);
+            if (!response.ok) {
+                return { category: 'unknown', icon: 'box' };
+            }
+            const html = await response.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            
+            // Look for the header with the icon
+            const header = doc.querySelector('h1 .bi');
+            if (header) {
+                const iconClass = header.className;
+                // Extract the icon name from "bi bi-iconname"
+                const iconName = iconClass.replace('bi bi-', '');
+                return { category: 'found', icon: iconName };
+            }
+            
+            return { category: 'unknown', icon: 'box' };
+        } catch (error) {
+            console.error('Error fetching resource category:', error);
+            return { category: 'error', icon: 'box' };
+        }
+    }
 
-        provenanceContainers.forEach(container => {
+    // Category to icon mapping
+    const categoryIcons = {
+        "Aggregator": "grid-3x3",
+        "Resource": "archive",
+        "KnowledgeGraph": "globe",
+        "DataSource": "shop",
+        "DataModel": "diagram-3",
+        "GraphProduct": "globe",
+        "Product": "box",
+        "MappingProduct": "map",
+        "ProcessProduct": "gear",
+        "DataModelProduct": "diagram-3",
+        "GraphicalInterface": "window",
+        "ProgrammingInterface": "code-square"
+    };
+
+    // D3.js Provenance Diagram renderer
+    async function renderProvenanceDiagrams() {
+        const provenanceContainers = document.querySelectorAll('.provenance-diagram');
+        
+        for (const container of provenanceContainers) {
             const data = JSON.parse(container.getAttribute('data-provenance'));
 
             // Calculate appropriate height based on number of sources
@@ -45,17 +89,17 @@
             container.style.height = `${calculatedHeight}px`;
 
             // Render the diagram with the calculated height
-            renderD3Diagram(container, data, calculatedHeight);
+            await renderD3Diagram(container, data, calculatedHeight);
 
             // Also set the height on the parent card
             const cardBody = container.closest('.card-body');
             if (cardBody) {
                 cardBody.style.minHeight = `${calculatedHeight + 70}px`; // Add some extra padding
             }
-        });
+        }
     }
 
-    function renderD3Diagram(container, data, height) {
+    async function renderD3Diagram(container, data, height) {
         // Clear any existing content
         container.innerHTML = '';
 
@@ -65,6 +109,55 @@
         const nodeWidth = 150;
         const nodeHeight = 50; // Increased node height for better text fit
         const nodePadding = 50;
+        
+        // Preload category icons for each resource
+        const resourceIcons = {};
+        
+        // Add product category icon - we know it's a product type already
+        const productCategory = container.getAttribute('data-product-category');
+        const productIcon = container.getAttribute('data-product-icon');
+        
+        if (productCategory && productIcon) {
+            // Use the category and icon from the data attributes
+            resourceIcons[data.product] = { 
+                category: productCategory, 
+                icon: productIcon
+            };
+        } else {
+            // Fallback to default Product icon
+            resourceIcons[data.product] = { 
+                category: 'Product', 
+                icon: categoryIcons['Product'] || 'box' 
+            };
+        }
+        
+        // Load all source icons asynchronously
+        const fetchPromises = [];
+        
+        // Load original source icons
+        if (data.originalSources && data.originalSources.length > 0) {
+            for (const source of data.originalSources) {
+                fetchPromises.push(
+                    fetchCategoryIcon(source).then(result => {
+                        resourceIcons[source] = result;
+                    })
+                );
+            }
+        }
+        
+        // Load secondary source icons
+        if (data.secondarySources && data.secondarySources.length > 0) {
+            for (const source of data.secondarySources) {
+                fetchPromises.push(
+                    fetchCategoryIcon(source).then(result => {
+                        resourceIcons[source] = result;
+                    })
+                );
+            }
+        }
+        
+        // Wait for all icon data to be loaded
+        await Promise.all(fetchPromises);
 
         // Create SVG
         const svg = d3.select(container)
@@ -342,6 +435,38 @@
             })
             .append('title')  // Add tooltip for full name
             .text(d => d.name);
+            
+        // Add category icons to each node
+        nodeGroups.append('g')
+            .attr('class', 'node-icon')
+            .attr('transform', d => `translate(${nodeWidth - 22}, 10)`) // Position in top-right corner with padding
+            .each(function(d) {
+                const iconGroup = d3.select(this);
+                const iconData = resourceIcons[d.id];
+                
+                if (iconData && iconData.icon) {
+                    // Create icon background circle
+                    iconGroup.append('circle')
+                        .attr('r', 10)
+                        .attr('fill', 'white')
+                        .attr('opacity', 0.9);
+                        
+                    // Create SVG for Bootstrap icon
+                    // Use foreign object to embed HTML icon
+                    iconGroup.append('foreignObject')
+                        .attr('width', 20)
+                        .attr('height', 20)
+                        .attr('x', -10)
+                        .attr('y', -10)
+                        .html(`<div style="width:20px;height:20px;display:flex;align-items:center;justify-content:center">
+                            <i class="bi bi-${iconData.icon}" style="font-size:12px;color:#333;"></i>
+                        </div>`);
+                        
+                    // Add tooltip with category name
+                    iconGroup.append('title')
+                        .text(iconData.category || 'Resource');
+                }
+            });
 
         // Add a legend (horizontal layout)
         const legend = svg.append('g')

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -19,6 +19,42 @@
                 renderProvenanceDiagrams().catch(console.error);
             }, 200);
         });
+        
+        // Add event listeners for PROV-XML export links
+        document.querySelectorAll('.export-prov-xml').forEach(link => {
+            link.addEventListener('click', function(e) {
+                e.preventDefault();
+                
+                // Find the closest provenance diagram
+                const diagramContainer = this.closest('.card-body').querySelector('.provenance-diagram');
+                if (!diagramContainer) return;
+                
+                // Get the provenance data
+                const data = JSON.parse(diagramContainer.getAttribute('data-provenance'));
+                
+                // Generate the PROV XML
+                const xml = generateProvXML(data);
+                
+                // Create a blob with the XML
+                const blob = new Blob([xml], { type: 'application/xml' });
+                
+                // Create a download link
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `${data.product}_provenance.xml`;
+                
+                // Trigger the download
+                document.body.appendChild(a);
+                a.click();
+                
+                // Clean up
+                setTimeout(() => {
+                    document.body.removeChild(a);
+                    URL.revokeObjectURL(url);
+                }, 0);
+            });
+        });
     });
 
     // Function to fetch resource category and icon
@@ -63,6 +99,106 @@
         "GraphicalInterface": "window",
         "ProgrammingInterface": "code-square"
     };
+
+    // Function to generate PROV XML representation of provenance data
+    function generateProvXML(data) {
+        // Create the timestamp for the XML
+        const now = new Date();
+        const timestamp = now.toISOString();
+        const kgRegistryUrl = window.location.origin + '/kg-registry/';
+        
+        // Start the XML document
+        let xml = `<?xml version="1.0" encoding="UTF-8"?>
+<prov:document xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:kgr="https://w3id.org/bridge2ai/data-sheets-schema/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    
+    <!-- KG-Registry Bundle Information -->
+    <prov:entity prov:id="kgr:registry">
+        <prov:label>KG-Registry</prov:label>
+        <prov:type>kgr:Registry</prov:type>
+        <rdfs:seeAlso>${kgRegistryUrl}</rdfs:seeAlso>
+    </prov:entity>
+    
+    <!-- Product entity -->
+    <prov:entity prov:id="kgr:${data.product}">
+        <prov:label>${data.product}</prov:label>
+        <prov:type>kgr:Product</prov:type>
+        <prov:generatedAtTime>${timestamp}</prov:generatedAtTime>
+        <rdfs:seeAlso>${kgRegistryUrl}resource/${data.product}/${data.product}.html</rdfs:seeAlso>
+    </prov:entity>`;
+        
+        // Add secondary sources
+        if (data.secondarySources && data.secondarySources.length > 0) {
+            for (const source of data.secondarySources) {
+                // Add the entity
+                xml += `
+    
+    <!-- Secondary source entity -->
+    <prov:entity prov:id="kgr:${source}">
+        <prov:label>${source}</prov:label>
+        <prov:type>kgr:Resource</prov:type>
+        <prov:type>kgr:secondary_source</prov:type>
+        <rdfs:seeAlso>${kgRegistryUrl}resource/${source}/${source}.html</rdfs:seeAlso>
+    </prov:entity>
+    
+    <!-- Derivation relation: product was derived from secondary source -->
+    <prov:wasDerivedFrom>
+        <prov:generatedEntity prov:ref="kgr:${data.product}"/>
+        <prov:usedEntity prov:ref="kgr:${source}"/>
+        <prov:type>prov:Derivation</prov:type>
+    </prov:wasDerivedFrom>`;
+            }
+        }
+        
+        // Add original sources
+        if (data.originalSources && data.originalSources.length > 0) {
+            for (const source of data.originalSources) {
+                // Add the entity
+                xml += `
+    
+    <!-- Original source entity -->
+    <prov:entity prov:id="kgr:${source}">
+        <prov:label>${source}</prov:label>
+        <prov:type>kgr:Resource</prov:type>
+        <prov:type>kgr:original_source</prov:type>
+        <rdfs:seeAlso>${kgRegistryUrl}resource/${source}/${source}.html</rdfs:seeAlso>
+    </prov:entity>`;
+                
+                // If there are secondary sources, connect original to secondary
+                if (data.secondarySources && data.secondarySources.length > 0) {
+                    for (const secondarySource of data.secondarySources) {
+                        xml += `
+    
+    <!-- Derivation relation: secondary source was derived from original source -->
+    <prov:wasDerivedFrom>
+        <prov:generatedEntity prov:ref="kgr:${secondarySource}"/>
+        <prov:usedEntity prov:ref="kgr:${source}"/>
+        <prov:type>prov:Derivation</prov:type>
+    </prov:wasDerivedFrom>`;
+                    }
+                } else {
+                    // If no secondary sources, connect original directly to product
+                    xml += `
+    
+    <!-- Derivation relation: product was derived from original source -->
+    <prov:wasDerivedFrom>
+        <prov:generatedEntity prov:ref="kgr:${data.product}"/>
+        <prov:usedEntity prov:ref="kgr:${source}"/>
+        <prov:type>prov:Derivation</prov:type>
+    </prov:wasDerivedFrom>`;
+                }
+            }
+        }
+        
+        // Close the XML document
+        xml += `
+</prov:document>`;
+        
+        return xml;
+    }
 
     // D3.js Provenance Diagram renderer
     async function renderProvenanceDiagrams() {

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -885,9 +885,9 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
             .attr('rx', 5)
             .attr('ry', 5)
             .attr('fill', d => {
-                if (d.type === 'product') return '#5588bb';
-                if (d.type === 'secondary') return '#88bb55';
-                return '#ddaa44';
+                if (d.type === 'product') return '#3366cc'; // Accessible blue for products
+                if (d.type === 'secondary') return '#9933cc'; // Accessible purple for secondary sources
+                return '#ff8800'; // Accessible orange for original sources
             })
             .attr('stroke', '#333')
             .attr('stroke-width', d => d.type === 'product' ? 3 : 1)
@@ -968,9 +968,9 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
             .attr('ry', 3) // Corner radius
             .attr('y', -9) // Shift up half height to align centers with icon circles
             .attr('fill', d => {
-                if (d.type === 'product') return '#5588bb';
-                if (d.type === 'secondary') return '#88bb55';
-                return '#ddaa44';
+                if (d.type === 'product') return '#3366cc'; // Accessible blue for products
+                if (d.type === 'secondary') return '#9933cc'; // Accessible purple for secondary sources
+                return '#ff8800'; // Accessible orange for original sources
             });
 
         legendGroups.append('text')

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -20,8 +20,8 @@
             }, 200);
         });
         
-        // Add event listeners for PROV-XML export links
-        document.querySelectorAll('.export-prov-xml').forEach(link => {
+        // Add event listeners for PROV export links
+        document.querySelectorAll('.export-prov-xml, .export-prov-rdf, .export-prov-json, .export-prov-svg').forEach(link => {
             link.addEventListener('click', function(e) {
                 e.preventDefault();
                 
@@ -32,21 +32,77 @@
                 // Get the provenance data
                 const data = JSON.parse(diagramContainer.getAttribute('data-provenance'));
                 
-                // Generate the PROV XML
-                const xml = generateProvXML(data);
+                // Get the format from the link
+                const format = this.getAttribute('data-format') || 'xml';
                 
-                // Create a blob with the XML
-                const blob = new Blob([xml], { type: 'application/xml' });
+                // Generate the appropriate format
+                let content, mimeType, fileExtension;
+                
+                switch(format) {
+                    case 'rdf':
+                        content = generateProvRDF(data);
+                        mimeType = 'text/turtle';
+                        fileExtension = 'ttl';
+                        break;
+                    case 'json':
+                        content = generateProvJSON(data);
+                        mimeType = 'application/json';
+                        fileExtension = 'json';
+                        break;
+                    case 'svg':
+                        // Export the SVG content directly
+                        const svgElement = diagramContainer.querySelector('svg');
+                        if (!svgElement) return;
+                        
+                        // Clone the SVG to avoid modifying the displayed one
+                        const svgClone = svgElement.cloneNode(true);
+                        
+                        // Add proper XML namespace and styling for standalone use
+                        svgClone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+                        svgClone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+                        
+                        // Add embedded CSS to ensure styles are preserved
+                        const style = document.createElement('style');
+                        style.textContent = `
+                            .node-box { fill: #f5f5f5; stroke: #aaa; stroke-width: 1px; rx: 5px; ry: 5px; }
+                            .node-text { font-family: Arial, sans-serif; font-size: 12px; fill: #333; }
+                            .node-icon-circle { fill: #fff; stroke: #999; stroke-width: 1px; }
+                            .node-icon-symbol { fill: #555; font-family: bootstrap-icons; font-size: 14px; }
+                            .link-path { stroke: #999; stroke-width: 1.5px; fill: none; stroke-dasharray: 2,2; }
+                            .link-arrow { fill: #999; }
+                            .direction-indicator { fill: #aaa; font-size: 10px; font-style: italic; }
+                            .legend-text { font-family: Arial, sans-serif; font-size: 11px; fill: #666; }
+                            .legend-item { font-family: Arial, sans-serif; font-size: 11px; fill: #333; }
+                        `;
+                        svgClone.insertBefore(style, svgClone.firstChild);
+                        
+                        content = new XMLSerializer().serializeToString(svgClone);
+                        mimeType = 'image/svg+xml';
+                        fileExtension = 'svg';
+                        break;
+                    case 'xml':
+                    default:
+                        content = generateProvXML(data);
+                        mimeType = 'application/xml';
+                        fileExtension = 'xml';
+                        break;
+                }
+                
+                // Create a blob with the content
+                const blob = new Blob([content], { type: mimeType });
                 
                 // Create a download link
                 const url = URL.createObjectURL(blob);
                 const a = document.createElement('a');
                 a.href = url;
-                a.download = `${data.product}_provenance.xml`;
+                a.download = `${data.product}_provenance.${fileExtension}`;
                 
                 // Trigger the download
                 document.body.appendChild(a);
                 a.click();
+                
+                // Show a notification toast
+                showExportNotification(format, data.product);
                 
                 // Clean up
                 setTimeout(() => {
@@ -55,6 +111,59 @@
                 }, 0);
             });
         });
+        
+        // Function to display a toast notification when file is exported
+        function showExportNotification(format, productName) {
+            // Create the toast container if it doesn't exist
+            let toastContainer = document.getElementById('toast-container');
+            if (!toastContainer) {
+                toastContainer = document.createElement('div');
+                toastContainer.id = 'toast-container';
+                toastContainer.className = 'toast-container position-fixed bottom-0 end-0 p-3';
+                document.body.appendChild(toastContainer);
+            }
+            
+            // Format names for the notification
+            let formatName;
+            switch(format) {
+                case 'rdf': formatName = 'PROV-RDF (Turtle)'; break;
+                case 'json': formatName = 'PROV-JSON'; break;
+                case 'svg': formatName = 'SVG Image'; break;
+                case 'xml': 
+                default: formatName = 'PROV-XML'; break;
+            }
+            
+            // Create a unique ID for this toast
+            const toastId = 'toast-' + Date.now();
+            
+            // Create the toast HTML
+            const toastHtml = `
+                <div id="${toastId}" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+                    <div class="toast-header">
+                        <i class="bi bi-check-circle-fill me-2" style="color: #28a745;"></i>
+                        <strong class="me-auto">Export Successful</strong>
+                        <small>Just now</small>
+                        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+                    </div>
+                    <div class="toast-body">
+                        ${formatName} for <strong>${productName}</strong> has been downloaded.
+                    </div>
+                </div>
+            `;
+            
+            // Add the toast to the container
+            toastContainer.insertAdjacentHTML('beforeend', toastHtml);
+            
+            // Initialize the toast and show it
+            const toastElement = document.getElementById(toastId);
+            const toast = new bootstrap.Toast(toastElement, { autohide: true, delay: 3000 });
+            toast.show();
+            
+            // Remove the toast from DOM after it's hidden
+            toastElement.addEventListener('hidden.bs.toast', function () {
+                toastElement.remove();
+            });
+        }
     });
 
     // Function to fetch resource category and icon
@@ -100,8 +209,37 @@
         "ProgrammingInterface": "code-square"
     };
 
+    // Function to validate PROV export data
+    function validateProvData(data) {
+        // Create a validated copy of the data
+        const validated = {
+            product: data.product || 'unknown',
+            originalSources: [],
+            secondarySources: []
+        };
+        
+        // Validate original sources (ensure it's an array of strings)
+        if (data.originalSources && Array.isArray(data.originalSources)) {
+            validated.originalSources = data.originalSources.filter(source => 
+                typeof source === 'string' && source.trim() !== ''
+            );
+        }
+        
+        // Validate secondary sources (ensure it's an array of strings)
+        if (data.secondarySources && Array.isArray(data.secondarySources)) {
+            validated.secondarySources = data.secondarySources.filter(source => 
+                typeof source === 'string' && source.trim() !== ''
+            );
+        }
+        
+        return validated;
+    }
+
     // Function to generate PROV XML representation of provenance data
     function generateProvXML(data) {
+        // Validate data first
+        const validatedData = validateProvData(data);
+        
         // Create the timestamp for the XML
         const now = new Date();
         const timestamp = now.toISOString();
@@ -123,16 +261,16 @@
     </prov:entity>
     
     <!-- Product entity -->
-    <prov:entity prov:id="kgr:${data.product}">
-        <prov:label>${data.product}</prov:label>
+    <prov:entity prov:id="kgr:${validatedData.product}">
+        <prov:label>${validatedData.product}</prov:label>
         <prov:type>kgr:Product</prov:type>
         <prov:generatedAtTime>${timestamp}</prov:generatedAtTime>
-        <rdfs:seeAlso>${kgRegistryUrl}resource/${data.product}/${data.product}.html</rdfs:seeAlso>
+        <rdfs:seeAlso>${kgRegistryUrl}resource/${validatedData.product}/${validatedData.product}.html</rdfs:seeAlso>
     </prov:entity>`;
         
         // Add secondary sources
-        if (data.secondarySources && data.secondarySources.length > 0) {
-            for (const source of data.secondarySources) {
+        if (validatedData.secondarySources && validatedData.secondarySources.length > 0) {
+            for (const source of validatedData.secondarySources) {
                 // Add the entity
                 xml += `
     
@@ -146,7 +284,7 @@
     
     <!-- Derivation relation: product was derived from secondary source -->
     <prov:wasDerivedFrom>
-        <prov:generatedEntity prov:ref="kgr:${data.product}"/>
+        <prov:generatedEntity prov:ref="kgr:${validatedData.product}"/>
         <prov:usedEntity prov:ref="kgr:${source}"/>
         <prov:type>prov:Derivation</prov:type>
     </prov:wasDerivedFrom>`;
@@ -154,8 +292,8 @@
         }
         
         // Add original sources
-        if (data.originalSources && data.originalSources.length > 0) {
-            for (const source of data.originalSources) {
+        if (validatedData.originalSources && validatedData.originalSources.length > 0) {
+            for (const source of validatedData.originalSources) {
                 // Add the entity
                 xml += `
     
@@ -168,8 +306,8 @@
     </prov:entity>`;
                 
                 // If there are secondary sources, connect original to secondary
-                if (data.secondarySources && data.secondarySources.length > 0) {
-                    for (const secondarySource of data.secondarySources) {
+                if (validatedData.secondarySources && validatedData.secondarySources.length > 0) {
+                    for (const secondarySource of validatedData.secondarySources) {
                         xml += `
     
     <!-- Derivation relation: secondary source was derived from original source -->
@@ -185,7 +323,7 @@
     
     <!-- Derivation relation: product was derived from original source -->
     <prov:wasDerivedFrom>
-        <prov:generatedEntity prov:ref="kgr:${data.product}"/>
+        <prov:generatedEntity prov:ref="kgr:${validatedData.product}"/>
         <prov:usedEntity prov:ref="kgr:${source}"/>
         <prov:type>prov:Derivation</prov:type>
     </prov:wasDerivedFrom>`;
@@ -198,6 +336,178 @@
 </prov:document>`;
         
         return xml;
+    }
+
+    // Function to generate PROV RDF (Turtle) representation of provenance data
+    function generateProvRDF(data) {
+        // Validate data first
+        const validatedData = validateProvData(data);
+        
+        // Create the timestamp for the RDF
+        const now = new Date();
+        const timestamp = now.toISOString();
+        const kgRegistryUrl = window.location.origin + '/kg-registry/';
+        
+        // Start the RDF document (Turtle format)
+        let rdf = `@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix kgr: <https://w3id.org/bridge2ai/data-sheets-schema/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# KG-Registry Bundle Information
+kgr:registry a prov:Entity ;
+    prov:type kgr:Registry ;
+    rdfs:label "KG-Registry" ;
+    rdfs:seeAlso "${kgRegistryUrl}" .
+
+# Product entity
+kgr:${validatedData.product} a prov:Entity ;
+    prov:type kgr:Product ;
+    rdfs:label "${validatedData.product}" ;
+    prov:generatedAtTime "${timestamp}"^^xsd:dateTime ;
+    rdfs:seeAlso "${kgRegistryUrl}resource/${validatedData.product}/${validatedData.product}.html" .
+`;
+        
+        // Add secondary sources
+        if (validatedData.secondarySources && validatedData.secondarySources.length > 0) {
+            for (const source of validatedData.secondarySources) {
+                // Add the entity
+                rdf += `
+# Secondary source entity
+kgr:${source} a prov:Entity ;
+    prov:type kgr:Resource , kgr:secondary_source ;
+    rdfs:label "${source}" ;
+    rdfs:seeAlso "${kgRegistryUrl}resource/${source}/${source}.html" .
+
+# Derivation relation: product was derived from secondary source
+kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
+`;
+            }
+        }
+        
+        // Add original sources
+        if (validatedData.originalSources && validatedData.originalSources.length > 0) {
+            for (const source of validatedData.originalSources) {
+                // Add the entity
+                rdf += `
+# Original source entity
+kgr:${source} a prov:Entity ;
+    prov:type kgr:Resource , kgr:original_source ;
+    rdfs:label "${source}" ;
+    rdfs:seeAlso "${kgRegistryUrl}resource/${source}/${source}.html" .
+`;
+                
+                // If there are secondary sources, connect original to secondary
+                if (validatedData.secondarySources && validatedData.secondarySources.length > 0) {
+                    for (const secondarySource of validatedData.secondarySources) {
+                        rdf += `
+# Derivation relation: secondary source was derived from original source
+kgr:${secondarySource} prov:wasDerivedFrom kgr:${source} .
+`;
+                    }
+                } else {
+                    // If no secondary sources, connect original directly to product
+                    rdf += `
+# Derivation relation: product was derived from original source
+kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
+`;
+                }
+            }
+        }
+        
+        return rdf;
+    }
+
+    // Function to generate PROV JSON representation of provenance data
+    function generateProvJSON(data) {
+        // Validate data first
+        const validatedData = validateProvData(data);
+        
+        // Create the timestamp for the JSON
+        const now = new Date();
+        const timestamp = now.toISOString();
+        const kgRegistryUrl = window.location.origin + '/kg-registry/';
+        
+        // Create the JSON object structure according to PROV-JSON spec
+        const provJSON = {
+            "prefix": {
+                "prov": "http://www.w3.org/ns/prov#",
+                "kgr": "https://w3id.org/bridge2ai/data-sheets-schema/",
+                "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                "xsd": "http://www.w3.org/2001/XMLSchema#"
+            },
+            "entity": {
+                "kgr:registry": {
+                    "prov:type": { "$": "kgr:Registry", "type": "prov:QUALIFIED_NAME" },
+                    "rdfs:label": "KG-Registry",
+                    "rdfs:seeAlso": kgRegistryUrl
+                },
+                [`kgr:${validatedData.product}`]: {
+                    "prov:type": { "$": "kgr:Product", "type": "prov:QUALIFIED_NAME" },
+                    "rdfs:label": validatedData.product,
+                    "prov:generatedAtTime": { "$": timestamp, "type": "xsd:dateTime" },
+                    "rdfs:seeAlso": `${kgRegistryUrl}resource/${validatedData.product}/${validatedData.product}.html`
+                }
+            },
+            "wasDerivedFrom": {}
+        };
+        
+        // Add secondary sources
+        if (validatedData.secondarySources && validatedData.secondarySources.length > 0) {
+            validatedData.secondarySources.forEach((source, index) => {
+                // Add entity
+                provJSON.entity[`kgr:${source}`] = {
+                    "prov:type": [
+                        { "$": "kgr:Resource", "type": "prov:QUALIFIED_NAME" },
+                        { "$": "kgr:secondary_source", "type": "prov:QUALIFIED_NAME" }
+                    ],
+                    "rdfs:label": source,
+                    "rdfs:seeAlso": `${kgRegistryUrl}resource/${source}/${source}.html`
+                };
+                
+                // Add derivation relation: product was derived from secondary source
+                provJSON.wasDerivedFrom[`_:wasDerivedFrom${index}`] = {
+                    "prov:generatedEntity": { "$": `kgr:${validatedData.product}`, "type": "prov:QUALIFIED_NAME" },
+                    "prov:usedEntity": { "$": `kgr:${source}`, "type": "prov:QUALIFIED_NAME" },
+                    "prov:type": { "$": "prov:Derivation", "type": "prov:QUALIFIED_NAME" }
+                };
+            });
+        }
+        
+        // Add original sources
+        if (validatedData.originalSources && validatedData.originalSources.length > 0) {
+            validatedData.originalSources.forEach((source, index) => {
+                // Add entity
+                provJSON.entity[`kgr:${source}`] = {
+                    "prov:type": [
+                        { "$": "kgr:Resource", "type": "prov:QUALIFIED_NAME" },
+                        { "$": "kgr:original_source", "type": "prov:QUALIFIED_NAME" }
+                    ],
+                    "rdfs:label": source,
+                    "rdfs:seeAlso": `${kgRegistryUrl}resource/${source}/${source}.html`
+                };
+                
+                // If there are secondary sources, connect original to secondary
+                if (validatedData.secondarySources && validatedData.secondarySources.length > 0) {
+                    validatedData.secondarySources.forEach((secondarySource, sIndex) => {
+                        provJSON.wasDerivedFrom[`_:wasDerivedFrom${index}_${sIndex}`] = {
+                            "prov:generatedEntity": { "$": `kgr:${secondarySource}`, "type": "prov:QUALIFIED_NAME" },
+                            "prov:usedEntity": { "$": `kgr:${source}`, "type": "prov:QUALIFIED_NAME" },
+                            "prov:type": { "$": "prov:Derivation", "type": "prov:QUALIFIED_NAME" }
+                        };
+                    });
+                } else {
+                    // If no secondary sources, connect original directly to product
+                    provJSON.wasDerivedFrom[`_:wasDerivedFrom${index}_direct`] = {
+                        "prov:generatedEntity": { "$": `kgr:${validatedData.product}`, "type": "prov:QUALIFIED_NAME" },
+                        "prov:usedEntity": { "$": `kgr:${source}`, "type": "prov:QUALIFIED_NAME" },
+                        "prov:type": { "$": "prov:Derivation", "type": "prov:QUALIFIED_NAME" }
+                    };
+                }
+            });
+        }
+        
+        return JSON.stringify(provJSON, null, 2);
     }
 
     // D3.js Provenance Diagram renderer
@@ -232,6 +542,9 @@
             if (cardBody) {
                 cardBody.style.minHeight = `${calculatedHeight + 70}px`; // Add some extra padding
             }
+            
+            // Add drag and drop functionality
+            addDragAndDrop(container);
         }
     }
 
@@ -640,5 +953,160 @@
             .attr('y', 14) // Vertical alignment
             .attr('font-size', '14px') // Font size
             .text(d => d.label);
+
+        // Add drag and drop functionality
+        function addDragAndDrop(container) {
+            // Find the SVG element in the container
+            const svg = container.querySelector('svg');
+            if (!svg) return;
+            
+            // Add an instruction overlay
+            const instructionOverlay = document.createElement('div');
+            instructionOverlay.className = 'drag-instruction-overlay';
+            instructionOverlay.innerHTML = `
+                <div class="drag-instruction">
+                    <i class="bi bi-arrows-move"></i>
+                    <span>Click and drag to reposition the diagram</span>
+                </div>
+            `;
+            container.appendChild(instructionOverlay);
+            
+            // Hide the instruction after a few seconds
+            setTimeout(() => {
+                instructionOverlay.style.opacity = '0';
+                setTimeout(() => {
+                    instructionOverlay.remove();
+                }, 1000);
+            }, 3000);
+            
+            // Set up drag functionality
+            let isDragging = false;
+            let startX, startY;
+            let currentTranslateX = 0, currentTranslateY = 0;
+            
+            // Get the main group element
+            const mainGroup = svg.querySelector('g');
+            
+            // Initialize transform if not already set
+            const currentTransform = mainGroup.getAttribute('transform') || 'translate(10, 20)';
+            const match = /translate\(([^,]+),\s*([^)]+)\)/.exec(currentTransform);
+            if (match) {
+                currentTranslateX = parseFloat(match[1]);
+                currentTranslateY = parseFloat(match[2]);
+            }
+            
+            // Mouse events for dragging
+            svg.addEventListener('mousedown', function(e) {
+                // Only start drag if not clicking on a node
+                if (e.target.closest('.node')) return;
+                
+                isDragging = true;
+                startX = e.clientX;
+                startY = e.clientY;
+                svg.style.cursor = 'grabbing';
+            });
+            
+            svg.addEventListener('mousemove', function(e) {
+                if (!isDragging) return;
+                
+                const dx = e.clientX - startX;
+                const dy = e.clientY - startY;
+                
+                // Update the transform
+                mainGroup.setAttribute('transform', `translate(${currentTranslateX + dx}, ${currentTranslateY + dy})`);
+            });
+            
+            svg.addEventListener('mouseup', function(e) {
+                if (!isDragging) return;
+                
+                // Update the current position
+                const dx = e.clientX - startX;
+                const dy = e.clientY - startY;
+                currentTranslateX += dx;
+                currentTranslateY += dy;
+                
+                isDragging = false;
+                svg.style.cursor = 'grab';
+            });
+            
+            svg.addEventListener('mouseleave', function() {
+                if (isDragging) {
+                    isDragging = false;
+                    svg.style.cursor = 'grab';
+                }
+            });
+            
+            // Touch events for mobile devices
+            svg.addEventListener('touchstart', function(e) {
+                // Prevent scrolling while dragging
+                e.preventDefault();
+                
+                // Only start drag if not touching a node
+                if (e.target.closest('.node')) return;
+                
+                isDragging = true;
+                startX = e.touches[0].clientX;
+                startY = e.touches[0].clientY;
+            });
+            
+            svg.addEventListener('touchmove', function(e) {
+                if (!isDragging) return;
+                
+                // Prevent scrolling while dragging
+                e.preventDefault();
+                
+                const dx = e.touches[0].clientX - startX;
+                const dy = e.touches[0].clientY - startY;
+                
+                // Update the transform
+                mainGroup.setAttribute('transform', `translate(${currentTranslateX + dx}, ${currentTranslateY + dy})`);
+            });
+            
+            svg.addEventListener('touchend', function(e) {
+                if (!isDragging) return;
+                
+                // Update the current position based on the last known touch position
+                const lastTouch = e.changedTouches[0];
+                const dx = lastTouch.clientX - startX;
+                const dy = lastTouch.clientY - startY;
+                currentTranslateX += dx;
+                currentTranslateY += dy;
+                
+                isDragging = false;
+            });
+            
+            // Set initial cursor
+            svg.style.cursor = 'grab';
+        }
+        
+        // Add drag and drop to the container
+        addDragAndDrop(container);
     }
+
+    // Add keyboard shortcut to reset the diagram position
+    document.addEventListener('keydown', function(e) {
+        // Only respond if a diagram is focused or the event is in the context of a diagram
+        const focusedDiagram = document.activeElement.closest('.provenance-diagram');
+        if (!focusedDiagram) return;
+        
+        // Reset position on 'R' key press
+        if (e.key === 'r' || e.key === 'R') {
+            const mainGroup = focusedDiagram.querySelector('svg g');
+            if (mainGroup) {
+                // Reset to initial position
+                mainGroup.setAttribute('transform', 'translate(10, 20)');
+                currentTranslateX = 10;
+                currentTranslateY = 20;
+                
+                // Show a short notification
+                const resetMsg = document.createElement('div');
+                resetMsg.className = 'reset-notification';
+                resetMsg.textContent = 'Diagram position reset';
+                focusedDiagram.appendChild(resetMsg);
+                
+                // Remove after animation completes
+                setTimeout(() => resetMsg.remove(), 1500);
+            }
+        }
+    });
 </script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -960,24 +960,7 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
             const svg = container.querySelector('svg');
             if (!svg) return;
             
-            // Add an instruction overlay
-            const instructionOverlay = document.createElement('div');
-            instructionOverlay.className = 'drag-instruction-overlay';
-            instructionOverlay.innerHTML = `
-                <div class="drag-instruction">
-                    <i class="bi bi-arrows-move"></i>
-                    <span>Click and drag to reposition the diagram</span>
-                </div>
-            `;
-            container.appendChild(instructionOverlay);
-            
-            // Hide the instruction after a few seconds
-            setTimeout(() => {
-                instructionOverlay.style.opacity = '0';
-                setTimeout(() => {
-                    instructionOverlay.remove();
-                }, 1000);
-            }, 3000);
+            // No instruction overlay - we'll keep the functionality without the message
             
             // Set up drag functionality
             let isDragging = false;

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -578,9 +578,23 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
         // Set up dimensions and spacing
         const width = 600;
         // Use the dynamic height passed from the parent function
-        const nodeWidth = 150;
+        const baseNodeWidth = 150;
         const nodeHeight = 50; // Increased node height for better text fit
         const nodePadding = 50;
+        
+        // Function to calculate node width dynamically based on text length
+        function calculateNodeWidth(name) {
+            // Base width for all nodes
+            const minWidth = baseNodeWidth;
+            // Max width is 50% wider than base width
+            const maxWidth = minWidth * 1.5;
+            
+            // Estimate width needed based on text length (rough estimate: ~8px per character)
+            const estimatedWidth = Math.max(minWidth, name.length * 8);
+            
+            // Clamp the width between min and max values
+            return Math.min(maxWidth, estimatedWidth);
+        }
         
         // Preload category icons for each resource
         const resourceIcons = {};
@@ -658,17 +672,19 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
         // Calculate horizontal positions
         // Left section for original sources, middle for secondary, right for product
         const leftMargin = 20; // Left edge margin
-        const rightMargin = width - nodeWidth - 20; // Right edge margin
-        const middlePosition = width / 2 - nodeWidth / 2; // Center position for secondary sources
+        const rightMargin = width - baseNodeWidth - 20; // Right edge margin
+        const middlePosition = width / 2 - baseNodeWidth / 2; // Center position for secondary sources
 
         // Define the diagram's horizontal layout zones more explicitly 
         const originalSourceZone = width * 0.15; // Original sources at about 15% from left
         const secondarySourceZone = width * 0.55; // Secondary sources at about 55% from left
 
         // Product node is always at the right
+        const productNodeWidth = calculateNodeWidth(data.product);
         const productNode = {
             id: data.product,
             name: data.product,
+            width: productNodeWidth, // Store node width for later use
             x: rightMargin,
             y: height / 2 - nodeHeight / 2,
             type: 'product'
@@ -678,13 +694,16 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
         // Process secondary sources (middle)
         if (data.secondarySources && data.secondarySources.length > 0) {
             // Use the secondarySourceZone position
-            const secondaryX = secondarySourceZone - nodeWidth / 2; // Center the node on the zone
+            const secondaryX = secondarySourceZone - baseNodeWidth / 2; // Center the node on the zone
 
             // If there's only one secondary source, center it vertically like the product node
             if (data.secondarySources.length === 1) {
+                const nodeName = data.secondarySources[0];
+                const nodeWidth = calculateNodeWidth(nodeName);
                 const node = {
-                    id: data.secondarySources[0],
-                    name: data.secondarySources[0],
+                    id: nodeName,
+                    name: nodeName,
+                    width: nodeWidth, // Store node width for later use
                     x: secondaryX,
                     y: height / 2 - nodeHeight / 2, // Same vertical centering as product node
                     type: 'secondary'
@@ -702,9 +721,11 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
                 const startY = 30; // Start further from the top
 
                 data.secondarySources.forEach((source, i) => {
+                    const nodeWidth = calculateNodeWidth(source);
                     const node = {
                         id: source,
                         name: source,
+                        width: nodeWidth, // Store node width for later use
                         x: secondaryX,
                         y: startY + (i + 1) * spacing - nodeHeight / 2,
                         type: 'secondary'
@@ -723,14 +744,17 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
         // Process original sources (left)
         if (data.originalSources && data.originalSources.length > 0) {
             // Use the originalSourceZone position
-            const originalBaseX = originalSourceZone - nodeWidth / 2; // Center the node on the zone
+            const originalBaseX = originalSourceZone - baseNodeWidth / 2; // Center the node on the zone
             const staggerWidth = 20; // How much to stagger horizontally
 
             // If there's only one original source, center it vertically like the product node
             if (data.originalSources.length === 1) {
+                const nodeName = data.originalSources[0];
+                const nodeWidth = calculateNodeWidth(nodeName);
                 const node = {
-                    id: data.originalSources[0],
-                    name: data.originalSources[0],
+                    id: nodeName,
+                    name: nodeName,
+                    width: nodeWidth, // Store node width for later use
                     x: originalBaseX,
                     y: height / 2 - nodeHeight / 2, // Same vertical centering as product node
                     type: 'original'
@@ -762,10 +786,12 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
                     // Alternate between originalBaseX and originalBaseX + staggerWidth
                     // Maintain the staggering effect
                     const staggeredX = i % 2 === 0 ? originalBaseX : originalBaseX + staggerWidth;
-
+                    const nodeWidth = calculateNodeWidth(source);
+                    
                     const node = {
                         id: source,
                         name: source,
+                        width: nodeWidth, // Store node width for later use
                         x: staggeredX,
                         y: startY + (i + 1) * spacing - nodeHeight / 2,
                         type: 'original'
@@ -802,7 +828,8 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
         // Add path for each arrow
         arrows.append('path')
             .attr('d', d => {
-                const sourceX = d.source.x + nodeWidth;
+                const sourceWidth = d.source.width || baseNodeWidth; // Use stored width or fallback to base width
+                const sourceX = d.source.x + sourceWidth;
                 const sourceY = d.source.y + nodeHeight / 2;
                 const targetX = d.target.x;
                 const targetY = d.target.y + nodeHeight / 2;
@@ -880,7 +907,7 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
 
         // Add rectangle for each node
         nodeGroups.append('rect')
-            .attr('width', nodeWidth)
+            .attr('width', d => calculateNodeWidth(d.name))
             .attr('height', nodeHeight)
             .attr('rx', 5)
             .attr('ry', 5)
@@ -895,15 +922,17 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
 
         // Add text for each node
         nodeGroups.append('text')
-            .attr('x', nodeWidth / 2 + 12) // Shift text more to the right to make room for the larger icon
+            .attr('x', d => calculateNodeWidth(d.name) / 2 + 12) // Center text in dynamic width node, with offset for icon
             .attr('y', nodeHeight / 2)
             .attr('text-anchor', 'middle')
             .attr('dominant-baseline', 'middle')
             .attr('fill', 'white')
             .attr('font-size', '14px') // Increased font size
             .text(d => {
-                // Truncate long names
-                return d.name.length > 15 ? d.name.substring(0, 12) + '...' : d.name;
+                // Use more of the available space - truncate only if necessary
+                const nodeWidth = calculateNodeWidth(d.name);
+                const maxChars = Math.floor((nodeWidth - 40) / 8); // Approximate chars that fit, leaving space for icon
+                return d.name.length > maxChars ? d.name.substring(0, maxChars - 3) + '...' : d.name;
             })
             .append('title')  // Add tooltip for full name
             .text(d => d.name);
@@ -911,7 +940,7 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
         // Add category icons to each node
         nodeGroups.append('g')
             .attr('class', 'node-icon')
-            .attr('transform', d => `translate(25, ${nodeHeight/2})`) // Position slightly more to the right, vertically centered
+            .attr('transform', d => `translate(25, ${nodeHeight/2})`) // Left-aligned position, vertically centered
             .each(function(d) {
                 const iconGroup = d3.select(this);
                 const iconData = resourceIcons[d.id];

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -423,7 +423,7 @@
 
         // Add text for each node
         nodeGroups.append('text')
-            .attr('x', nodeWidth / 2)
+            .attr('x', nodeWidth / 2 + 12) // Shift text more to the right to make room for the larger icon
             .attr('y', nodeHeight / 2)
             .attr('text-anchor', 'middle')
             .attr('dominant-baseline', 'middle')
@@ -431,7 +431,7 @@
             .attr('font-size', '14px') // Increased font size
             .text(d => {
                 // Truncate long names
-                return d.name.length > 18 ? d.name.substring(0, 15) + '...' : d.name;
+                return d.name.length > 15 ? d.name.substring(0, 12) + '...' : d.name;
             })
             .append('title')  // Add tooltip for full name
             .text(d => d.name);
@@ -439,7 +439,7 @@
         // Add category icons to each node
         nodeGroups.append('g')
             .attr('class', 'node-icon')
-            .attr('transform', d => `translate(${nodeWidth - 22}, 10)`) // Position in top-right corner with padding
+            .attr('transform', d => `translate(25, ${nodeHeight/2})`) // Position slightly more to the right, vertically centered
             .each(function(d) {
                 const iconGroup = d3.select(this);
                 const iconData = resourceIcons[d.id];
@@ -447,19 +447,19 @@
                 if (iconData && iconData.icon) {
                     // Create icon background circle
                     iconGroup.append('circle')
-                        .attr('r', 10)
+                        .attr('r', 15) // Bigger circle
                         .attr('fill', 'white')
                         .attr('opacity', 0.9);
                         
                     // Create SVG for Bootstrap icon
                     // Use foreign object to embed HTML icon
                     iconGroup.append('foreignObject')
-                        .attr('width', 20)
-                        .attr('height', 20)
-                        .attr('x', -10)
-                        .attr('y', -10)
-                        .html(`<div style="width:20px;height:20px;display:flex;align-items:center;justify-content:center">
-                            <i class="bi bi-${iconData.icon}" style="font-size:12px;color:#333;"></i>
+                        .attr('width', 30) // Bigger icon container
+                        .attr('height', 30) // Bigger icon container
+                        .attr('x', -15) // Half of width
+                        .attr('y', -15) // Half of height
+                        .html(`<div style="width:30px;height:30px;display:flex;align-items:center;justify-content:center">
+                            <i class="bi bi-${iconData.icon}" style="font-size:18px;color:#333;"></i>
                         </div>`);
                         
                     // Add tooltip with category name

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,6 +9,15 @@
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         renderProvenanceDiagrams();
+        
+        // Add window resize listener to adjust diagrams on window resize
+        window.addEventListener('resize', function() {
+            // Debounce the resize event
+            if (this.resizeTimeout) clearTimeout(this.resizeTimeout);
+            this.resizeTimeout = setTimeout(function() {
+                renderProvenanceDiagrams();
+            }, 200);
+        });
     });
 
     // D3.js Provenance Diagram renderer
@@ -17,19 +26,44 @@
         
         provenanceContainers.forEach(container => {
             const data = JSON.parse(container.getAttribute('data-provenance'));
-            renderD3Diagram(container, data);
+            
+            // Calculate appropriate height based on number of sources
+            const originalSourceCount = data.originalSources ? data.originalSources.length : 0;
+            const secondarySourceCount = data.secondarySources ? data.secondarySources.length : 0;
+            
+            // Base height + additional height per source (with some minimum)
+            const minHeight = 300; // Minimum height
+            const heightPerSource = 70; // Add this much height per source
+            
+            // Calculate height based on whichever is larger: original or secondary sources
+            const calculatedHeight = Math.max(
+                minHeight,
+                Math.max(originalSourceCount, secondarySourceCount) * heightPerSource + 100
+            );
+            
+            // Set height on the container
+            container.style.height = `${calculatedHeight}px`;
+            
+            // Render the diagram with the calculated height
+            renderD3Diagram(container, data, calculatedHeight);
+            
+            // Also set the height on the parent card
+            const cardBody = container.closest('.card-body');
+            if (cardBody) {
+                cardBody.style.minHeight = `${calculatedHeight + 70}px`; // Add some extra padding
+            }
         });
     }
 
-    function renderD3Diagram(container, data) {
+    function renderD3Diagram(container, data, height) {
         // Clear any existing content
         container.innerHTML = '';
         
         // Set up dimensions and spacing
         const width = 600;
-        const height = 300;
+        // Use the dynamic height passed from the parent function
         const nodeWidth = 150;
-        const nodeHeight = 40;
+        const nodeHeight = 50; // Increased node height for better text fit
         const nodePadding = 50;
         
         // Create SVG
@@ -49,6 +83,7 @@
             .attr('x', width / 2)
             .attr('y', height - 10)
             .attr('text-anchor', 'middle')
+            .attr('font-size', '14px') // Increased font size
             .text('Data Flow →');
             
         // Process the data to create node positions
@@ -74,17 +109,14 @@
         // Process secondary sources (middle)
         if (data.secondarySources && data.secondarySources.length > 0) {
             const secondaryX = middlePosition;
-            data.secondarySources.forEach((source, i) => {
-                // For multiple secondary sources, distribute them vertically
-                const y = data.secondarySources.length > 1 
-                    ? (height / (data.secondarySources.length + 1)) * (i + 1) - nodeHeight / 2
-                    : height / 2 - nodeHeight / 2;
-                    
+            
+            // If there's only one secondary source, center it vertically like the product node
+            if (data.secondarySources.length === 1) {
                 const node = {
-                    id: source,
-                    name: source,
+                    id: data.secondarySources[0],
+                    name: data.secondarySources[0],
                     x: secondaryX,
-                    y: y,
+                    y: height / 2 - nodeHeight / 2, // Same vertical centering as product node
                     type: 'secondary'
                 };
                 nodes.push(node);
@@ -94,20 +126,41 @@
                     source: node,
                     target: productNode
                 });
-            });
+            } else {
+                // For multiple secondary sources, distribute them evenly
+                const spacing = (height - 60) / (data.secondarySources.length + 1);
+                const startY = 30; // Start further from the top
+                
+                data.secondarySources.forEach((source, i) => {
+                    const node = {
+                        id: source,
+                        name: source,
+                        x: secondaryX,
+                        y: startY + (i + 1) * spacing - nodeHeight / 2,
+                        type: 'secondary'
+                    };
+                    nodes.push(node);
+                    
+                    // Link to product
+                    links.push({
+                        source: node,
+                        target: productNode
+                    });
+                });
+            }
         }
         
         // Process original sources (left)
         if (data.originalSources && data.originalSources.length > 0) {
             const originalX = leftMargin;
-            const spacing = height / (data.originalSources.length + 1);
             
-            data.originalSources.forEach((source, i) => {
+            // If there's only one original source, center it vertically like the product node
+            if (data.originalSources.length === 1) {
                 const node = {
-                    id: source,
-                    name: source,
+                    id: data.originalSources[0],
+                    name: data.originalSources[0],
                     x: originalX,
-                    y: (i + 1) * spacing - nodeHeight / 2,
+                    y: height / 2 - nodeHeight / 2, // Same vertical centering as product node
                     type: 'original'
                 };
                 nodes.push(node);
@@ -128,7 +181,39 @@
                         target: productNode
                     });
                 }
-            });
+            } else {
+                // For multiple original sources, distribute them evenly
+                const spacing = (height - 60) / (data.originalSources.length + 1);
+                const startY = 30; // Start further from the top
+                
+                data.originalSources.forEach((source, i) => {
+                    const node = {
+                        id: source,
+                        name: source,
+                        x: originalX,
+                        y: startY + (i + 1) * spacing - nodeHeight / 2,
+                        type: 'original'
+                    };
+                    nodes.push(node);
+                    
+                    // Link to secondary source or product
+                    if (data.secondarySources && data.secondarySources.length > 0) {
+                        // Link to each secondary source
+                        nodes.filter(n => n.type === 'secondary').forEach(target => {
+                            links.push({
+                                source: node,
+                                target: target
+                            });
+                        });
+                    } else {
+                        // Link directly to product if no secondary sources
+                        links.push({
+                            source: node,
+                            target: productNode
+                        });
+                    }
+                });
+            }
         }
         
         // Create links (arrows)
@@ -226,6 +311,7 @@
             .attr('text-anchor', 'middle')
             .attr('dominant-baseline', 'middle')
             .attr('fill', 'white')
+            .attr('font-size', '14px') // Increased font size
             .text(d => {
                 // Truncate long names
                 return d.name.length > 18 ? d.name.substring(0, 15) + '...' : d.name;
@@ -233,10 +319,10 @@
             .append('title')  // Add tooltip for full name
             .text(d => d.name);
             
-        // Add a legend
+        // Add a legend (horizontal layout)
         const legend = svg.append('g')
             .attr('class', 'legend')
-            .attr('transform', `translate(${width - 130}, 10)`);
+            .attr('transform', `translate(${width/2 - 250}, 10)`); // Centered at the top
             
         const legendItems = [
             { type: 'original', label: 'Original Source' },
@@ -244,18 +330,20 @@
             { type: 'product', label: 'Product' }
         ];
         
+        const legendItemWidth = 160; // Width for each legend item
+        
         const legendGroups = legend.selectAll('.legend-item')
             .data(legendItems)
             .enter()
             .append('g')
             .attr('class', 'legend-item')
-            .attr('transform', (d, i) => `translate(0, ${i * 20})`);
+            .attr('transform', (d, i) => `translate(${i * legendItemWidth}, 0)`); // Horizontal layout
             
         legendGroups.append('rect')
-            .attr('width', 15)
-            .attr('height', 15)
-            .attr('rx', 2)
-            .attr('ry', 2)
+            .attr('width', 18) // Width of color box
+            .attr('height', 18) // Height of color box
+            .attr('rx', 3) // Corner radius
+            .attr('ry', 3) // Corner radius
             .attr('fill', d => {
                 if (d.type === 'product') return '#5588bb';
                 if (d.type === 'secondary') return '#88bb55';
@@ -263,9 +351,9 @@
             });
             
         legendGroups.append('text')
-            .attr('x', 20)
-            .attr('y', 12)
-            .attr('font-size', '10px')
+            .attr('x', 24) // Position text to the right of the rectangle
+            .attr('y', 14) // Vertical alignment
+            .attr('font-size', '14px') // Font size
             .text(d => d.label);
     }
   </script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,22 +1,271 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://d3js.org/d3.v7.min.js"></script>
 
 <!-- prism.js is for code blocks, see https://prismjs.com -->
 <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 
-<script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-
-    mermaid.initialize({ startOnLoad: false,
-                         theme: 'neutral',
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        renderProvenanceDiagrams();
     });
 
-    async function runMermaid() {
-        await mermaid.run({
-            querySelector: 'pre > code.language-mermaid',
+    // D3.js Provenance Diagram renderer
+    function renderProvenanceDiagrams() {
+        const provenanceContainers = document.querySelectorAll('.provenance-diagram');
+        
+        provenanceContainers.forEach(container => {
+            const data = JSON.parse(container.getAttribute('data-provenance'));
+            renderD3Diagram(container, data);
         });
     }
 
-    document.addEventListener('DOMContentLoaded', runMermaid);
+    function renderD3Diagram(container, data) {
+        // Clear any existing content
+        container.innerHTML = '';
+        
+        // Set up dimensions and spacing
+        const width = 600;
+        const height = 300;
+        const nodeWidth = 150;
+        const nodeHeight = 40;
+        const nodePadding = 50;
+        
+        // Create SVG
+        const svg = d3.select(container)
+            .append('svg')
+            .attr('width', width)
+            .attr('height', height)
+            .attr('class', 'provenance-svg');
+            
+        // Create a group for the entire diagram
+        const g = svg.append('g')
+            .attr('transform', 'translate(10, 20)');
+            
+        // Add a subtle data flow indicator
+        svg.append('text')
+            .attr('class', 'direction-indicator')
+            .attr('x', width / 2)
+            .attr('y', height - 10)
+            .attr('text-anchor', 'middle')
+            .text('Data Flow →');
+            
+        // Process the data to create node positions
+        const nodes = [];
+        const links = [];
+        
+        // Calculate horizontal positions
+        // Left section for original sources, middle for secondary, right for product
+        const leftMargin = 20;
+        const rightMargin = width - nodeWidth - 20;
+        const middlePosition = width / 2 - nodeWidth / 2;
+        
+        // Product node is always at the right
+        const productNode = {
+            id: data.product,
+            name: data.product,
+            x: rightMargin,
+            y: height / 2 - nodeHeight / 2,
+            type: 'product'
+        };
+        nodes.push(productNode);
+        
+        // Process secondary sources (middle)
+        if (data.secondarySources && data.secondarySources.length > 0) {
+            const secondaryX = middlePosition;
+            data.secondarySources.forEach((source, i) => {
+                // For multiple secondary sources, distribute them vertically
+                const y = data.secondarySources.length > 1 
+                    ? (height / (data.secondarySources.length + 1)) * (i + 1) - nodeHeight / 2
+                    : height / 2 - nodeHeight / 2;
+                    
+                const node = {
+                    id: source,
+                    name: source,
+                    x: secondaryX,
+                    y: y,
+                    type: 'secondary'
+                };
+                nodes.push(node);
+                
+                // Link to product
+                links.push({
+                    source: node,
+                    target: productNode
+                });
+            });
+        }
+        
+        // Process original sources (left)
+        if (data.originalSources && data.originalSources.length > 0) {
+            const originalX = leftMargin;
+            const spacing = height / (data.originalSources.length + 1);
+            
+            data.originalSources.forEach((source, i) => {
+                const node = {
+                    id: source,
+                    name: source,
+                    x: originalX,
+                    y: (i + 1) * spacing - nodeHeight / 2,
+                    type: 'original'
+                };
+                nodes.push(node);
+                
+                // Link to secondary source or product
+                if (data.secondarySources && data.secondarySources.length > 0) {
+                    // Link to each secondary source
+                    nodes.filter(n => n.type === 'secondary').forEach(target => {
+                        links.push({
+                            source: node,
+                            target: target
+                        });
+                    });
+                } else {
+                    // Link directly to product if no secondary sources
+                    links.push({
+                        source: node,
+                        target: productNode
+                    });
+                }
+            });
+        }
+        
+        // Create links (arrows)
+        const arrows = g.selectAll('.arrow')
+            .data(links)
+            .enter()
+            .append('g')
+            .attr('class', 'arrow');
+            
+        // Add path for each arrow
+        arrows.append('path')
+            .attr('d', d => {
+                const sourceX = d.source.x + nodeWidth;
+                const sourceY = d.source.y + nodeHeight / 2;
+                const targetX = d.target.x;
+                const targetY = d.target.y + nodeHeight / 2;
+                
+                return `M${sourceX},${sourceY} C${sourceX + 30},${sourceY} ${targetX - 30},${targetY} ${targetX},${targetY}`;
+            })
+            .attr('fill', 'none')
+            .attr('stroke', '#999')
+            .attr('stroke-width', 2)
+            .attr('marker-end', 'url(#arrowhead)');
+            
+        // Add arrowhead marker definition
+        svg.append('defs').append('marker')
+            .attr('id', 'arrowhead')
+            .attr('viewBox', '0 -5 10 10')
+            .attr('refX', 8)
+            .attr('refY', 0)
+            .attr('markerWidth', 6)
+            .attr('markerHeight', 6)
+            .attr('orient', 'auto')
+            .append('path')
+            .attr('d', 'M0,-5L10,0L0,5')
+            .attr('fill', '#999');
+            
+        // Create nodes
+        const nodeGroups = g.selectAll('.node')
+            .data(nodes)
+            .enter()
+            .append('g')
+            .attr('class', d => `node ${d.type}`)
+            .attr('transform', d => `translate(${d.x}, ${d.y})`)
+            .on('click', function(event, d) {
+                // Navigate to the resource page when clicking a node
+                window.location.href = `/kg-registry/resource/${d.id}/${d.id}.html`;
+            })
+            .on('mouseover', function(event, d) {
+                // Highlight connected links and nodes
+                d3.select(this).select('rect')
+                    .attr('stroke-width', d.type === 'product' ? 4 : 2)
+                    .attr('filter', 'brightness(1.1)');
+                
+                // Highlight connected arrows
+                arrows.selectAll('path')
+                    .attr('stroke-width', link => 
+                        (link.source.id === d.id || link.target.id === d.id) ? 3 : 2
+                    )
+                    .attr('stroke', link => 
+                        (link.source.id === d.id || link.target.id === d.id) ? '#666' : '#999'
+                    );
+            })
+            .on('mouseout', function(event, d) {
+                // Reset highlights
+                d3.select(this).select('rect')
+                    .attr('stroke-width', d.type === 'product' ? 3 : 1)
+                    .attr('filter', null);
+                
+                // Reset arrows
+                arrows.selectAll('path')
+                    .attr('stroke-width', 2)
+                    .attr('stroke', '#999');
+            });
+            
+        // Add rectangle for each node
+        nodeGroups.append('rect')
+            .attr('width', nodeWidth)
+            .attr('height', nodeHeight)
+            .attr('rx', 5)
+            .attr('ry', 5)
+            .attr('fill', d => {
+                if (d.type === 'product') return '#5588bb';
+                if (d.type === 'secondary') return '#88bb55';
+                return '#ddaa44';
+            })
+            .attr('stroke', '#333')
+            .attr('stroke-width', d => d.type === 'product' ? 3 : 1)
+            .attr('cursor', 'pointer');
+            
+        // Add text for each node
+        nodeGroups.append('text')
+            .attr('x', nodeWidth / 2)
+            .attr('y', nodeHeight / 2)
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'middle')
+            .attr('fill', 'white')
+            .text(d => {
+                // Truncate long names
+                return d.name.length > 18 ? d.name.substring(0, 15) + '...' : d.name;
+            })
+            .append('title')  // Add tooltip for full name
+            .text(d => d.name);
+            
+        // Add a legend
+        const legend = svg.append('g')
+            .attr('class', 'legend')
+            .attr('transform', `translate(${width - 130}, 10)`);
+            
+        const legendItems = [
+            { type: 'original', label: 'Original Source' },
+            { type: 'secondary', label: 'Secondary Source' },
+            { type: 'product', label: 'Product' }
+        ];
+        
+        const legendGroups = legend.selectAll('.legend-item')
+            .data(legendItems)
+            .enter()
+            .append('g')
+            .attr('class', 'legend-item')
+            .attr('transform', (d, i) => `translate(0, ${i * 20})`);
+            
+        legendGroups.append('rect')
+            .attr('width', 15)
+            .attr('height', 15)
+            .attr('rx', 2)
+            .attr('ry', 2)
+            .attr('fill', d => {
+                if (d.type === 'product') return '#5588bb';
+                if (d.type === 'secondary') return '#88bb55';
+                return '#ddaa44';
+            });
+            
+        legendGroups.append('text')
+            .attr('x', 20)
+            .attr('y', 12)
+            .attr('font-size', '10px')
+            .text(d => d.label);
+    }
   </script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -7,14 +7,14 @@
 <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
         renderProvenanceDiagrams();
-        
+
         // Add window resize listener to adjust diagrams on window resize
-        window.addEventListener('resize', function() {
+        window.addEventListener('resize', function () {
             // Debounce the resize event
             if (this.resizeTimeout) clearTimeout(this.resizeTimeout);
-            this.resizeTimeout = setTimeout(function() {
+            this.resizeTimeout = setTimeout(function () {
                 renderProvenanceDiagrams();
             }, 200);
         });
@@ -23,30 +23,30 @@
     // D3.js Provenance Diagram renderer
     function renderProvenanceDiagrams() {
         const provenanceContainers = document.querySelectorAll('.provenance-diagram');
-        
+
         provenanceContainers.forEach(container => {
             const data = JSON.parse(container.getAttribute('data-provenance'));
-            
+
             // Calculate appropriate height based on number of sources
             const originalSourceCount = data.originalSources ? data.originalSources.length : 0;
             const secondarySourceCount = data.secondarySources ? data.secondarySources.length : 0;
-            
+
             // Base height + additional height per source (with some minimum)
             const minHeight = 300; // Minimum height
             const heightPerSource = 70; // Add this much height per source
-            
+
             // Calculate height based on whichever is larger: original or secondary sources
             const calculatedHeight = Math.max(
                 minHeight,
                 Math.max(originalSourceCount, secondarySourceCount) * heightPerSource + 100
             );
-            
+
             // Set height on the container
             container.style.height = `${calculatedHeight}px`;
-            
+
             // Render the diagram with the calculated height
             renderD3Diagram(container, data, calculatedHeight);
-            
+
             // Also set the height on the parent card
             const cardBody = container.closest('.card-body');
             if (cardBody) {
@@ -58,25 +58,25 @@
     function renderD3Diagram(container, data, height) {
         // Clear any existing content
         container.innerHTML = '';
-        
+
         // Set up dimensions and spacing
         const width = 600;
         // Use the dynamic height passed from the parent function
         const nodeWidth = 150;
         const nodeHeight = 50; // Increased node height for better text fit
         const nodePadding = 50;
-        
+
         // Create SVG
         const svg = d3.select(container)
             .append('svg')
             .attr('width', width)
             .attr('height', height)
             .attr('class', 'provenance-svg');
-            
+
         // Create a group for the entire diagram
         const g = svg.append('g')
             .attr('transform', 'translate(10, 20)');
-            
+
         // Add a subtle data flow indicator
         svg.append('text')
             .attr('class', 'direction-indicator')
@@ -85,21 +85,21 @@
             .attr('text-anchor', 'middle')
             .attr('font-size', '14px') // Increased font size
             .text('Data Flow →');
-            
+
         // Process the data to create node positions
         const nodes = [];
         const links = [];
-        
+
         // Calculate horizontal positions
         // Left section for original sources, middle for secondary, right for product
         const leftMargin = 20; // Left edge margin
         const rightMargin = width - nodeWidth - 20; // Right edge margin
         const middlePosition = width / 2 - nodeWidth / 2; // Center position for secondary sources
-        
+
         // Define the diagram's horizontal layout zones more explicitly 
         const originalSourceZone = width * 0.15; // Original sources at about 15% from left
         const secondarySourceZone = width * 0.55; // Secondary sources at about 55% from left
-        
+
         // Product node is always at the right
         const productNode = {
             id: data.product,
@@ -109,12 +109,12 @@
             type: 'product'
         };
         nodes.push(productNode);
-        
+
         // Process secondary sources (middle)
         if (data.secondarySources && data.secondarySources.length > 0) {
             // Use the secondarySourceZone position
-            const secondaryX = secondarySourceZone - nodeWidth/2; // Center the node on the zone
-            
+            const secondaryX = secondarySourceZone - nodeWidth / 2; // Center the node on the zone
+
             // If there's only one secondary source, center it vertically like the product node
             if (data.secondarySources.length === 1) {
                 const node = {
@@ -125,7 +125,7 @@
                     type: 'secondary'
                 };
                 nodes.push(node);
-                
+
                 // Link to product
                 links.push({
                     source: node,
@@ -135,7 +135,7 @@
                 // For multiple secondary sources, distribute them evenly
                 const spacing = (height - 60) / (data.secondarySources.length + 1);
                 const startY = 30; // Start further from the top
-                
+
                 data.secondarySources.forEach((source, i) => {
                     const node = {
                         id: source,
@@ -145,7 +145,7 @@
                         type: 'secondary'
                     };
                     nodes.push(node);
-                    
+
                     // Link to product
                     links.push({
                         source: node,
@@ -154,13 +154,13 @@
                 });
             }
         }
-        
+
         // Process original sources (left)
         if (data.originalSources && data.originalSources.length > 0) {
             // Use the originalSourceZone position
-            const originalBaseX = originalSourceZone - nodeWidth/2; // Center the node on the zone
+            const originalBaseX = originalSourceZone - nodeWidth / 2; // Center the node on the zone
             const staggerWidth = 20; // How much to stagger horizontally
-            
+
             // If there's only one original source, center it vertically like the product node
             if (data.originalSources.length === 1) {
                 const node = {
@@ -171,7 +171,7 @@
                     type: 'original'
                 };
                 nodes.push(node);
-                
+
                 // Link to secondary source or product
                 if (data.secondarySources && data.secondarySources.length > 0) {
                     // Link to each secondary source
@@ -192,12 +192,12 @@
                 // For multiple original sources, distribute them evenly and stagger them horizontally
                 const spacing = (height - 60) / (data.originalSources.length + 1);
                 const startY = 30; // Start further from the top
-                
+
                 data.originalSources.forEach((source, i) => {
                     // Alternate between originalBaseX and originalBaseX + staggerWidth
                     // Maintain the staggering effect
                     const staggeredX = i % 2 === 0 ? originalBaseX : originalBaseX + staggerWidth;
-                    
+
                     const node = {
                         id: source,
                         name: source,
@@ -206,7 +206,7 @@
                         type: 'original'
                     };
                     nodes.push(node);
-                    
+
                     // Link to secondary source or product
                     if (data.secondarySources && data.secondarySources.length > 0) {
                         // Link to each secondary source
@@ -226,14 +226,14 @@
                 });
             }
         }
-        
+
         // Create links (arrows)
         const arrows = g.selectAll('.arrow')
             .data(links)
             .enter()
             .append('g')
             .attr('class', 'arrow');
-            
+
         // Add path for each arrow
         arrows.append('path')
             .attr('d', d => {
@@ -241,25 +241,25 @@
                 const sourceY = d.source.y + nodeHeight / 2;
                 const targetX = d.target.x;
                 const targetY = d.target.y + nodeHeight / 2;
-                
+
                 // Calculate distance between source and target
                 const distance = targetX - sourceX;
-                
+
                 // For long distances (original to secondary), use a more gentle curve
                 // For shorter distances (secondary to product), use a tighter curve
                 const isLongDistance = distance > width * 0.25;
-                
+
                 // Adjust control points based on distance
                 const controlPoint1X = sourceX + (isLongDistance ? distance * 0.25 : distance * 0.4);
                 const controlPoint2X = targetX - (isLongDistance ? distance * 0.25 : distance * 0.4);
-                
+
                 return `M${sourceX},${sourceY} C${controlPoint1X},${sourceY} ${controlPoint2X},${targetY} ${targetX},${targetY}`;
             })
             .attr('fill', 'none')
             .attr('stroke', '#999')
             .attr('stroke-width', 2)
             .attr('marker-end', 'url(#arrowhead)');
-            
+
         // Add arrowhead marker definition
         svg.append('defs').append('marker')
             .attr('id', 'arrowhead')
@@ -272,7 +272,7 @@
             .append('path')
             .attr('d', 'M0,-5L10,0L0,5')
             .attr('fill', '#999');
-            
+
         // Create nodes
         const nodeGroups = g.selectAll('.node')
             .data(nodes)
@@ -280,37 +280,39 @@
             .append('g')
             .attr('class', d => `node ${d.type}`)
             .attr('transform', d => `translate(${d.x}, ${d.y})`)
-            .on('click', function(event, d) {
-                // Navigate to the resource page when clicking a node
-                window.location.href = `/kg-registry/resource/${d.id}/${d.id}.html`;
+            .on('click', function (event, d) {
+                // Only navigate if it's not the product node (since we're already on the product page)
+                if (d.type !== 'product') {
+                    window.location.href = `/kg-registry/resource/${d.id}/${d.id}.html`;
+                }
             })
-            .on('mouseover', function(event, d) {
+            .on('mouseover', function (event, d) {
                 // Highlight connected links and nodes
                 d3.select(this).select('rect')
                     .attr('stroke-width', d.type === 'product' ? 4 : 2)
                     .attr('filter', 'brightness(1.1)');
-                
+
                 // Highlight connected arrows
                 arrows.selectAll('path')
-                    .attr('stroke-width', link => 
+                    .attr('stroke-width', link =>
                         (link.source.id === d.id || link.target.id === d.id) ? 3 : 2
                     )
-                    .attr('stroke', link => 
+                    .attr('stroke', link =>
                         (link.source.id === d.id || link.target.id === d.id) ? '#666' : '#999'
                     );
             })
-            .on('mouseout', function(event, d) {
+            .on('mouseout', function (event, d) {
                 // Reset highlights
                 d3.select(this).select('rect')
                     .attr('stroke-width', d.type === 'product' ? 3 : 1)
                     .attr('filter', null);
-                
+
                 // Reset arrows
                 arrows.selectAll('path')
                     .attr('stroke-width', 2)
                     .attr('stroke', '#999');
             });
-            
+
         // Add rectangle for each node
         nodeGroups.append('rect')
             .attr('width', nodeWidth)
@@ -324,8 +326,8 @@
             })
             .attr('stroke', '#333')
             .attr('stroke-width', d => d.type === 'product' ? 3 : 1)
-            .attr('cursor', 'pointer');
-            
+            .attr('cursor', d => d.type === 'product' ? 'default' : 'pointer');
+
         // Add text for each node
         nodeGroups.append('text')
             .attr('x', nodeWidth / 2)
@@ -340,27 +342,27 @@
             })
             .append('title')  // Add tooltip for full name
             .text(d => d.name);
-            
+
         // Add a legend (horizontal layout)
         const legend = svg.append('g')
             .attr('class', 'legend')
-            .attr('transform', `translate(${width/2 - 250}, 10)`); // Centered at the top
-            
+            .attr('transform', `translate(${width / 2 - 250}, 10)`); // Centered at the top
+
         const legendItems = [
             { type: 'original', label: 'Original Source' },
             { type: 'secondary', label: 'Secondary Source' },
             { type: 'product', label: 'Product' }
         ];
-        
+
         const legendItemWidth = 160; // Width for each legend item
-        
+
         const legendGroups = legend.selectAll('.legend-item')
             .data(legendItems)
             .enter()
             .append('g')
             .attr('class', 'legend-item')
             .attr('transform', (d, i) => `translate(${i * legendItemWidth}, 0)`); // Horizontal layout
-            
+
         legendGroups.append('rect')
             .attr('width', 18) // Width of color box
             .attr('height', 18) // Height of color box
@@ -371,11 +373,11 @@
                 if (d.type === 'secondary') return '#88bb55';
                 return '#ddaa44';
             });
-            
+
         legendGroups.append('text')
             .attr('x', 24) // Position text to the right of the rectangle
             .attr('y', 14) // Vertical alignment
             .attr('font-size', '14px') // Font size
             .text(d => d.label);
     }
-  </script>
+</script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -92,9 +92,13 @@
         
         // Calculate horizontal positions
         // Left section for original sources, middle for secondary, right for product
-        const leftMargin = 20;
-        const rightMargin = width - nodeWidth - 20;
-        const middlePosition = width / 2 - nodeWidth / 2;
+        const leftMargin = 20; // Left edge margin
+        const rightMargin = width - nodeWidth - 20; // Right edge margin
+        const middlePosition = width / 2 - nodeWidth / 2; // Center position for secondary sources
+        
+        // Define the diagram's horizontal layout zones more explicitly 
+        const originalSourceZone = width * 0.15; // Original sources at about 15% from left
+        const secondarySourceZone = width * 0.55; // Secondary sources at about 55% from left
         
         // Product node is always at the right
         const productNode = {
@@ -108,7 +112,8 @@
         
         // Process secondary sources (middle)
         if (data.secondarySources && data.secondarySources.length > 0) {
-            const secondaryX = middlePosition;
+            // Use the secondarySourceZone position
+            const secondaryX = secondarySourceZone - nodeWidth/2; // Center the node on the zone
             
             // If there's only one secondary source, center it vertically like the product node
             if (data.secondarySources.length === 1) {
@@ -152,14 +157,16 @@
         
         // Process original sources (left)
         if (data.originalSources && data.originalSources.length > 0) {
-            const originalX = leftMargin;
+            // Use the originalSourceZone position
+            const originalBaseX = originalSourceZone - nodeWidth/2; // Center the node on the zone
+            const staggerWidth = 20; // How much to stagger horizontally
             
             // If there's only one original source, center it vertically like the product node
             if (data.originalSources.length === 1) {
                 const node = {
                     id: data.originalSources[0],
                     name: data.originalSources[0],
-                    x: originalX,
+                    x: originalBaseX,
                     y: height / 2 - nodeHeight / 2, // Same vertical centering as product node
                     type: 'original'
                 };
@@ -182,15 +189,19 @@
                     });
                 }
             } else {
-                // For multiple original sources, distribute them evenly
+                // For multiple original sources, distribute them evenly and stagger them horizontally
                 const spacing = (height - 60) / (data.originalSources.length + 1);
                 const startY = 30; // Start further from the top
                 
                 data.originalSources.forEach((source, i) => {
+                    // Alternate between originalBaseX and originalBaseX + staggerWidth
+                    // Maintain the staggering effect
+                    const staggeredX = i % 2 === 0 ? originalBaseX : originalBaseX + staggerWidth;
+                    
                     const node = {
                         id: source,
                         name: source,
-                        x: originalX,
+                        x: staggeredX,
                         y: startY + (i + 1) * spacing - nodeHeight / 2,
                         type: 'original'
                     };
@@ -231,7 +242,18 @@
                 const targetX = d.target.x;
                 const targetY = d.target.y + nodeHeight / 2;
                 
-                return `M${sourceX},${sourceY} C${sourceX + 30},${sourceY} ${targetX - 30},${targetY} ${targetX},${targetY}`;
+                // Calculate distance between source and target
+                const distance = targetX - sourceX;
+                
+                // For long distances (original to secondary), use a more gentle curve
+                // For shorter distances (secondary to product), use a tighter curve
+                const isLongDistance = distance > width * 0.25;
+                
+                // Adjust control points based on distance
+                const controlPoint1X = sourceX + (isLongDistance ? distance * 0.25 : distance * 0.4);
+                const controlPoint2X = targetX - (isLongDistance ? distance * 0.25 : distance * 0.4);
+                
+                return `M${sourceX},${sourceY} C${controlPoint1X},${sourceY} ${controlPoint2X},${targetY} ${targetX},${targetY}`;
             })
             .attr('fill', 'none')
             .attr('stroke', '#999')

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -517,6 +517,29 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
         for (const container of provenanceContainers) {
             const data = JSON.parse(container.getAttribute('data-provenance'));
 
+            // Set up the legend toggle button
+            const containerCardBody = container.closest('.card-body');
+            const legendToggleBtn = containerCardBody.querySelector('.legend-toggle-button');
+            if (legendToggleBtn) {
+                legendToggleBtn.addEventListener('click', function() {
+                    const svg = container.querySelector('svg');
+                    const legends = svg.querySelectorAll('.legend');
+                    legends.forEach(legend => {
+                        legend.classList.toggle('hidden');
+                    });
+                    
+                    // Update icon to show active/inactive state
+                    const icon = this.querySelector('i');
+                    if (svg.querySelector('.legend.hidden')) {
+                        icon.classList.remove('bi-list-check');
+                        icon.classList.add('bi-list-ul');
+                    } else {
+                        icon.classList.remove('bi-list-ul');
+                        icon.classList.add('bi-list-check');
+                    }
+                });
+            }
+
             // Calculate appropriate height based on number of sources
             const originalSourceCount = data.originalSources ? data.originalSources.length : 0;
             const secondarySourceCount = data.secondarySources ? data.secondarySources.length : 0;
@@ -917,10 +940,10 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
                 }
             });
 
-        // Add a legend (horizontal layout)
+        // Add a legend (horizontal layout) - initially hidden
         const legend = svg.append('g')
-            .attr('class', 'legend')
-            .attr('transform', `translate(${width / 2 - 250}, 10)`); // Centered at the top
+            .attr('class', 'legend hidden')
+            .attr('transform', `translate(${width / 2 - 300}, 10)`); // Centered at the top, adjusted for larger text
 
         const legendItems = [
             { type: 'original', label: 'Original Source' },
@@ -928,7 +951,7 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
             { type: 'product', label: 'Product' }
         ];
 
-        const legendItemWidth = 160; // Width for each legend item
+        const legendItemWidth = 180; // Width for each legend item, increased to accommodate icons
 
         const legendGroups = legend.selectAll('.legend-item')
             .data(legendItems)
@@ -937,11 +960,13 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
             .attr('class', 'legend-item')
             .attr('transform', (d, i) => `translate(${i * legendItemWidth}, 0)`); // Horizontal layout
 
+        // Add color squares of the same size as icon circles (18x18)
         legendGroups.append('rect')
-            .attr('width', 18) // Width of color box
-            .attr('height', 18) // Height of color box
+            .attr('width', 18) // Width of color box - match icon circle diameter
+            .attr('height', 18) // Height of color box - match icon circle diameter
             .attr('rx', 3) // Corner radius
             .attr('ry', 3) // Corner radius
+            .attr('y', -9) // Shift up half height to align centers with icon circles
             .attr('fill', d => {
                 if (d.type === 'product') return '#5588bb';
                 if (d.type === 'secondary') return '#88bb55';
@@ -950,8 +975,67 @@ kgr:${validatedData.product} prov:wasDerivedFrom kgr:${source} .
 
         legendGroups.append('text')
             .attr('x', 24) // Position text to the right of the rectangle
-            .attr('y', 14) // Vertical alignment
-            .attr('font-size', '14px') // Font size
+            .attr('y', 0) // Center text vertically at same level as icon labels
+            .attr('dominant-baseline', 'middle') // Align vertically
+            .attr('font-size', '14px') // Increased font size for better readability
+            .text(d => d.label);
+            
+        // Add a second section to the legend for icon types
+        const iconLegendGroup = svg.append('g')
+            .attr('class', 'legend legend-icons hidden')
+            .attr('transform', `translate(${width / 2 - 300}, 45)`); // Position below the main legend, adjusted for larger text
+            
+        // Common icon categories that appear often
+        const iconLegendItems = [
+            { category: 'KnowledgeGraph', icon: 'globe', label: 'Knowledge Graph' },
+            { category: 'DataSource', icon: 'shop', label: 'Data Source' },
+            { category: 'Resource', icon: 'archive', label: 'Resource' },
+            { category: 'DataModel', icon: 'diagram-3', label: 'Data Model' },
+            { category: 'Product', icon: 'box', label: 'Generic Product' }
+        ];
+        
+        const iconLegendItemWidth = 180; // Width for each icon legend item, increased for larger text
+        
+        // Create icon legend items
+        const iconGroups = iconLegendGroup.selectAll('.legend-icon-item')
+            .data(iconLegendItems)
+            .enter()
+            .append('g')
+            .attr('class', 'legend-icon-item')
+            .attr('transform', (d, i) => {
+                // Create two rows of icons if more than 3
+                const row = Math.floor(i / 3);
+                const col = i % 3;
+                return `translate(${col * iconLegendItemWidth}, ${row * 30})`; // Increased vertical spacing between rows
+            });
+            
+        // Add icon circles
+        iconGroups.append('circle')
+            .attr('r', 9)
+            .attr('fill', 'white')
+            .attr('stroke', '#999')
+            .attr('stroke-width', '1px');
+            
+        // Add icons using foreignObject with HTML (same approach as in the main diagram)
+        iconGroups.each(function(d) {
+            const group = d3.select(this);
+            group.append('foreignObject')
+                .attr('width', 18) 
+                .attr('height', 18)
+                .attr('x', -9) // Center horizontally
+                .attr('y', -9) // Center vertically
+                .html(d => `<div style="width:18px;height:18px;display:flex;align-items:center;justify-content:center">
+                    <i class="bi bi-${d.icon}" style="font-size:13px;color:#333;"></i>
+                </div>`);
+        });
+            
+        // Add labels
+        iconGroups.append('text')
+            .attr('x', 14) // Position to the right of the icon
+            .attr('y', 0) // Center vertically
+            .attr('dominant-baseline', 'middle')
+            .attr('font-size', '14px') // Increased font size for better readability
+            .attr('fill', '#333')
             .text(d => d.label);
 
         // Add drag and drop functionality

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -92,6 +92,9 @@ layout: default
           <span class="provenance-help" title="Click and drag to reposition. Press 'R' to reset position.">
             <i class="bi bi-question-circle"></i>
           </span>
+          <button class="btn btn-sm legend-toggle-button" type="button" title="Toggle Legend and Icon Key">
+            <i class="bi bi-list-ul"></i>
+          </button>
           <div class="dropdown export-dropdown">
             <button class="btn btn-sm dropdown-toggle export-menu-button" type="button" id="exportDropdown" data-bs-toggle="dropdown" aria-expanded="false">
               <i class="bi bi-download"></i> Export

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -83,57 +83,35 @@ layout: default
     {% endfor %}
     {% endif %}
 
-    <!-- This diagram should probably reference the full registry,
-because some details may not be available from the current
-product (e.g., there may be multiple sources and they
-may be processed differently).
-The current diagram is rather hacky.
-TODO: restructure accordingly. -->
+    <!-- Provenance visualization using D3.js -->
     {% if page.original_source or page.secondary_source %}
-    {% if page.secondary_source and page.original_source %}
     <div class="card bg-light mb-3" style="max-width: 60rem;">
       <div class="card-body">
         <h4 class="card-title"><i class="bi bi-arrow-down-right-square-fill"></i> Provenance</h4>
-        {% if page.original_source.size > 1 %}
-        <pre><code class="language-mermaid" style="display: flex; justify-content: center"> 
-            block-beta
-            columns 3
-            DataSourceA("{{page.original_source[0]}}") space:1
-            DataSourceB("{{page.original_source[1]}}") space:4
-            Aggregator("{{page.secondary_source}}") space:5
-            Product("{{page.id}}")
-            DataSourceA  --> Aggregator
-            DataSourceB  --> Aggregator
-            Aggregator  --> Product  
-          
-            style Product stroke:#5588bb,stroke-width:5px;
-                
-          </code></pre>
-        {% elsif page.secondary_source == page.original_source %}
-        <pre><code class="language-mermaid" style="display: flex; justify-content: center"> 
-            block-beta
-            columns 1
-            DataSource("{{page.original_source}}") space:1
-            Product("{{page.id}}")
-            DataSource  --> Product
-          
-            style Product stroke:#5588bb,stroke-width:5px;
-                
-          </code></pre>
-        {% else %}
-        <pre><code class="language-mermaid" style="display: flex; justify-content: center"> 
-            block-beta
-            columns 1
-            DataSource("{{page.original_source}}") space:1
-            Aggregator("{{page.secondary_source}}") space:1
-            Product("{{page.id}}")
-            DataSource  --> Aggregator
-            Aggregator  --> Product  
-          
-            style Product stroke:#5588bb,stroke-width:5px;
-                
-          </code></pre>
-        {% endif %}
+        {% if page.secondary_source and page.original_source %}
+        <div class="provenance-diagram" style="height: 300px; width: 100%;" 
+          data-provenance='{
+            "product": "{{page.id}}",
+            "originalSources": [{% for source in page.original_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}],
+            "secondarySources": [{% if page.secondary_source.first != nil %}{% for source in page.secondary_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}{% else %}"{{page.secondary_source}}"{% endif %}]
+          }'>
+        </div>
+        {% elsif page.original_source %}
+        <div class="provenance-diagram" style="height: 300px; width: 100%;" 
+          data-provenance='{
+            "product": "{{page.id}}",
+            "originalSources": [{% for source in page.original_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}],
+            "secondarySources": []
+          }'>
+        </div>
+        {% elsif page.secondary_source %}
+        <div class="provenance-diagram" style="height: 300px; width: 100%;" 
+          data-provenance='{
+            "product": "{{page.id}}",
+            "originalSources": [],
+            "secondarySources": [{% if page.secondary_source.first != nil %}{% for source in page.secondary_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}{% else %}"{{page.secondary_source}}"{% endif %}]
+          }'>
+        </div>
         {% endif %}
       </div>
     </div>

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -94,7 +94,9 @@ layout: default
             "product": "{{page.id}}",
             "originalSources": [{% for source in page.original_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}],
             "secondarySources": [{% if page.secondary_source.first != nil %}{% for source in page.secondary_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}{% else %}"{{page.secondary_source}}"{% endif %}]
-          }'>
+          }'
+          data-product-category="{{category}}"
+          data-product-icon="{{icon_name}}">
         </div>
         {% elsif page.original_source %}
         <div class="provenance-diagram" style="width: 100%;" 
@@ -102,7 +104,9 @@ layout: default
             "product": "{{page.id}}",
             "originalSources": [{% for source in page.original_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}],
             "secondarySources": []
-          }'>
+          }'
+          data-product-category="{{category}}"
+          data-product-icon="{{icon_name}}">
         </div>
         {% elsif page.secondary_source %}
         <div class="provenance-diagram" style="width: 100%;" 
@@ -110,7 +114,9 @@ layout: default
             "product": "{{page.id}}",
             "originalSources": [],
             "secondarySources": [{% if page.secondary_source.first != nil %}{% for source in page.secondary_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}{% else %}"{{page.secondary_source}}"{% endif %}]
-          }'>
+          }'
+          data-product-category="{{category}}"
+          data-product-icon="{{icon_name}}">
         </div>
         {% endif %}
       </div>

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -89,7 +89,7 @@ layout: default
       <div class="card-body">
         <h4 class="card-title"><i class="bi bi-arrow-down-right-square-fill"></i> Provenance</h4>
         {% if page.secondary_source and page.original_source %}
-        <div class="provenance-diagram" style="height: 300px; width: 100%;" 
+        <div class="provenance-diagram" style="width: 100%;" 
           data-provenance='{
             "product": "{{page.id}}",
             "originalSources": [{% for source in page.original_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}],
@@ -97,7 +97,7 @@ layout: default
           }'>
         </div>
         {% elsif page.original_source %}
-        <div class="provenance-diagram" style="height: 300px; width: 100%;" 
+        <div class="provenance-diagram" style="width: 100%;" 
           data-provenance='{
             "product": "{{page.id}}",
             "originalSources": [{% for source in page.original_source %}"{{source}}"{% unless forloop.last %},{% endunless %}{% endfor %}],
@@ -105,7 +105,7 @@ layout: default
           }'>
         </div>
         {% elsif page.secondary_source %}
-        <div class="provenance-diagram" style="height: 300px; width: 100%;" 
+        <div class="provenance-diagram" style="width: 100%;" 
           data-provenance='{
             "product": "{{page.id}}",
             "originalSources": [],

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -87,10 +87,23 @@ layout: default
     {% if page.original_source or page.secondary_source %}
     <div class="card bg-light mb-3" style="max-width: 60rem;">
       <div class="card-body">
-        <h4 class="card-title"><i class="bi bi-arrow-down-right-square-fill"></i> Provenance 
-          <small><a href="#" class="export-prov-xml" data-product="{{page.id}}" title="Export as PROV-XML">
-            <i class="bi bi-download"></i> PROV-XML
-          </a></small>
+        <h4 class="card-title">
+          <i class="bi bi-arrow-down-right-square-fill"></i> Provenance 
+          <span class="provenance-help" title="Drag to reposition diagram. Press 'R' to reset position.">
+            <i class="bi bi-question-circle"></i>
+          </span>
+          <div class="dropdown export-dropdown">
+            <button class="btn btn-sm dropdown-toggle export-menu-button" type="button" id="exportDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="bi bi-download"></i> Export
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="exportDropdown">
+              <li><a class="dropdown-item export-prov-xml" href="#" data-product="{{page.id}}" data-format="xml"><i class="bi bi-file-earmark-code"></i> PROV-XML</a></li>
+              <li><a class="dropdown-item export-prov-rdf" href="#" data-product="{{page.id}}" data-format="rdf"><i class="bi bi-filetype-ttl"></i> PROV-RDF (Turtle)</a></li>
+              <li><a class="dropdown-item export-prov-json" href="#" data-product="{{page.id}}" data-format="json"><i class="bi bi-filetype-json"></i> PROV-JSON</a></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><a class="dropdown-item export-prov-svg" href="#" data-product="{{page.id}}" data-format="svg"><i class="bi bi-filetype-svg"></i> SVG Image</a></li>
+            </ul>
+          </div>
         </h4>
         {% if page.secondary_source and page.original_source %}
         <div class="provenance-diagram" style="width: 100%;" 

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -97,8 +97,8 @@ layout: default
               <i class="bi bi-download"></i> Export
             </button>
             <ul class="dropdown-menu" aria-labelledby="exportDropdown">
-              <li><a class="dropdown-item export-prov-xml" href="#" data-product="{{page.id}}" data-format="xml"><i class="bi bi-file-earmark-code"></i> PROV-XML</a></li>
-              <li><a class="dropdown-item export-prov-rdf" href="#" data-product="{{page.id}}" data-format="rdf"><i class="bi bi-filetype-ttl"></i> PROV-RDF (Turtle)</a></li>
+              <li><a class="dropdown-item export-prov-xml" href="#" data-product="{{page.id}}" data-format="xml"><i class="bi bi-filetype-xml"></i> PROV-XML</a></li>
+              <li><a class="dropdown-item export-prov-rdf" href="#" data-product="{{page.id}}" data-format="rdf"><i class="bi bi-filetype-txt"></i> PROV-RDF (Turtle)</a></li>
               <li><a class="dropdown-item export-prov-json" href="#" data-product="{{page.id}}" data-format="json"><i class="bi bi-filetype-json"></i> PROV-JSON</a></li>
               <li><hr class="dropdown-divider"></li>
               <li><a class="dropdown-item export-prov-svg" href="#" data-product="{{page.id}}" data-format="svg"><i class="bi bi-filetype-svg"></i> SVG Image</a></li>

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -89,7 +89,7 @@ layout: default
       <div class="card-body">
         <h4 class="card-title">
           <i class="bi bi-arrow-down-right-square-fill"></i> Provenance 
-          <span class="provenance-help" title="Drag to reposition diagram. Press 'R' to reset position.">
+          <span class="provenance-help" title="Click and drag to reposition. Press 'R' to reset position.">
             <i class="bi bi-question-circle"></i>
           </span>
           <div class="dropdown export-dropdown">

--- a/_layouts/product_detail.html
+++ b/_layouts/product_detail.html
@@ -87,7 +87,11 @@ layout: default
     {% if page.original_source or page.secondary_source %}
     <div class="card bg-light mb-3" style="max-width: 60rem;">
       <div class="card-body">
-        <h4 class="card-title"><i class="bi bi-arrow-down-right-square-fill"></i> Provenance</h4>
+        <h4 class="card-title"><i class="bi bi-arrow-down-right-square-fill"></i> Provenance 
+          <small><a href="#" class="export-prov-xml" data-product="{{page.id}}" title="Export as PROV-XML">
+            <i class="bi bi-download"></i> PROV-XML
+          </a></small>
+        </h4>
         {% if page.secondary_source and page.original_source %}
         <div class="provenance-diagram" style="width: 100%;" 
           data-provenance='{

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -63,11 +63,13 @@
 .node-icon circle {
   stroke: #333;
   stroke-width: 0.5;
+  filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.2));
 }
 
 .node-icon i {
   display: inline-block;
   vertical-align: middle;
+  font-weight: 500;
 }
 
 /* Legend styles */

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -145,7 +145,7 @@
   margin: 0.3rem 0;
 }
 
-/* Format-specific icon colors */
+/* Format-specific icon colors - all consistent with 5px right margin */
 .export-prov-xml .bi {
   color: #007acc;
 }
@@ -162,26 +162,20 @@
   color: #FF8A3C;
 }
 
-/* Legacy export link styles (kept for backward compatibility) */
-.export-prov-xml {
-  font-size: 0.75em;
-  margin-left: 15px;
-  text-decoration: none;
-  color: #666;
-  padding: 2px 6px;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-  transition: all 0.2s ease;
+/* Legacy export styles - applied to all export types for consistency */
+.export-prov-xml,
+.export-prov-rdf,
+.export-prov-json,
+.export-prov-svg {
+  /* No specific styling here - let the dropdown-item class handle this */
 }
 
-.export-prov-xml:hover {
-  background-color: #f0f0f0;
-  color: #333;
-  text-decoration: none;
-}
-
-.export-prov-xml .bi {
-  margin-right: 2px;
+/* Make sure all icons have consistent margin */
+.export-prov-xml .bi,
+.export-prov-rdf .bi,
+.export-prov-json .bi,
+.export-prov-svg .bi {
+  margin-right: 5px;
 }
 
 /* Toast notification styles */

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -1,5 +1,6 @@
 /* Styles for D3.js Provenance Diagram */
 .provenance-diagram {
+  position: relative;
   overflow: visible;
   margin: 0 auto;
   min-height: 300px; /* Minimum height */
@@ -102,7 +103,66 @@
   }
 }
 
-/* Export PROV-XML link styles */
+/* Export menu styles */
+.export-dropdown {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 15px;
+}
+
+.export-menu-button {
+  font-size: 0.75em;
+  color: #666;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  padding: 2px 8px;
+  transition: all 0.2s ease;
+}
+
+.export-menu-button:hover,
+.export-menu-button:focus {
+  background-color: #f0f0f0;
+  color: #333;
+  border-color: #999;
+}
+
+.dropdown-item {
+  font-size: 0.9em;
+  padding: 0.4rem 1rem;
+  transition: all 0.2s ease;
+}
+
+.dropdown-item:hover {
+  background-color: #f5f5f5;
+}
+
+.dropdown-item .bi {
+  margin-right: 5px;
+  color: #555;
+}
+
+.dropdown-divider {
+  margin: 0.3rem 0;
+}
+
+/* Format-specific icon colors */
+.export-prov-xml .bi {
+  color: #007acc;
+}
+
+.export-prov-rdf .bi {
+  color: #5C8DBC;
+}
+
+.export-prov-json .bi {
+  color: #F5BB12;
+}
+
+.export-prov-svg .bi {
+  color: #FF8A3C;
+}
+
+/* Legacy export link styles (kept for backward compatibility) */
 .export-prov-xml {
   font-size: 0.75em;
   margin-left: 15px;
@@ -122,4 +182,100 @@
 
 .export-prov-xml .bi {
   margin-right: 2px;
+}
+
+/* Toast notification styles */
+.toast-container {
+  z-index: 1060;
+}
+
+.toast {
+  min-width: 250px;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.toast-header {
+  background-color: rgba(255, 255, 255, 0.85);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.toast-body {
+  padding: 0.75rem;
+}
+
+/* Drag and drop instruction overlay */
+.drag-instruction-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.8);
+  z-index: 10;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+}
+
+.drag-instruction {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 15px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.drag-instruction i {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.drag-instruction span {
+  font-size: 14px;
+  text-align: center;
+}
+
+/* Reset notification */
+.reset-notification {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 8px 15px;
+  border-radius: 4px;
+  font-size: 14px;
+  animation: fadeInOut 1.5s ease forwards;
+  z-index: 20;
+}
+
+@keyframes fadeInOut {
+  0% { opacity: 0; }
+  20% { opacity: 1; }
+  80% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* Help button */
+.provenance-help {
+  display: inline-block;
+  margin-left: 8px;
+  cursor: help;
+  color: #888;
+  font-size: 0.8em;
+  vertical-align: middle;
+  transition: color 0.2s ease;
+}
+
+.provenance-help:hover {
+  color: #555;
 }

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -18,6 +18,11 @@
 
 .node:hover rect {
   filter: brightness(1.1);
+}
+
+/* Only show pointer cursor on non-product nodes */
+.node.original:hover rect,
+.node.secondary:hover rect {
   cursor: pointer;
 }
 

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -101,3 +101,25 @@
     height: auto;
   }
 }
+
+/* Export PROV-XML link styles */
+.export-prov-xml {
+  font-size: 0.75em;
+  margin-left: 15px;
+  text-decoration: none;
+  color: #666;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  transition: all 0.2s ease;
+}
+
+.export-prov-xml:hover {
+  background-color: #f0f0f0;
+  color: #333;
+  text-decoration: none;
+}
+
+.export-prov-xml .bi {
+  margin-right: 2px;
+}

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -75,7 +75,15 @@
 
 /* Legend styles */
 .legend {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.3s ease, visibility 0.3s;
   font-family: 'Helvetica Neue', Arial, sans-serif;
+}
+
+.legend.hidden {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .legend-item {
@@ -86,6 +94,50 @@
 .legend-item text {
   font-size: 14px;
   fill: #333;
+}
+
+/* Legend toggle button */
+.legend-toggle-button {
+  margin-left: 5px;
+  padding: 2px 6px;
+  background-color: transparent;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  color: #888;
+  transition: all 0.2s ease;
+}
+
+.legend-toggle-button:hover {
+  background-color: #f5f5f5;
+  color: #555;
+  border-color: #ccc;
+}
+
+.legend-toggle-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(85, 136, 187, 0.25);
+}
+
+.legend-toggle-button i {
+  font-size: 0.8em;
+}
+
+.legend-icons {
+  margin-top: 15px; /* Increased margin for better separation */
+  padding-top: 8px; /* Increased padding */
+  border-top: 1px dashed #ddd;
+}
+
+.legend-icon-item {
+  display: inline-block;
+  margin-right: 15px;
+  margin-bottom: 5px;
+  font-size: 14px; /* Match the increased font size */
+}
+
+.legend-icon-symbol {
+  font-family: bootstrap-icons;
+  font-size: 14px; /* Match the increased font size */
 }
 
 /* Data flow direction indicator - horizontal layout */
@@ -272,4 +324,11 @@
 
 .provenance-help:hover {
   color: #555;
+}
+
+/* Make sure both legend sections share the same visibility state */
+.legend.hidden,
+.legend-icons.hidden {
+  opacity: 0;
+  visibility: hidden;
 }

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -55,6 +55,21 @@
   fill: #ddaa44;
 }
 
+/* Node icon styles */
+.node-icon {
+  pointer-events: none;
+}
+
+.node-icon circle {
+  stroke: #333;
+  stroke-width: 0.5;
+}
+
+.node-icon i {
+  display: inline-block;
+  vertical-align: middle;
+}
+
 /* Legend styles */
 .legend {
   font-family: 'Helvetica Neue', Arial, sans-serif;

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -2,6 +2,8 @@
 .provenance-diagram {
   overflow: visible;
   margin: 0 auto;
+  min-height: 300px; /* Minimum height */
+  transition: height 0.3s ease; /* Smooth transition when height changes */
 }
 
 .provenance-svg {
@@ -22,7 +24,7 @@
 .node text {
   font-family: 'Helvetica Neue', Arial, sans-serif;
   font-weight: 500;
-  font-size: 12px;
+  font-size: 14px;
   pointer-events: none;
 }
 
@@ -48,9 +50,24 @@
   fill: #ddaa44;
 }
 
+/* Legend styles */
+.legend {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+}
+
+.legend-item {
+  display: inline-block;
+  margin-right: 15px;
+}
+
+.legend-item text {
+  font-size: 14px;
+  fill: #333;
+}
+
 /* Data flow direction indicator - horizontal layout */
 .direction-indicator {
-  font-size: 10px;
+  font-size: 14px;
   fill: #666;
   font-style: italic;
 }

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -1,0 +1,64 @@
+/* Styles for D3.js Provenance Diagram */
+.provenance-diagram {
+  overflow: visible;
+  margin: 0 auto;
+}
+
+.provenance-svg {
+  display: block;
+  margin: 0 auto;
+  overflow: visible;
+}
+
+.node rect {
+  transition: all 0.3s ease;
+}
+
+.node:hover rect {
+  filter: brightness(1.1);
+  cursor: pointer;
+}
+
+.node text {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  font-weight: 500;
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.arrow path {
+  transition: stroke-width 0.2s ease;
+}
+
+.arrow:hover path {
+  stroke-width: 3px;
+  stroke: #666;
+}
+
+/* Node type styles */
+.node.product rect {
+  fill: #5588bb;
+}
+
+.node.secondary rect {
+  fill: #88bb55;
+}
+
+.node.original rect {
+  fill: #ddaa44;
+}
+
+/* Data flow direction indicator - horizontal layout */
+.direction-indicator {
+  font-size: 10px;
+  fill: #666;
+  font-style: italic;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .provenance-svg {
+    max-width: 100%;
+    height: auto;
+  }
+}

--- a/assets/css/provenance-diagram.css
+++ b/assets/css/provenance-diagram.css
@@ -45,15 +45,15 @@
 
 /* Node type styles */
 .node.product rect {
-  fill: #5588bb;
+  fill: #3366cc; /* Accessible blue for products */
 }
 
 .node.secondary rect {
-  fill: #88bb55;
+  fill: #9933cc; /* Accessible purple for secondary sources */
 }
 
 .node.original rect {
-  fill: #ddaa44;
+  fill: #ff8800; /* Accessible orange for original sources */
 }
 
 /* Node icon styles */


### PR DESCRIPTION
New provenance diagram for Product pages, including:
* Nodes to show original sources, secondary sources, and the current product
* Icons on each node to denote its type (e.g., another KG, data product, data model, etc)
* A menu for the figure legend
* A menu with export options, including three different flavors of PROV and SVG