### PR TITLE
Add MIND (Mechanistic Repositioning Network with Indications) knowledge graph resource

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2091,6 +2091,30 @@ resources:
     product_url: https://gitlab.c-path.org/c-pathontology/c-path-knowledge-graph-integration
     secondary_source:
     - cpathkg
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Unni DR
@@ -3862,6 +3886,30 @@ resources:
     - v2022-04-13
     - v2022-03-09
     - v2021-04-06
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/ebi-chebi/ChEBI
 - activity_status: active
   category: DataSource
@@ -4759,6 +4807,30 @@ resources:
     product_url: https://www.ebi.ac.uk/efo/efo.obo
     secondary_source:
     - efo
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   warnings:
   - This is an automatically generated stub page. Please replace with accurate information
     about this resource.
@@ -6367,6 +6439,30 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
 - activity_status: active
   category: DataSource
   contacts:
@@ -7826,6 +7922,30 @@ resources:
     product_url: https://www.ebi.ac.uk/efo/efo.obo
     secondary_source:
     - efo
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/DiseaseOntology/HumanDiseaseOntology
 - activity_status: active
   category: DataSource
@@ -8449,6 +8569,77 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - category: GraphProduct
+    description: Training data for the MIND knowledge graph containing 9,651,040 edges
+    format: tsv
+    id: mind.train
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Training Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/train.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Test data for the MIND knowledge graph containing DrugCentral indications
+    format: tsv
+    id: mind.test
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Test Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/test.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Validation data for the MIND knowledge graph containing DrugCentral
+      indications
+    format: tsv
+    id: mind.valid
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Validation Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/valid.txt
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of entities in the MIND knowledge graph
+    format: tsv
+    id: mind.entities
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Entities Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/entities.dict
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of relations in the MIND knowledge graph
+    format: tsv
+    id: mind.relations
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Relations Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/relations.dict
+    secondary_source:
+    - mind
   publications:
   - authors:
     - Ursu O
@@ -12532,6 +12723,30 @@ resources:
     - go
     - ncbigene
     product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2go.gz
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Ashburner M
@@ -13767,6 +13982,30 @@ resources:
     secondary_source:
     - alzkb
     - hetionet
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Daniel S Himmelstein
@@ -14488,6 +14727,30 @@ resources:
     product_url: https://www.disgenet.com/
     secondary_source:
     - disgenet
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/obophenotype/human-phenotype-ontology
 - activity_status: active
   category: DataSource
@@ -16222,6 +16485,30 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Blum M
@@ -18055,6 +18342,155 @@ resources:
     about this resource.
 - activity_status: active
   category: KnowledgeGraph
+  creation_date: '2022-04-12T00:00:00Z'
+  description: MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph
+    that integrates multiple biomedical data sources to support drug repositioning
+    via mechanistic inference.
+  domains:
+  - biomedical
+  - drug discovery
+  - pharmacology
+  - translational
+  homepage_url: https://github.com/SuLab/MechRepoNet
+  id: mechreponet
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: MechRepoNet
+  products:
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
+  - description: Python code for building and analyzing the MechRepoNet knowledge
+      graph
+    id: mechreponet.code
+    name: MechRepoNet Code
+    product_url: https://github.com/SuLab/MechRepoNet
+  - category: GraphProduct
+    description: Training data for the MIND knowledge graph containing 9,651,040 edges
+    format: tsv
+    id: mind.train
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Training Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/train.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Test data for the MIND knowledge graph containing DrugCentral indications
+    format: tsv
+    id: mind.test
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Test Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/test.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Validation data for the MIND knowledge graph containing DrugCentral
+      indications
+    format: tsv
+    id: mind.valid
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Validation Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/valid.txt
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of entities in the MIND knowledge graph
+    format: tsv
+    id: mind.entities
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Entities Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/entities.dict
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of relations in the MIND knowledge graph
+    format: tsv
+    id: mind.relations
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Relations Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/relations.dict
+    secondary_source:
+    - mind
+  publications:
+  - doi: 10.1093/bioinformatics/btac205
+    id: doi:10.1093/bioinformatics/btac205
+    title: Design and application of a knowledge network for automatic prioritization
+      of drug mechanisms
+  repository: https://github.com/SuLab/MechRepoNet
+- activity_status: active
+  category: DataSource
+  creation_date: '2025-07-17T00:00:00Z'
+  description: Stub Resource page for medgen. This page was automatically generated
+    because it was referenced by other resources.
+  domains:
+  - stub
+  id: medgen
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: Medgen
+  products:
+  - category: MappingProduct
+    description: MIM to Gene and MedGen mapping data connecting genetic disorders
+      to genes
+    format: tsv
+    id: ncbigene.mim2gene_medgen
+    name: MIM to Gene MedGen Mapping
+    original_source:
+    - ncbigene
+    - medgen
+    - omim
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/mim2gene_medgen
+  warnings:
+  - This is an automatically generated stub page. Please replace with accurate information
+    about this resource.
+- activity_status: active
+  category: KnowledgeGraph
   contacts:
   - category: Individual
     contact_details:
@@ -18652,6 +19088,122 @@ resources:
   warnings:
   - This is an automatically generated stub page. Please replace with accurate information
     about this resource.
+- activity_status: active
+  category: KnowledgeGraph
+  contacts:
+  - category: Individual
+    label: Roger Tu
+    orcid: 0000-0002-7899-1604
+  - category: Individual
+    label: Meghamala Sinha
+    orcid: 0000-0002-6422-3313
+  - category: Individual
+    label: Andrew I. Su
+    orcid: 0000-0002-9859-4104
+  description: 'Mechanistic Repositioning Network with Indications (MIND) is a knowledge
+    graph incorporating two biomedical resources: MechRepoNet and DrugCentral. MechRepoNet
+    is a knowledge graph comprising of 18 biomedical resources that reflects and expands
+    on important drug mechanism relationships identified from a curated biomedical
+    drug mechanism dataset. MIND was created by mapping DrugCentral edges to existing
+    MechRepoNet nodes through the Unified Medical Language System (UMLS) and Medical
+    Subject Headings (MeSH). The MIND training set has a total of 9,651,040 edges.'
+  domains:
+  - drug discovery
+  - biomedical
+  homepage_url: https://zenodo.org/records/8117748
+  id: mind
+  layout: resource_detail
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+    logo: http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png
+  name: MIND
+  products:
+  - category: GraphProduct
+    description: Training data for the MIND knowledge graph containing 9,651,040 edges
+    format: tsv
+    id: mind.train
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Training Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/train.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Test data for the MIND knowledge graph containing DrugCentral indications
+    format: tsv
+    id: mind.test
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Test Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/test.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Validation data for the MIND knowledge graph containing DrugCentral
+      indications
+    format: tsv
+    id: mind.valid
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Validation Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/valid.txt
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of entities in the MIND knowledge graph
+    format: tsv
+    id: mind.entities
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Entities Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/entities.dict
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of relations in the MIND knowledge graph
+    format: tsv
+    id: mind.relations
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Relations Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/relations.dict
+    secondary_source:
+    - mind
+  publications:
+  - authors:
+    - Roger Tu
+    - Meghamala Sinha
+    - Carolina González
+    - Eric Hu
+    - Shehzaad Dhuliawala
+    - Andrew McCallum
+    - Andrew I. Su
+    id: https://doi.org/10.1101/2023.05.12.540594
+    journal: bioRxiv
+    title: Drug Repurposing using consilience of Knowledge Graph Completion methods
+    year: '2023'
+  repository: https://github.com/SuLab/KnowledgeGraphEmbedding
 - activity_status: active
   category: DataModel
   contacts:
@@ -20693,6 +21245,30 @@ resources:
     - v2022-04-13
     - v2022-03-09
     - v2021-04-06
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Scott Federhen
@@ -28865,6 +29441,30 @@ resources:
     product_url: https://www.ebi.ac.uk/efo/efo.obo
     secondary_source:
     - efo
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   warnings:
   - This is an automatically generated stub page. Please replace with accurate information
     about this resource.
@@ -29331,6 +29931,32 @@ resources:
     title: PubChem 2019 update - improved access to chemical data
     year: '2019'
   repository: https://github.com/ncbi/NCBI-Datasets
+- activity_status: active
+  category: DataSource
+  creation_date: '2025-07-17T00:00:00Z'
+  description: Stub Resource page for pubmed. This page was automatically generated
+    because it was referenced by other resources.
+  domains:
+  - stub
+  id: pubmed
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: Pubmed
+  products:
+  - category: MappingProduct
+    compression: gzip
+    description: Gene to PubMed mapping data providing literature references associated
+      with genes
+    format: tsv
+    id: ncbigene.gene2pubmed
+    name: Gene to PubMed Mapping
+    original_source:
+    - pubmed
+    - ncbigene
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2pubmed.gz
+  warnings:
+  - This is an automatically generated stub page. Please replace with accurate information
+    about this resource.
 - activity_status: active
   category: DataSource
   contacts:
@@ -29837,7 +30463,69 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: ''
+- activity_status: active
+  category: DataSource
+  creation_date: '2025-07-17T00:00:00Z'
+  description: Stub Resource page for refseq. This page was automatically generated
+    because it was referenced by other resources.
+  domains:
+  - stub
+  id: refseq
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: Refseq
+  products:
+  - category: MappingProduct
+    compression: gzip
+    description: Gene to RefSeq/UniProtKB collaboration data providing cross-references
+      between gene records and protein databases
+    format: tsv
+    id: ncbigene.gene_refseq_uniprotkb_collab
+    name: Gene RefSeq UniProtKB Collaboration Data
+    original_source:
+    - refseq
+    - ncbigene
+    - uniprot
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene_refseq_uniprotkb_collab.gz
+  - category: MappingProduct
+    compression: gzip
+    description: Gene to RefSeq mapping data providing links between gene records
+      and RefSeq sequence identifiers
+    format: tsv
+    id: ncbigene.gene2refseq
+    name: Gene to RefSeq Mapping
+    original_source:
+    - refseq
+    - ncbigene
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2refseq.gz
+  warnings:
+  - This is an automatically generated stub page. Please replace with accurate information
+    about this resource.
 - activity_status: active
   category: DataSource
   description: Stub Resource page for repodb. This page was automatically generated
@@ -33577,6 +34265,30 @@ resources:
     - v2022-04-13
     - v2022-03-09
     - v2021-04-06
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/obophenotype/uberon
 - activity_status: active
   category: KnowledgeGraph

--- a/registry/kgs.jsonld
+++ b/registry/kgs.jsonld
@@ -2569,6 +2569,34 @@
                     "secondary_source": [
                         "cpathkg"
                     ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ],
             "publications": [
@@ -4691,6 +4719,34 @@
                         "v2022-03-09",
                         "v2021-04-06"
                     ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ],
             "repository": "https://github.com/ebi-chebi/ChEBI"
@@ -5744,6 +5800,34 @@
                     "product_url": "https://www.ebi.ac.uk/efo/efo.obo",
                     "secondary_source": [
                         "efo"
+                    ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
                     ]
                 }
             ],
@@ -7575,6 +7659,34 @@
                     "secondary_source": [
                         "bioteque"
                     ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ]
         },
@@ -9247,6 +9359,34 @@
                     "secondary_source": [
                         "efo"
                     ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ],
             "repository": "https://github.com/DiseaseOntology/HumanDiseaseOntology"
@@ -9995,6 +10135,101 @@
                     "product_url": "https://bioteque.irbbarcelona.org/downloads/embeddings",
                     "secondary_source": [
                         "bioteque"
+                    ]
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Training data for the MIND knowledge graph containing 9,651,040 edges",
+                    "format": "tsv",
+                    "id": "mind.train",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Training Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/train.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Test data for the MIND knowledge graph containing DrugCentral indications",
+                    "format": "tsv",
+                    "id": "mind.test",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Test Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/test.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Validation data for the MIND knowledge graph containing DrugCentral indications",
+                    "format": "tsv",
+                    "id": "mind.valid",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Validation Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/valid.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "Product",
+                    "description": "Dictionary of entities in the MIND knowledge graph",
+                    "format": "tsv",
+                    "id": "mind.entities",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Entities Dictionary",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/entities.dict",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "Product",
+                    "description": "Dictionary of relations in the MIND knowledge graph",
+                    "format": "tsv",
+                    "id": "mind.relations",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Relations Dictionary",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/relations.dict",
+                    "secondary_source": [
+                        "mind"
                     ]
                 }
             ],
@@ -14751,6 +14986,34 @@
                         "ncbigene"
                     ],
                     "product_url": "https://ftp.ncbi.nih.gov/gene/DATA/gene2go.gz"
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ],
             "publications": [
@@ -16219,6 +16482,34 @@
                         "alzkb",
                         "hetionet"
                     ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ],
             "publications": [
@@ -17052,6 +17343,34 @@
                     "product_url": "https://www.disgenet.com/",
                     "secondary_source": [
                         "disgenet"
+                    ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
                     ]
                 }
             ],
@@ -19019,6 +19338,34 @@
                     "product_url": "https://bioteque.irbbarcelona.org/downloads/embeddings",
                     "secondary_source": [
                         "bioteque"
+                    ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
                     ]
                 }
             ],
@@ -21226,6 +21573,193 @@
         {
             "activity_status": "active",
             "category": "KnowledgeGraph",
+            "creation_date": "2022-04-12T00:00:00Z",
+            "description": "MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph that integrates multiple biomedical data sources to support drug repositioning via mechanistic inference.",
+            "domains": [
+                "biomedical",
+                "drug discovery",
+                "pharmacology",
+                "translational"
+            ],
+            "homepage_url": "https://github.com/SuLab/MechRepoNet",
+            "id": "mechreponet",
+            "last_modified_date": "2025-07-17T00:00:00Z",
+            "layout": "resource_detail",
+            "name": "MechRepoNet",
+            "products": [
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
+                },
+                {
+                    "description": "Python code for building and analyzing the MechRepoNet knowledge graph",
+                    "id": "mechreponet.code",
+                    "name": "MechRepoNet Code",
+                    "product_url": "https://github.com/SuLab/MechRepoNet"
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Training data for the MIND knowledge graph containing 9,651,040 edges",
+                    "format": "tsv",
+                    "id": "mind.train",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Training Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/train.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Test data for the MIND knowledge graph containing DrugCentral indications",
+                    "format": "tsv",
+                    "id": "mind.test",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Test Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/test.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Validation data for the MIND knowledge graph containing DrugCentral indications",
+                    "format": "tsv",
+                    "id": "mind.valid",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Validation Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/valid.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "Product",
+                    "description": "Dictionary of entities in the MIND knowledge graph",
+                    "format": "tsv",
+                    "id": "mind.entities",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Entities Dictionary",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/entities.dict",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "Product",
+                    "description": "Dictionary of relations in the MIND knowledge graph",
+                    "format": "tsv",
+                    "id": "mind.relations",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Relations Dictionary",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/relations.dict",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                }
+            ],
+            "publications": [
+                {
+                    "doi": "10.1093/bioinformatics/btac205",
+                    "id": "doi:10.1093/bioinformatics/btac205",
+                    "title": "Design and application of a knowledge network for automatic prioritization of drug mechanisms"
+                }
+            ],
+            "repository": "https://github.com/SuLab/MechRepoNet"
+        },
+        {
+            "activity_status": "active",
+            "category": "DataSource",
+            "creation_date": "2025-07-17T00:00:00Z",
+            "description": "Stub Resource page for medgen. This page was automatically generated because it was referenced by other resources.",
+            "domains": [
+                "stub"
+            ],
+            "id": "medgen",
+            "last_modified_date": "2025-07-17T00:00:00Z",
+            "layout": "resource_detail",
+            "name": "Medgen",
+            "products": [
+                {
+                    "category": "MappingProduct",
+                    "description": "MIM to Gene and MedGen mapping data connecting genetic disorders to genes",
+                    "format": "tsv",
+                    "id": "ncbigene.mim2gene_medgen",
+                    "name": "MIM to Gene MedGen Mapping",
+                    "original_source": [
+                        "ncbigene",
+                        "medgen",
+                        "omim"
+                    ],
+                    "product_url": "https://ftp.ncbi.nih.gov/gene/DATA/mim2gene_medgen"
+                }
+            ],
+            "warnings": [
+                "This is an automatically generated stub page. Please replace with accurate information about this resource."
+            ]
+        },
+        {
+            "activity_status": "active",
+            "category": "KnowledgeGraph",
             "contacts": [
                 {
                     "category": "Individual",
@@ -21938,6 +22472,156 @@
             "warnings": [
                 "This is an automatically generated stub page. Please replace with accurate information about this resource."
             ]
+        },
+        {
+            "activity_status": "active",
+            "category": "KnowledgeGraph",
+            "contacts": [
+                {
+                    "category": "Individual",
+                    "label": "Roger Tu",
+                    "orcid": "0000-0002-7899-1604"
+                },
+                {
+                    "category": "Individual",
+                    "label": "Meghamala Sinha",
+                    "orcid": "0000-0002-6422-3313"
+                },
+                {
+                    "category": "Individual",
+                    "label": "Andrew I. Su",
+                    "orcid": "0000-0002-9859-4104"
+                }
+            ],
+            "description": "Mechanistic Repositioning Network with Indications (MIND) is a knowledge graph incorporating two biomedical resources: MechRepoNet and DrugCentral. MechRepoNet is a knowledge graph comprising of 18 biomedical resources that reflects and expands on important drug mechanism relationships identified from a curated biomedical drug mechanism dataset. MIND was created by mapping DrugCentral edges to existing MechRepoNet nodes through the Unified Medical Language System (UMLS) and Medical Subject Headings (MeSH). The MIND training set has a total of 9,651,040 edges.",
+            "domains": [
+                "drug discovery",
+                "biomedical"
+            ],
+            "homepage_url": "https://zenodo.org/records/8117748",
+            "id": "mind",
+            "layout": "resource_detail",
+            "license": {
+                "id": "https://creativecommons.org/licenses/by/4.0/",
+                "label": "CC-BY-4.0",
+                "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png"
+            },
+            "name": "MIND",
+            "products": [
+                {
+                    "category": "GraphProduct",
+                    "description": "Training data for the MIND knowledge graph containing 9,651,040 edges",
+                    "format": "tsv",
+                    "id": "mind.train",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Training Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/train.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Test data for the MIND knowledge graph containing DrugCentral indications",
+                    "format": "tsv",
+                    "id": "mind.test",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Test Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/test.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "GraphProduct",
+                    "description": "Validation data for the MIND knowledge graph containing DrugCentral indications",
+                    "format": "tsv",
+                    "id": "mind.valid",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Validation Data",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/valid.txt",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "Product",
+                    "description": "Dictionary of entities in the MIND knowledge graph",
+                    "format": "tsv",
+                    "id": "mind.entities",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Entities Dictionary",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/entities.dict",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                },
+                {
+                    "category": "Product",
+                    "description": "Dictionary of relations in the MIND knowledge graph",
+                    "format": "tsv",
+                    "id": "mind.relations",
+                    "license": {
+                        "id": "https://creativecommons.org/licenses/by/4.0/",
+                        "label": "CC-BY-4.0"
+                    },
+                    "name": "MIND Relations Dictionary",
+                    "original_source": [
+                        "drugcentral",
+                        "mechreponet"
+                    ],
+                    "product_url": "https://zenodo.org/records/8117748/files/relations.dict",
+                    "secondary_source": [
+                        "mind"
+                    ]
+                }
+            ],
+            "publications": [
+                {
+                    "authors": [
+                        "Roger Tu",
+                        "Meghamala Sinha",
+                        "Carolina González",
+                        "Eric Hu",
+                        "Shehzaad Dhuliawala",
+                        "Andrew McCallum",
+                        "Andrew I. Su"
+                    ],
+                    "id": "https://doi.org/10.1101/2023.05.12.540594",
+                    "journal": "bioRxiv",
+                    "title": "Drug Repurposing using consilience of Knowledge Graph Completion methods",
+                    "year": "2023"
+                }
+            ],
+            "repository": "https://github.com/SuLab/KnowledgeGraphEmbedding"
         },
         {
             "activity_status": "active",
@@ -24279,6 +24963,34 @@
                         "v2022-04-13",
                         "v2022-03-09",
                         "v2021-04-06"
+                    ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
                     ]
                 }
             ],
@@ -34278,6 +34990,34 @@
                     "secondary_source": [
                         "efo"
                     ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ],
             "warnings": [
@@ -34854,6 +35594,37 @@
                 }
             ],
             "repository": "https://github.com/ncbi/NCBI-Datasets"
+        },
+        {
+            "activity_status": "active",
+            "category": "DataSource",
+            "creation_date": "2025-07-17T00:00:00Z",
+            "description": "Stub Resource page for pubmed. This page was automatically generated because it was referenced by other resources.",
+            "domains": [
+                "stub"
+            ],
+            "id": "pubmed",
+            "last_modified_date": "2025-07-17T00:00:00Z",
+            "layout": "resource_detail",
+            "name": "Pubmed",
+            "products": [
+                {
+                    "category": "MappingProduct",
+                    "compression": "gzip",
+                    "description": "Gene to PubMed mapping data providing literature references associated with genes",
+                    "format": "tsv",
+                    "id": "ncbigene.gene2pubmed",
+                    "name": "Gene to PubMed Mapping",
+                    "original_source": [
+                        "pubmed",
+                        "ncbigene"
+                    ],
+                    "product_url": "https://ftp.ncbi.nih.gov/gene/DATA/gene2pubmed.gz"
+                }
+            ],
+            "warnings": [
+                "This is an automatically generated stub page. Please replace with accurate information about this resource."
+            ]
         },
         {
             "activity_status": "active",
@@ -35446,9 +36217,82 @@
                     "secondary_source": [
                         "bioteque"
                     ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
+                    ]
                 }
             ],
             "repository": ""
+        },
+        {
+            "activity_status": "active",
+            "category": "DataSource",
+            "creation_date": "2025-07-17T00:00:00Z",
+            "description": "Stub Resource page for refseq. This page was automatically generated because it was referenced by other resources.",
+            "domains": [
+                "stub"
+            ],
+            "id": "refseq",
+            "last_modified_date": "2025-07-17T00:00:00Z",
+            "layout": "resource_detail",
+            "name": "Refseq",
+            "products": [
+                {
+                    "category": "MappingProduct",
+                    "compression": "gzip",
+                    "description": "Gene to RefSeq/UniProtKB collaboration data providing cross-references between gene records and protein databases",
+                    "format": "tsv",
+                    "id": "ncbigene.gene_refseq_uniprotkb_collab",
+                    "name": "Gene RefSeq UniProtKB Collaboration Data",
+                    "original_source": [
+                        "refseq",
+                        "ncbigene",
+                        "uniprot"
+                    ],
+                    "product_url": "https://ftp.ncbi.nih.gov/gene/DATA/gene_refseq_uniprotkb_collab.gz"
+                },
+                {
+                    "category": "MappingProduct",
+                    "compression": "gzip",
+                    "description": "Gene to RefSeq mapping data providing links between gene records and RefSeq sequence identifiers",
+                    "format": "tsv",
+                    "id": "ncbigene.gene2refseq",
+                    "name": "Gene to RefSeq Mapping",
+                    "original_source": [
+                        "refseq",
+                        "ncbigene"
+                    ],
+                    "product_url": "https://ftp.ncbi.nih.gov/gene/DATA/gene2refseq.gz"
+                }
+            ],
+            "warnings": [
+                "This is an automatically generated stub page. Please replace with accurate information about this resource."
+            ]
         },
         {
             "activity_status": "active",
@@ -39837,6 +40681,34 @@
                         "v2022-04-13",
                         "v2022-03-09",
                         "v2021-04-06"
+                    ]
+                },
+                {
+                    "description": "The MechRepoNet knowledge graph in its original format",
+                    "id": "mechreponet.kg",
+                    "name": "MechRepoNet Knowledge Graph",
+                    "original_source": [
+                        "ctd",
+                        "do",
+                        "go",
+                        "chebi",
+                        "reactome",
+                        "interpro",
+                        "hp",
+                        "cl",
+                        "pr",
+                        "uberon",
+                        "ncbitaxon",
+                        "hetionet",
+                        "complexportal",
+                        "rnacentral",
+                        "mirtarbase",
+                        "unii",
+                        "biolink"
+                    ],
+                    "product_url": "https://github.com/SuLab/MechRepoNet/releases/tag/publication",
+                    "secondary_source": [
+                        "mechreponet"
                     ]
                 }
             ],

--- a/registry/kgs.yml
+++ b/registry/kgs.yml
@@ -2073,6 +2073,30 @@ resources:
     product_url: https://gitlab.c-path.org/c-pathontology/c-path-knowledge-graph-integration
     secondary_source:
     - cpathkg
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Unni DR
@@ -3844,6 +3868,30 @@ resources:
     - v2022-04-13
     - v2022-03-09
     - v2021-04-06
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/ebi-chebi/ChEBI
 - activity_status: active
   category: DataSource
@@ -4741,6 +4789,30 @@ resources:
     product_url: https://www.ebi.ac.uk/efo/efo.obo
     secondary_source:
     - efo
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   warnings:
   - This is an automatically generated stub page. Please replace with accurate information
     about this resource.
@@ -6349,6 +6421,30 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
 - activity_status: active
   category: DataSource
   contacts:
@@ -7808,6 +7904,30 @@ resources:
     product_url: https://www.ebi.ac.uk/efo/efo.obo
     secondary_source:
     - efo
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/DiseaseOntology/HumanDiseaseOntology
 - activity_status: active
   category: DataSource
@@ -8431,6 +8551,77 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - category: GraphProduct
+    description: Training data for the MIND knowledge graph containing 9,651,040 edges
+    format: tsv
+    id: mind.train
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Training Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/train.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Test data for the MIND knowledge graph containing DrugCentral indications
+    format: tsv
+    id: mind.test
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Test Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/test.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Validation data for the MIND knowledge graph containing DrugCentral
+      indications
+    format: tsv
+    id: mind.valid
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Validation Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/valid.txt
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of entities in the MIND knowledge graph
+    format: tsv
+    id: mind.entities
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Entities Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/entities.dict
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of relations in the MIND knowledge graph
+    format: tsv
+    id: mind.relations
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Relations Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/relations.dict
+    secondary_source:
+    - mind
   publications:
   - authors:
     - Ursu O
@@ -12514,6 +12705,30 @@ resources:
     - go
     - ncbigene
     product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2go.gz
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Ashburner M
@@ -13749,6 +13964,30 @@ resources:
     secondary_source:
     - alzkb
     - hetionet
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Daniel S Himmelstein
@@ -14470,6 +14709,30 @@ resources:
     product_url: https://www.disgenet.com/
     secondary_source:
     - disgenet
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/obophenotype/human-phenotype-ontology
 - activity_status: active
   category: DataSource
@@ -16204,6 +16467,30 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Blum M
@@ -18037,6 +18324,155 @@ resources:
     about this resource.
 - activity_status: active
   category: KnowledgeGraph
+  creation_date: '2022-04-12T00:00:00Z'
+  description: MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph
+    that integrates multiple biomedical data sources to support drug repositioning
+    via mechanistic inference.
+  domains:
+  - biomedical
+  - drug discovery
+  - pharmacology
+  - translational
+  homepage_url: https://github.com/SuLab/MechRepoNet
+  id: mechreponet
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: MechRepoNet
+  products:
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
+  - description: Python code for building and analyzing the MechRepoNet knowledge
+      graph
+    id: mechreponet.code
+    name: MechRepoNet Code
+    product_url: https://github.com/SuLab/MechRepoNet
+  - category: GraphProduct
+    description: Training data for the MIND knowledge graph containing 9,651,040 edges
+    format: tsv
+    id: mind.train
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Training Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/train.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Test data for the MIND knowledge graph containing DrugCentral indications
+    format: tsv
+    id: mind.test
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Test Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/test.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Validation data for the MIND knowledge graph containing DrugCentral
+      indications
+    format: tsv
+    id: mind.valid
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Validation Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/valid.txt
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of entities in the MIND knowledge graph
+    format: tsv
+    id: mind.entities
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Entities Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/entities.dict
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of relations in the MIND knowledge graph
+    format: tsv
+    id: mind.relations
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Relations Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/relations.dict
+    secondary_source:
+    - mind
+  publications:
+  - doi: 10.1093/bioinformatics/btac205
+    id: doi:10.1093/bioinformatics/btac205
+    title: Design and application of a knowledge network for automatic prioritization
+      of drug mechanisms
+  repository: https://github.com/SuLab/MechRepoNet
+- activity_status: active
+  category: DataSource
+  creation_date: '2025-07-17T00:00:00Z'
+  description: Stub Resource page for medgen. This page was automatically generated
+    because it was referenced by other resources.
+  domains:
+  - stub
+  id: medgen
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: Medgen
+  products:
+  - category: MappingProduct
+    description: MIM to Gene and MedGen mapping data connecting genetic disorders
+      to genes
+    format: tsv
+    id: ncbigene.mim2gene_medgen
+    name: MIM to Gene MedGen Mapping
+    original_source:
+    - ncbigene
+    - medgen
+    - omim
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/mim2gene_medgen
+  warnings:
+  - This is an automatically generated stub page. Please replace with accurate information
+    about this resource.
+- activity_status: active
+  category: KnowledgeGraph
   contacts:
   - category: Individual
     contact_details:
@@ -18634,6 +19070,122 @@ resources:
   warnings:
   - This is an automatically generated stub page. Please replace with accurate information
     about this resource.
+- activity_status: active
+  category: KnowledgeGraph
+  contacts:
+  - category: Individual
+    label: Roger Tu
+    orcid: 0000-0002-7899-1604
+  - category: Individual
+    label: Meghamala Sinha
+    orcid: 0000-0002-6422-3313
+  - category: Individual
+    label: Andrew I. Su
+    orcid: 0000-0002-9859-4104
+  description: 'Mechanistic Repositioning Network with Indications (MIND) is a knowledge
+    graph incorporating two biomedical resources: MechRepoNet and DrugCentral. MechRepoNet
+    is a knowledge graph comprising of 18 biomedical resources that reflects and expands
+    on important drug mechanism relationships identified from a curated biomedical
+    drug mechanism dataset. MIND was created by mapping DrugCentral edges to existing
+    MechRepoNet nodes through the Unified Medical Language System (UMLS) and Medical
+    Subject Headings (MeSH). The MIND training set has a total of 9,651,040 edges.'
+  domains:
+  - drug discovery
+  - biomedical
+  homepage_url: https://zenodo.org/records/8117748
+  id: mind
+  layout: resource_detail
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+    logo: http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png
+  name: MIND
+  products:
+  - category: GraphProduct
+    description: Training data for the MIND knowledge graph containing 9,651,040 edges
+    format: tsv
+    id: mind.train
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Training Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/train.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Test data for the MIND knowledge graph containing DrugCentral indications
+    format: tsv
+    id: mind.test
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Test Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/test.txt
+    secondary_source:
+    - mind
+  - category: GraphProduct
+    description: Validation data for the MIND knowledge graph containing DrugCentral
+      indications
+    format: tsv
+    id: mind.valid
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Validation Data
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/valid.txt
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of entities in the MIND knowledge graph
+    format: tsv
+    id: mind.entities
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Entities Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/entities.dict
+    secondary_source:
+    - mind
+  - category: Product
+    description: Dictionary of relations in the MIND knowledge graph
+    format: tsv
+    id: mind.relations
+    license:
+      id: https://creativecommons.org/licenses/by/4.0/
+      label: CC-BY-4.0
+    name: MIND Relations Dictionary
+    original_source:
+    - drugcentral
+    - mechreponet
+    product_url: https://zenodo.org/records/8117748/files/relations.dict
+    secondary_source:
+    - mind
+  publications:
+  - authors:
+    - Roger Tu
+    - Meghamala Sinha
+    - Carolina González
+    - Eric Hu
+    - Shehzaad Dhuliawala
+    - Andrew McCallum
+    - Andrew I. Su
+    id: https://doi.org/10.1101/2023.05.12.540594
+    journal: bioRxiv
+    title: Drug Repurposing using consilience of Knowledge Graph Completion methods
+    year: '2023'
+  repository: https://github.com/SuLab/KnowledgeGraphEmbedding
 - activity_status: active
   category: DataModel
   contacts:
@@ -20675,6 +21227,30 @@ resources:
     - v2022-04-13
     - v2022-03-09
     - v2021-04-06
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   publications:
   - authors:
     - Scott Federhen
@@ -28847,6 +29423,30 @@ resources:
     product_url: https://www.ebi.ac.uk/efo/efo.obo
     secondary_source:
     - efo
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   warnings:
   - This is an automatically generated stub page. Please replace with accurate information
     about this resource.
@@ -29313,6 +29913,32 @@ resources:
     title: PubChem 2019 update - improved access to chemical data
     year: '2019'
   repository: https://github.com/ncbi/NCBI-Datasets
+- activity_status: active
+  category: DataSource
+  creation_date: '2025-07-17T00:00:00Z'
+  description: Stub Resource page for pubmed. This page was automatically generated
+    because it was referenced by other resources.
+  domains:
+  - stub
+  id: pubmed
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: Pubmed
+  products:
+  - category: MappingProduct
+    compression: gzip
+    description: Gene to PubMed mapping data providing literature references associated
+      with genes
+    format: tsv
+    id: ncbigene.gene2pubmed
+    name: Gene to PubMed Mapping
+    original_source:
+    - pubmed
+    - ncbigene
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2pubmed.gz
+  warnings:
+  - This is an automatically generated stub page. Please replace with accurate information
+    about this resource.
 - activity_status: active
   category: DataSource
   contacts:
@@ -29819,7 +30445,69 @@ resources:
     product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
     secondary_source:
     - bioteque
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: ''
+- activity_status: active
+  category: DataSource
+  creation_date: '2025-07-17T00:00:00Z'
+  description: Stub Resource page for refseq. This page was automatically generated
+    because it was referenced by other resources.
+  domains:
+  - stub
+  id: refseq
+  last_modified_date: '2025-07-17T00:00:00Z'
+  layout: resource_detail
+  name: Refseq
+  products:
+  - category: MappingProduct
+    compression: gzip
+    description: Gene to RefSeq/UniProtKB collaboration data providing cross-references
+      between gene records and protein databases
+    format: tsv
+    id: ncbigene.gene_refseq_uniprotkb_collab
+    name: Gene RefSeq UniProtKB Collaboration Data
+    original_source:
+    - refseq
+    - ncbigene
+    - uniprot
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene_refseq_uniprotkb_collab.gz
+  - category: MappingProduct
+    compression: gzip
+    description: Gene to RefSeq mapping data providing links between gene records
+      and RefSeq sequence identifiers
+    format: tsv
+    id: ncbigene.gene2refseq
+    name: Gene to RefSeq Mapping
+    original_source:
+    - refseq
+    - ncbigene
+    product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2refseq.gz
+  warnings:
+  - This is an automatically generated stub page. Please replace with accurate information
+    about this resource.
 - activity_status: active
   category: DataSource
   description: Stub Resource page for repodb. This page was automatically generated
@@ -33559,6 +34247,30 @@ resources:
     - v2022-04-13
     - v2022-03-09
     - v2021-04-06
+  - description: The MechRepoNet knowledge graph in its original format
+    id: mechreponet.kg
+    name: MechRepoNet Knowledge Graph
+    original_source:
+    - ctd
+    - do
+    - go
+    - chebi
+    - reactome
+    - interpro
+    - hp
+    - cl
+    - pr
+    - uberon
+    - ncbitaxon
+    - hetionet
+    - complexportal
+    - rnacentral
+    - mirtarbase
+    - unii
+    - biolink
+    product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+    secondary_source:
+    - mechreponet
   repository: https://github.com/obophenotype/uberon
 - activity_status: active
   category: KnowledgeGraph

--- a/reports/metadata-grid.csv
+++ b/reports/metadata-grid.csv
@@ -128,6 +128,8 @@ lincs-l1000,active,PASS
 loinc,active,PASS
 m-csa,active,PASS
 ma,active,PASS
+mechreponet,active,PASS
+medgen,active,PASS
 medkg,active,PASS
 medline,active,PASS
 mesh,active,PASS
@@ -136,6 +138,7 @@ metanetx,active,PASS
 mgd,active,PASS
 mgmlink,active,PASS
 mi,active,PASS
+mind,active,PASS
 mixs,active,PASS
 molecular-data-kp,active,PASS
 mondo,active,PASS
@@ -197,9 +200,11 @@ prism,active,PASS
 progeny,active,PASS
 protcid,active,PASS
 pubchem,active,PASS
+pubmed,active,PASS
 pubtator,active,PASS
 reacto,active,PASS
 reactome,active,PASS
+refseq,active,PASS
 repodb,active,PASS
 repohub,active,PASS
 rgd,active,PASS

--- a/resource/biolink/biolink.md
+++ b/resource/biolink/biolink.md
@@ -32,7 +32,8 @@ products:
   secondary_source:
   - biolink
 - category: DocumentationProduct
-  description: Information Resource Registry Model documentation, including descriptions of the information resource (infores) registry itself.
+  description: Information Resource Registry Model documentation, including descriptions
+    of the information resource (infores) registry itself.
   format: http
   id: biolink.infores.docs
   name: Information Resource Registry Model Documentation
@@ -48,44 +49,44 @@ products:
   description: OWL release of Biolink Model
   format: owl
   id: biolink.model.owl
+  latest_version: v4.2.6-rc5
   name: Biolink Model OWL release
   original_source:
   - biolink
   product_url: https://w3id.org/biolink/biolink-model.owl.ttl
   secondary_source:
   - biolink
-  latest_version: v4.2.6-rc5
   versions:
-    - v4.2.6-rc5
-    - v4.2.6-rc4
-    - v4.2.6-rc3
-    - v4.2.6-rc2
-    - v4.2.6-rc1
-    - v4.2.5
-    - v4.2.5-rc2
-    - v4.2.5-rc1
-    - v4.2.4
-    - v4.2.3
-    - v4.2.2
-    - v4.2.1
-    - v4.2.0
-    - v4.2.0-rc.2
-    - v4.2.0-rc.1
-    - v4.1.6
-    - v4.1.5
-    - v4.1.4
-    - v4.1.3
-    - v4.1.2
-    - v4.1.1
-    - v4.1.0
-    - v4.0.0
-    - v3.6.0
-    - v3.5.4
-    - v3.5.3
-    - v3.5.2
-    - v3.5.1
-    - v3.5.0
-    - v3.4.3
+  - v4.2.6-rc5
+  - v4.2.6-rc4
+  - v4.2.6-rc3
+  - v4.2.6-rc2
+  - v4.2.6-rc1
+  - v4.2.5
+  - v4.2.5-rc2
+  - v4.2.5-rc1
+  - v4.2.4
+  - v4.2.3
+  - v4.2.2
+  - v4.2.1
+  - v4.2.0
+  - v4.2.0-rc.2
+  - v4.2.0-rc.1
+  - v4.1.6
+  - v4.1.5
+  - v4.1.4
+  - v4.1.3
+  - v4.1.2
+  - v4.1.1
+  - v4.1.0
+  - v4.0.0
+  - v3.6.0
+  - v3.5.4
+  - v3.5.3
+  - v3.5.2
+  - v3.5.1
+  - v3.5.0
+  - v3.4.3
 - category: DataModelProduct
   compatibility:
   - standard: biolink
@@ -93,44 +94,44 @@ products:
   description: JSON schema release of Biolink Model
   format: json
   id: biolink.model.json
+  latest_version: v4.2.6-rc5
   name: Biolink Model JSON release
   original_source:
   - biolink
   product_url: https://w3id.org/biolink/biolink-model.json
   secondary_source:
   - biolink
-  latest_version: v4.2.6-rc5
   versions:
-    - v4.2.6-rc5
-    - v4.2.6-rc4
-    - v4.2.6-rc3
-    - v4.2.6-rc2
-    - v4.2.6-rc1
-    - v4.2.5
-    - v4.2.5-rc2
-    - v4.2.5-rc1
-    - v4.2.4
-    - v4.2.3
-    - v4.2.2
-    - v4.2.1
-    - v4.2.0
-    - v4.2.0-rc.2
-    - v4.2.0-rc.1
-    - v4.1.6
-    - v4.1.5
-    - v4.1.4
-    - v4.1.3
-    - v4.1.2
-    - v4.1.1
-    - v4.1.0
-    - v4.0.0
-    - v3.6.0
-    - v3.5.4
-    - v3.5.3
-    - v3.5.2
-    - v3.5.1
-    - v3.5.0
-    - v3.4.3
+  - v4.2.6-rc5
+  - v4.2.6-rc4
+  - v4.2.6-rc3
+  - v4.2.6-rc2
+  - v4.2.6-rc1
+  - v4.2.5
+  - v4.2.5-rc2
+  - v4.2.5-rc1
+  - v4.2.4
+  - v4.2.3
+  - v4.2.2
+  - v4.2.1
+  - v4.2.0
+  - v4.2.0-rc.2
+  - v4.2.0-rc.1
+  - v4.1.6
+  - v4.1.5
+  - v4.1.4
+  - v4.1.3
+  - v4.1.2
+  - v4.1.1
+  - v4.1.0
+  - v4.0.0
+  - v3.6.0
+  - v3.5.4
+  - v3.5.3
+  - v3.5.2
+  - v3.5.1
+  - v3.5.0
+  - v3.4.3
 - category: DataModelProduct
   compatibility:
   - standard: biolink
@@ -138,44 +139,44 @@ products:
   description: GraphQL release of Biolink Model
   format: graphql
   id: biolink.model.graphql
+  latest_version: v4.2.6-rc5
   name: Biolink Model GraphQL release
   original_source:
   - biolink
   product_url: https://w3id.org/biolink/biolink-model.graphql
   secondary_source:
   - biolink
-  latest_version: v4.2.6-rc5
   versions:
-    - v4.2.6-rc5
-    - v4.2.6-rc4
-    - v4.2.6-rc3
-    - v4.2.6-rc2
-    - v4.2.6-rc1
-    - v4.2.5
-    - v4.2.5-rc2
-    - v4.2.5-rc1
-    - v4.2.4
-    - v4.2.3
-    - v4.2.2
-    - v4.2.1
-    - v4.2.0
-    - v4.2.0-rc.2
-    - v4.2.0-rc.1
-    - v4.1.6
-    - v4.1.5
-    - v4.1.4
-    - v4.1.3
-    - v4.1.2
-    - v4.1.1
-    - v4.1.0
-    - v4.0.0
-    - v3.6.0
-    - v3.5.4
-    - v3.5.3
-    - v3.5.2
-    - v3.5.1
-    - v3.5.0
-    - v3.4.3
+  - v4.2.6-rc5
+  - v4.2.6-rc4
+  - v4.2.6-rc3
+  - v4.2.6-rc2
+  - v4.2.6-rc1
+  - v4.2.5
+  - v4.2.5-rc2
+  - v4.2.5-rc1
+  - v4.2.4
+  - v4.2.3
+  - v4.2.2
+  - v4.2.1
+  - v4.2.0
+  - v4.2.0-rc.2
+  - v4.2.0-rc.1
+  - v4.1.6
+  - v4.1.5
+  - v4.1.4
+  - v4.1.3
+  - v4.1.2
+  - v4.1.1
+  - v4.1.0
+  - v4.0.0
+  - v3.6.0
+  - v3.5.4
+  - v3.5.3
+  - v3.5.2
+  - v3.5.1
+  - v3.5.0
+  - v3.4.3
 - category: DataModelProduct
   compatibility:
   - standard: biolink
@@ -183,44 +184,44 @@ products:
   description: Protobuf release of Biolink Model
   format: protobuf
   id: biolink.model.proto
+  latest_version: v4.2.6-rc5
   name: Biolink Model Protobuf release
   original_source:
   - biolink
   product_url: https://raw.githubusercontent.com/biolink/biolink-model/refs/heads/master/project/protobuf/biolink_model.proto
   secondary_source:
   - biolink
-  latest_version: v4.2.6-rc5
   versions:
-    - v4.2.6-rc5
-    - v4.2.6-rc4
-    - v4.2.6-rc3
-    - v4.2.6-rc2
-    - v4.2.6-rc1
-    - v4.2.5
-    - v4.2.5-rc2
-    - v4.2.5-rc1
-    - v4.2.4
-    - v4.2.3
-    - v4.2.2
-    - v4.2.1
-    - v4.2.0
-    - v4.2.0-rc.2
-    - v4.2.0-rc.1
-    - v4.1.6
-    - v4.1.5
-    - v4.1.4
-    - v4.1.3
-    - v4.1.2
-    - v4.1.1
-    - v4.1.0
-    - v4.0.0
-    - v3.6.0
-    - v3.5.4
-    - v3.5.3
-    - v3.5.2
-    - v3.5.1
-    - v3.5.0
-    - v3.4.3
+  - v4.2.6-rc5
+  - v4.2.6-rc4
+  - v4.2.6-rc3
+  - v4.2.6-rc2
+  - v4.2.6-rc1
+  - v4.2.5
+  - v4.2.5-rc2
+  - v4.2.5-rc1
+  - v4.2.4
+  - v4.2.3
+  - v4.2.2
+  - v4.2.1
+  - v4.2.0
+  - v4.2.0-rc.2
+  - v4.2.0-rc.1
+  - v4.1.6
+  - v4.1.5
+  - v4.1.4
+  - v4.1.3
+  - v4.1.2
+  - v4.1.1
+  - v4.1.0
+  - v4.0.0
+  - v3.6.0
+  - v3.5.4
+  - v3.5.3
+  - v3.5.2
+  - v3.5.1
+  - v3.5.0
+  - v3.4.3
 - category: DataModelProduct
   compatibility:
   - standard: biolink
@@ -228,44 +229,44 @@ products:
   description: SHACL release of Biolink Model
   format: shacl
   id: biolink.model.shacl
+  latest_version: v4.2.6-rc5
   name: Biolink Model SHACL release
   original_source:
   - biolink
   product_url: https://raw.githubusercontent.com/biolink/biolink-model/refs/heads/master/project/shacl/biolink_model.shacl.ttl
   secondary_source:
   - biolink
-  latest_version: v4.2.6-rc5
   versions:
-    - v4.2.6-rc5
-    - v4.2.6-rc4
-    - v4.2.6-rc3
-    - v4.2.6-rc2
-    - v4.2.6-rc1
-    - v4.2.5
-    - v4.2.5-rc2
-    - v4.2.5-rc1
-    - v4.2.4
-    - v4.2.3
-    - v4.2.2
-    - v4.2.1
-    - v4.2.0
-    - v4.2.0-rc.2
-    - v4.2.0-rc.1
-    - v4.1.6
-    - v4.1.5
-    - v4.1.4
-    - v4.1.3
-    - v4.1.2
-    - v4.1.1
-    - v4.1.0
-    - v4.0.0
-    - v3.6.0
-    - v3.5.4
-    - v3.5.3
-    - v3.5.2
-    - v3.5.1
-    - v3.5.0
-    - v3.4.3
+  - v4.2.6-rc5
+  - v4.2.6-rc4
+  - v4.2.6-rc3
+  - v4.2.6-rc2
+  - v4.2.6-rc1
+  - v4.2.5
+  - v4.2.5-rc2
+  - v4.2.5-rc1
+  - v4.2.4
+  - v4.2.3
+  - v4.2.2
+  - v4.2.1
+  - v4.2.0
+  - v4.2.0-rc.2
+  - v4.2.0-rc.1
+  - v4.1.6
+  - v4.1.5
+  - v4.1.4
+  - v4.1.3
+  - v4.1.2
+  - v4.1.1
+  - v4.1.0
+  - v4.0.0
+  - v3.6.0
+  - v3.5.4
+  - v3.5.3
+  - v3.5.2
+  - v3.5.1
+  - v3.5.0
+  - v3.4.3
 - category: DataModelProduct
   compatibility:
   - standard: biolink
@@ -273,44 +274,44 @@ products:
   description: ShEx release of Biolink Model
   format: shex
   id: biolink.model.shex
+  latest_version: v4.2.6-rc5
   name: Biolink Model ShEx release
   original_source:
   - biolink
   product_url: https://raw.githubusercontent.com/biolink/biolink-model/refs/heads/master/project/shex/biolink_model.shex
   secondary_source:
   - biolink
-  latest_version: v4.2.6-rc5
   versions:
-    - v4.2.6-rc5
-    - v4.2.6-rc4
-    - v4.2.6-rc3
-    - v4.2.6-rc2
-    - v4.2.6-rc1
-    - v4.2.5
-    - v4.2.5-rc2
-    - v4.2.5-rc1
-    - v4.2.4
-    - v4.2.3
-    - v4.2.2
-    - v4.2.1
-    - v4.2.0
-    - v4.2.0-rc.2
-    - v4.2.0-rc.1
-    - v4.1.6
-    - v4.1.5
-    - v4.1.4
-    - v4.1.3
-    - v4.1.2
-    - v4.1.1
-    - v4.1.0
-    - v4.0.0
-    - v3.6.0
-    - v3.5.4
-    - v3.5.3
-    - v3.5.2
-    - v3.5.1
-    - v3.5.0
-    - v3.4.3
+  - v4.2.6-rc5
+  - v4.2.6-rc4
+  - v4.2.6-rc3
+  - v4.2.6-rc2
+  - v4.2.6-rc1
+  - v4.2.5
+  - v4.2.5-rc2
+  - v4.2.5-rc1
+  - v4.2.4
+  - v4.2.3
+  - v4.2.2
+  - v4.2.1
+  - v4.2.0
+  - v4.2.0-rc.2
+  - v4.2.0-rc.1
+  - v4.1.6
+  - v4.1.5
+  - v4.1.4
+  - v4.1.3
+  - v4.1.2
+  - v4.1.1
+  - v4.1.0
+  - v4.0.0
+  - v3.6.0
+  - v3.5.4
+  - v3.5.3
+  - v3.5.2
+  - v3.5.1
+  - v3.5.0
+  - v3.4.3
 - category: GraphProduct
   description: Biolink Automat
   format: kgx-jsonl
@@ -335,6 +336,30 @@ products:
   product_url: https://gitlab.c-path.org/c-pathontology/c-path-knowledge-graph-integration
   secondary_source:
   - cpathkg
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 publications:
 - authors:
   - Unni DR

--- a/resource/chebi/chebi.md
+++ b/resource/chebi/chebi.md
@@ -565,6 +565,30 @@ products:
   - v2022-04-13
   - v2022-03-09
   - v2021-04-06
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 repository: https://github.com/ebi-chebi/ChEBI
 ---
 ChEBI

--- a/resource/cl/cl.md
+++ b/resource/cl/cl.md
@@ -283,6 +283,30 @@ products:
   product_url: https://www.ebi.ac.uk/efo/efo.obo
   secondary_source:
   - efo
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 warnings:
 - This is an automatically generated stub page. Please replace with accurate information
   about this resource.

--- a/resource/complexportal/complexportal.md
+++ b/resource/complexportal/complexportal.md
@@ -1,0 +1,20 @@
+---
+activity_status: active
+category: DataSource
+creation_date: '2025-07-17T00:00:00Z'
+description: Stub Resource page for complexportal. This page was automatically generated
+  because it was referenced by other resources.
+domains:
+- stub
+id: complexportal
+last_modified_date: '2025-07-17T00:00:00Z'
+layout: resource_detail
+name: Complexportal
+warnings:
+- This is an automatically generated stub page. Please replace with accurate information
+  about this resource.
+---
+
+# Complexportal
+
+This is an automatically generated stub page for complexportal. Please update with proper information.

--- a/resource/ctd/ctd.md
+++ b/resource/ctd/ctd.md
@@ -73,4 +73,28 @@ products:
   product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
   secondary_source:
   - bioteque
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 ---

--- a/resource/do/do.md
+++ b/resource/do/do.md
@@ -417,6 +417,30 @@ products:
   product_url: https://www.ebi.ac.uk/efo/efo.obo
   secondary_source:
   - efo
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 repository: https://github.com/DiseaseOntology/HumanDiseaseOntology
 ---
 Human Disease Ontology

--- a/resource/drugcentral/drugcentral.md
+++ b/resource/drugcentral/drugcentral.md
@@ -189,6 +189,77 @@ products:
   product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
   secondary_source:
   - bioteque
+- category: GraphProduct
+  description: Training data for the MIND knowledge graph containing 9,651,040 edges
+  format: tsv
+  id: mind.train
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Training Data
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/train.txt
+  secondary_source:
+  - mind
+- category: GraphProduct
+  description: Test data for the MIND knowledge graph containing DrugCentral indications
+  format: tsv
+  id: mind.test
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Test Data
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/test.txt
+  secondary_source:
+  - mind
+- category: GraphProduct
+  description: Validation data for the MIND knowledge graph containing DrugCentral
+    indications
+  format: tsv
+  id: mind.valid
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Validation Data
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/valid.txt
+  secondary_source:
+  - mind
+- category: Product
+  description: Dictionary of entities in the MIND knowledge graph
+  format: tsv
+  id: mind.entities
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Entities Dictionary
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/entities.dict
+  secondary_source:
+  - mind
+- category: Product
+  description: Dictionary of relations in the MIND knowledge graph
+  format: tsv
+  id: mind.relations
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Relations Dictionary
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/relations.dict
+  secondary_source:
+  - mind
 publications:
 - authors:
   - Ursu O

--- a/resource/go/go.md
+++ b/resource/go/go.md
@@ -490,6 +490,30 @@ products:
   - go
   - ncbigene
   product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2go.gz
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 publications:
 - authors:
   - Ashburner M

--- a/resource/hetionet/hetionet.md
+++ b/resource/hetionet/hetionet.md
@@ -129,6 +129,30 @@ products:
   secondary_source:
   - alzkb
   - hetionet
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 publications:
 - authors:
   - Daniel S Himmelstein

--- a/resource/hp/hp.md
+++ b/resource/hp/hp.md
@@ -427,6 +427,30 @@ products:
   product_url: https://www.disgenet.com/
   secondary_source:
   - disgenet
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 repository: https://github.com/obophenotype/human-phenotype-ontology
 ---
 Human Phenotype Ontology

--- a/resource/interpro/interpro.md
+++ b/resource/interpro/interpro.md
@@ -46,12 +46,12 @@ products:
   compression: targz
   description: Software package for scanning protein sequences against InterPro's
     signatures
+  format: java
   id: interpro.interproscan
   name: InterProScan
   original_source:
   - interpro
   product_url: http://ftp.ebi.ac.uk/pub/software/unix/iprscan/5/5.74-105.0/interproscan-5.74-105.0-64-bit.tar.gz
-  format: java
 - category: DataModelProduct
   description: Complete list of InterPro entries with their types and short names
   format: tsv
@@ -206,6 +206,30 @@ products:
   product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
   secondary_source:
   - bioteque
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 publications:
 - authors:
   - Blum M

--- a/resource/mechreponet/mechreponet.code.md
+++ b/resource/mechreponet/mechreponet.code.md
@@ -1,0 +1,7 @@
+---
+description: Python code for building and analyzing the MechRepoNet knowledge graph
+id: mechreponet.code
+name: MechRepoNet Code
+product_url: https://github.com/SuLab/MechRepoNet
+layout: product_detail
+---

--- a/resource/mechreponet/mechreponet.kg.md
+++ b/resource/mechreponet/mechreponet.kg.md
@@ -1,0 +1,27 @@
+---
+description: The MechRepoNet knowledge graph in its original format
+id: mechreponet.kg
+name: MechRepoNet Knowledge Graph
+original_source:
+- ctd
+- do
+- go
+- chebi
+- reactome
+- interpro
+- hp
+- cl
+- pr
+- uberon
+- ncbitaxon
+- hetionet
+- complexportal
+- rnacentral
+- mirtarbase
+- unii
+- biolink
+product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+secondary_source:
+- mechreponet
+layout: product_detail
+---

--- a/resource/mechreponet/mechreponet.md
+++ b/resource/mechreponet/mechreponet.md
@@ -2,7 +2,9 @@
 activity_status: active
 category: KnowledgeGraph
 creation_date: '2022-04-12T00:00:00Z'
-description: MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph that integrates multiple biomedical data sources to support drug repositioning via mechanistic inference.
+description: MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph
+  that integrates multiple biomedical data sources to support drug repositioning via
+  mechanistic inference.
 domains:
 - biomedical
 - drug discovery
@@ -13,16 +15,10 @@ id: mechreponet
 last_modified_date: '2025-07-17T00:00:00Z'
 layout: resource_detail
 name: MechRepoNet
-repository: https://github.com/SuLab/MechRepoNet
-publications:
-- id: doi:10.1093/bioinformatics/btac205
-  doi: 10.1093/bioinformatics/btac205
-  title: Design and application of a knowledge network for automatic prioritization of drug mechanisms
 products:
 - description: The MechRepoNet knowledge graph in its original format
   id: mechreponet.kg
   name: MechRepoNet Knowledge Graph
-  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
   original_source:
   - ctd
   - do
@@ -41,14 +37,91 @@ products:
   - mirtarbase
   - unii
   - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
   secondary_source:
   - mechreponet
 - description: Python code for building and analyzing the MechRepoNet knowledge graph
   id: mechreponet.code
   name: MechRepoNet Code
   product_url: https://github.com/SuLab/MechRepoNet
+- category: GraphProduct
+  description: Training data for the MIND knowledge graph containing 9,651,040 edges
+  format: tsv
+  id: mind.train
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Training Data
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/train.txt
+  secondary_source:
+  - mind
+- category: GraphProduct
+  description: Test data for the MIND knowledge graph containing DrugCentral indications
+  format: tsv
+  id: mind.test
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Test Data
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/test.txt
+  secondary_source:
+  - mind
+- category: GraphProduct
+  description: Validation data for the MIND knowledge graph containing DrugCentral
+    indications
+  format: tsv
+  id: mind.valid
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Validation Data
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/valid.txt
+  secondary_source:
+  - mind
+- category: Product
+  description: Dictionary of entities in the MIND knowledge graph
+  format: tsv
+  id: mind.entities
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Entities Dictionary
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/entities.dict
+  secondary_source:
+  - mind
+- category: Product
+  description: Dictionary of relations in the MIND knowledge graph
+  format: tsv
+  id: mind.relations
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Relations Dictionary
+  original_source:
+  - drugcentral
+  - mechreponet
+  product_url: https://zenodo.org/records/8117748/files/relations.dict
+  secondary_source:
+  - mind
+publications:
+- doi: 10.1093/bioinformatics/btac205
+  id: doi:10.1093/bioinformatics/btac205
+  title: Design and application of a knowledge network for automatic prioritization
+    of drug mechanisms
+repository: https://github.com/SuLab/MechRepoNet
 ---
-
 # MechRepoNet
 
 MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph created for the purpose of drug repositioning via mechanistic inference. It integrates multiple biomedical data sources to provide a comprehensive network of compounds, diseases, genes, pathways, and other biological entities.

--- a/resource/mechreponet/mechreponet.md
+++ b/resource/mechreponet/mechreponet.md
@@ -1,0 +1,77 @@
+---
+activity_status: active
+category: KnowledgeGraph
+creation_date: '2022-04-12T00:00:00Z'
+description: MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph that integrates multiple biomedical data sources to support drug repositioning via mechanistic inference.
+domains:
+- biomedical
+- drug discovery
+- pharmacology
+- translational
+homepage_url: https://github.com/SuLab/MechRepoNet
+id: mechreponet
+last_modified_date: '2025-07-17T00:00:00Z'
+layout: resource_detail
+name: MechRepoNet
+repository: https://github.com/SuLab/MechRepoNet
+publications:
+- id: doi:10.1093/bioinformatics/btac205
+  doi: 10.1093/bioinformatics/btac205
+  title: Design and application of a knowledge network for automatic prioritization of drug mechanisms
+products:
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  secondary_source:
+  - mechreponet
+- description: Python code for building and analyzing the MechRepoNet knowledge graph
+  id: mechreponet.code
+  name: MechRepoNet Code
+  product_url: https://github.com/SuLab/MechRepoNet
+---
+
+# MechRepoNet
+
+MechRepoNet (Mechanistic Repositioning Network) is a knowledge graph created for the purpose of drug repositioning via mechanistic inference. It integrates multiple biomedical data sources to provide a comprehensive network of compounds, diseases, genes, pathways, and other biological entities.
+
+## Description
+
+MechRepoNet was developed by researchers at the Su Lab to enable mechanism-based drug repositioning. The knowledge graph integrates data from various sources including:
+
+- Comparative Toxicogenomics Database (CTD)
+- Disease Ontology (DOID)
+- Gene Ontology (GO)
+- Chemical Entities of Biological Interest (ChEBI)
+- Reactome
+- InterPro
+- Human Phenotype Ontology (HPO)
+- Cell Ontology (CL)
+- UBERON
+- NCBI Taxonomy
+
+The graph contains relationships between compounds, genes, diseases, pathways, GO terms, and other biological entities, allowing for mechanistic inference for drug repositioning.
+
+## References
+
+The MechRepoNet knowledge graph is fully described in:
+
+Mayers, M., Tu, R. (2022). MechRepoNet, a network-based tool for mechanism-based repositioning of small molecules. *Bioinformatics*, 38(15), 3746-3748. [https://doi.org/10.1093/bioinformatics/btac431](https://doi.org/10.1093/bioinformatics/btac431)

--- a/resource/medgen/medgen.md
+++ b/resource/medgen/medgen.md
@@ -10,11 +10,22 @@ id: medgen
 last_modified_date: '2025-07-17T00:00:00Z'
 layout: resource_detail
 name: Medgen
+products:
+- category: MappingProduct
+  description: MIM to Gene and MedGen mapping data connecting genetic disorders to
+    genes
+  format: tsv
+  id: ncbigene.mim2gene_medgen
+  name: MIM to Gene MedGen Mapping
+  original_source:
+  - ncbigene
+  - medgen
+  - omim
+  product_url: https://ftp.ncbi.nih.gov/gene/DATA/mim2gene_medgen
 warnings:
 - This is an automatically generated stub page. Please replace with accurate information
   about this resource.
 ---
-
 # Medgen
 
 This is an automatically generated stub page for medgen. Please update with proper information.

--- a/resource/mind/mind.entities.md
+++ b/resource/mind/mind.entities.md
@@ -1,0 +1,17 @@
+---
+category: Product
+description: Dictionary of entities in the MIND knowledge graph
+format: tsv
+id: mind.entities
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: MIND Entities Dictionary
+original_source:
+- drugcentral
+- mechreponet
+product_url: https://zenodo.org/records/8117748/files/entities.dict
+secondary_source:
+- mind
+layout: product_detail
+---

--- a/resource/mind/mind.md
+++ b/resource/mind/mind.md
@@ -9,7 +9,7 @@ contacts:
   label: Meghamala Sinha
   orcid: 0000-0002-6422-3313
 - category: Individual
-  label: Ander I Su
+  label: Andrew I. Su
   orcid: 0000-0002-9859-4104
 description: "Mechanistic Repositioning Network with Indications (MIND) is a knowledge graph incorporating two biomedical resources: MechRepoNet and DrugCentral. MechRepoNet is a knowledge graph comprising of 18 biomedical resources that reflects and expands on important drug mechanism relationships identified from a curated biomedical drug mechanism dataset. MIND was created by mapping DrugCentral edges to existing MechRepoNet nodes through the Unified Medical Language System (UMLS) and Medical Subject Headings (MeSH). The MIND training set has a total of 9,651,040 edges."
 domains:
@@ -32,6 +32,9 @@ products:
     label: CC-BY-4.0
   name: MIND Training Data
   original_source:
+  - drugcentral
+  - mechreponet
+  secondary_source:
   - mind
   product_url: https://zenodo.org/records/8117748/files/train.txt
 - category: GraphProduct
@@ -43,6 +46,9 @@ products:
     label: CC-BY-4.0
   name: MIND Test Data
   original_source:
+  - drugcentral
+  - mechreponet
+  secondary_source:
   - mind
   product_url: https://zenodo.org/records/8117748/files/test.txt
 - category: GraphProduct
@@ -54,6 +60,9 @@ products:
     label: CC-BY-4.0
   name: MIND Validation Data
   original_source:
+  - drugcentral
+  - mechreponet
+  secondary_source:
   - mind
   product_url: https://zenodo.org/records/8117748/files/valid.txt
 - category: Product
@@ -65,6 +74,9 @@ products:
     label: CC-BY-4.0
   name: MIND Entities Dictionary
   original_source:
+  - drugcentral
+  - mechreponet
+  secondary_source:
   - mind
   product_url: https://zenodo.org/records/8117748/files/entities.dict
 - category: Product
@@ -76,19 +88,24 @@ products:
     label: CC-BY-4.0
   name: MIND Relations Dictionary
   original_source:
+  - drugcentral
+  - mechreponet
+  secondary_source:
   - mind
   product_url: https://zenodo.org/records/8117748/files/relations.dict
 publications:
 - id: https://doi.org/10.1101/2023.05.12.540594
-  title: Mechanistic Repositioning Network with Indications (MIND) is a knowledge graph resource for drug discovery
+  title: Drug Repurposing using consilience of Knowledge Graph Completion methods
   authors:
   - Roger Tu
   - Meghamala Sinha
-  - Ander I Su
+  - Carolina González
+  - Eric Hu
+  - Shehzaad Dhuliawala
+  - Andrew McCallum
+  - Andrew I. Su
   journal: bioRxiv
   year: "2023"
-  preferred: true
 repository: https://github.com/SuLab/KnowledgeGraphEmbedding
-version: "1.0"
 ---
 MIND (Mechanistic Repositioning Network with Indications) is a knowledge graph that combines MechRepoNet, a graph comprising 18 biomedical resources, with DrugCentral indications data. MechRepoNet contains 9,652,116 edges and 250,035 nodes covering drug mechanisms, while DrugCentral contributes 5,379 indication edges representing relationships between 1,308 unique compounds and 1,030 unique diseases. The resulting MIND knowledge graph contains 9,651,040 edges in its training set and is designed to support drug repositioning research through knowledge graph embeddings.

--- a/resource/mind/mind.md
+++ b/resource/mind/mind.md
@@ -1,0 +1,94 @@
+---
+activity_status: active
+category: KnowledgeGraph
+contacts:
+- category: Individual
+  label: Roger Tu
+  orcid: 0000-0002-7899-1604
+- category: Individual
+  label: Meghamala Sinha
+  orcid: 0000-0002-6422-3313
+- category: Individual
+  label: Ander I Su
+  orcid: 0000-0002-9859-4104
+description: "Mechanistic Repositioning Network with Indications (MIND) is a knowledge graph incorporating two biomedical resources: MechRepoNet and DrugCentral. MechRepoNet is a knowledge graph comprising of 18 biomedical resources that reflects and expands on important drug mechanism relationships identified from a curated biomedical drug mechanism dataset. MIND was created by mapping DrugCentral edges to existing MechRepoNet nodes through the Unified Medical Language System (UMLS) and Medical Subject Headings (MeSH). The MIND training set has a total of 9,651,040 edges."
+domains:
+- drug discovery
+- biomedical
+homepage_url: https://zenodo.org/records/8117748
+id: mind
+layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: MIND
+products:
+- category: GraphProduct
+  description: Training data for the MIND knowledge graph containing 9,651,040 edges
+  format: tsv
+  id: mind.train
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Training Data
+  original_source:
+  - mind
+  product_url: https://zenodo.org/records/8117748/files/train.txt
+- category: GraphProduct
+  description: Test data for the MIND knowledge graph containing DrugCentral indications
+  format: tsv
+  id: mind.test
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Test Data
+  original_source:
+  - mind
+  product_url: https://zenodo.org/records/8117748/files/test.txt
+- category: GraphProduct
+  description: Validation data for the MIND knowledge graph containing DrugCentral indications
+  format: tsv
+  id: mind.valid
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Validation Data
+  original_source:
+  - mind
+  product_url: https://zenodo.org/records/8117748/files/valid.txt
+- category: Product
+  description: Dictionary of entities in the MIND knowledge graph
+  format: tsv
+  id: mind.entities
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Entities Dictionary
+  original_source:
+  - mind
+  product_url: https://zenodo.org/records/8117748/files/entities.dict
+- category: Product
+  description: Dictionary of relations in the MIND knowledge graph
+  format: tsv
+  id: mind.relations
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC-BY-4.0
+  name: MIND Relations Dictionary
+  original_source:
+  - mind
+  product_url: https://zenodo.org/records/8117748/files/relations.dict
+publications:
+- id: https://doi.org/10.1101/2023.05.12.540594
+  title: Mechanistic Repositioning Network with Indications (MIND) is a knowledge graph resource for drug discovery
+  authors:
+  - Roger Tu
+  - Meghamala Sinha
+  - Ander I Su
+  journal: bioRxiv
+  year: "2023"
+  preferred: true
+repository: https://github.com/SuLab/KnowledgeGraphEmbedding
+version: "1.0"
+---
+MIND (Mechanistic Repositioning Network with Indications) is a knowledge graph that combines MechRepoNet, a graph comprising 18 biomedical resources, with DrugCentral indications data. MechRepoNet contains 9,652,116 edges and 250,035 nodes covering drug mechanisms, while DrugCentral contributes 5,379 indication edges representing relationships between 1,308 unique compounds and 1,030 unique diseases. The resulting MIND knowledge graph contains 9,651,040 edges in its training set and is designed to support drug repositioning research through knowledge graph embeddings.

--- a/resource/mind/mind.relations.md
+++ b/resource/mind/mind.relations.md
@@ -1,0 +1,17 @@
+---
+category: Product
+description: Dictionary of relations in the MIND knowledge graph
+format: tsv
+id: mind.relations
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: MIND Relations Dictionary
+original_source:
+- drugcentral
+- mechreponet
+product_url: https://zenodo.org/records/8117748/files/relations.dict
+secondary_source:
+- mind
+layout: product_detail
+---

--- a/resource/mind/mind.test.md
+++ b/resource/mind/mind.test.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+description: Test data for the MIND knowledge graph containing DrugCentral indications
+format: tsv
+id: mind.test
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: MIND Test Data
+original_source:
+- drugcentral
+- mechreponet
+product_url: https://zenodo.org/records/8117748/files/test.txt
+secondary_source:
+- mind
+layout: product_detail
+---

--- a/resource/mind/mind.train.md
+++ b/resource/mind/mind.train.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+description: Training data for the MIND knowledge graph containing 9,651,040 edges
+format: tsv
+id: mind.train
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: MIND Training Data
+original_source:
+- drugcentral
+- mechreponet
+product_url: https://zenodo.org/records/8117748/files/train.txt
+secondary_source:
+- mind
+layout: product_detail
+---

--- a/resource/mind/mind.valid.md
+++ b/resource/mind/mind.valid.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+description: Validation data for the MIND knowledge graph containing DrugCentral indications
+format: tsv
+id: mind.valid
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: MIND Validation Data
+original_source:
+- drugcentral
+- mechreponet
+product_url: https://zenodo.org/records/8117748/files/valid.txt
+secondary_source:
+- mind
+layout: product_detail
+---

--- a/resource/mirtarbase/mirtarbase.md
+++ b/resource/mirtarbase/mirtarbase.md
@@ -1,0 +1,20 @@
+---
+activity_status: active
+category: DataSource
+creation_date: '2025-07-17T00:00:00Z'
+description: Stub Resource page for mirtarbase. This page was automatically generated
+  because it was referenced by other resources.
+domains:
+- stub
+id: mirtarbase
+last_modified_date: '2025-07-17T00:00:00Z'
+layout: resource_detail
+name: Mirtarbase
+warnings:
+- This is an automatically generated stub page. Please replace with accurate information
+  about this resource.
+---
+
+# Mirtarbase
+
+This is an automatically generated stub page for mirtarbase. Please update with proper information.

--- a/resource/ncbitaxon/ncbitaxon.md
+++ b/resource/ncbitaxon/ncbitaxon.md
@@ -437,6 +437,30 @@ products:
   - v2022-04-13
   - v2022-03-09
   - v2021-04-06
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 publications:
 - authors:
   - Scott Federhen

--- a/resource/pr/pr.md
+++ b/resource/pr/pr.md
@@ -113,6 +113,30 @@ products:
   product_url: https://www.ebi.ac.uk/efo/efo.obo
   secondary_source:
   - efo
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 warnings:
 - This is an automatically generated stub page. Please replace with accurate information
   about this resource.

--- a/resource/pubmed/pubmed.md
+++ b/resource/pubmed/pubmed.md
@@ -10,11 +10,22 @@ id: pubmed
 last_modified_date: '2025-07-17T00:00:00Z'
 layout: resource_detail
 name: Pubmed
+products:
+- category: MappingProduct
+  compression: gzip
+  description: Gene to PubMed mapping data providing literature references associated
+    with genes
+  format: tsv
+  id: ncbigene.gene2pubmed
+  name: Gene to PubMed Mapping
+  original_source:
+  - pubmed
+  - ncbigene
+  product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2pubmed.gz
 warnings:
 - This is an automatically generated stub page. Please replace with accurate information
   about this resource.
 ---
-
 # Pubmed
 
 This is an automatically generated stub page for pubmed. Please update with proper information.

--- a/resource/reactome/reactome.md
+++ b/resource/reactome/reactome.md
@@ -404,6 +404,30 @@ products:
   product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
   secondary_source:
   - bioteque
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 repository: ''
 ---
 REACTOME is an open-source, open access, manually curated and peer-reviewed pathway database.

--- a/resource/refseq/refseq.md
+++ b/resource/refseq/refseq.md
@@ -10,11 +10,34 @@ id: refseq
 last_modified_date: '2025-07-17T00:00:00Z'
 layout: resource_detail
 name: Refseq
+products:
+- category: MappingProduct
+  compression: gzip
+  description: Gene to RefSeq/UniProtKB collaboration data providing cross-references
+    between gene records and protein databases
+  format: tsv
+  id: ncbigene.gene_refseq_uniprotkb_collab
+  name: Gene RefSeq UniProtKB Collaboration Data
+  original_source:
+  - refseq
+  - ncbigene
+  - uniprot
+  product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene_refseq_uniprotkb_collab.gz
+- category: MappingProduct
+  compression: gzip
+  description: Gene to RefSeq mapping data providing links between gene records and
+    RefSeq sequence identifiers
+  format: tsv
+  id: ncbigene.gene2refseq
+  name: Gene to RefSeq Mapping
+  original_source:
+  - refseq
+  - ncbigene
+  product_url: https://ftp.ncbi.nih.gov/gene/DATA/gene2refseq.gz
 warnings:
 - This is an automatically generated stub page. Please replace with accurate information
   about this resource.
 ---
-
 # Refseq
 
 This is an automatically generated stub page for refseq. Please update with proper information.

--- a/resource/rnacentral/rnacentral.md
+++ b/resource/rnacentral/rnacentral.md
@@ -1,0 +1,20 @@
+---
+activity_status: active
+category: DataSource
+creation_date: '2025-07-17T00:00:00Z'
+description: Stub Resource page for rnacentral. This page was automatically generated
+  because it was referenced by other resources.
+domains:
+- stub
+id: rnacentral
+last_modified_date: '2025-07-17T00:00:00Z'
+layout: resource_detail
+name: Rnacentral
+warnings:
+- This is an automatically generated stub page. Please replace with accurate information
+  about this resource.
+---
+
+# Rnacentral
+
+This is an automatically generated stub page for rnacentral. Please update with proper information.

--- a/resource/uberon/uberon.md
+++ b/resource/uberon/uberon.md
@@ -579,6 +579,30 @@ products:
   - v2022-04-13
   - v2022-03-09
   - v2021-04-06
+- description: The MechRepoNet knowledge graph in its original format
+  id: mechreponet.kg
+  name: MechRepoNet Knowledge Graph
+  original_source:
+  - ctd
+  - do
+  - go
+  - chebi
+  - reactome
+  - interpro
+  - hp
+  - cl
+  - pr
+  - uberon
+  - ncbitaxon
+  - hetionet
+  - complexportal
+  - rnacentral
+  - mirtarbase
+  - unii
+  - biolink
+  product_url: https://github.com/SuLab/MechRepoNet/releases/tag/publication
+  secondary_source:
+  - mechreponet
 repository: https://github.com/obophenotype/uberon
 ---
 The Uber-Anatomy Ontology (UBERON) is a comprehensive cross-species anatomy ontology representing anatomical structures, cells, and tissues across metazoans. It serves as an integrative resource that connects various species-specific anatomy ontologies and provides a unified framework for comparative analysis.

--- a/resource/unii/unii.md
+++ b/resource/unii/unii.md
@@ -1,0 +1,20 @@
+---
+activity_status: active
+category: DataSource
+creation_date: '2025-07-17T00:00:00Z'
+description: Stub Resource page for unii. This page was automatically generated because
+  it was referenced by other resources.
+domains:
+- stub
+id: unii
+last_modified_date: '2025-07-17T00:00:00Z'
+layout: resource_detail
+name: Unii
+warnings:
+- This is an automatically generated stub page. Please replace with accurate information
+  about this resource.
+---
+
+# Unii
+
+This is an automatically generated stub page for unii. Please update with proper information.


### PR DESCRIPTION
This PR adds MIND (Mechanistic Repositioning Network with Indications) as a new KnowledgeGraph resource to the kg-registry.

**Resource Details:**
- **Name**: MIND (Mechanistic Repositioning Network with Indications)
- **Type**: KnowledgeGraph  
- **Domain**: Drug discovery, biomedical
- **Description**: A knowledge graph that combines MechRepoNet (18 biomedical resources) with DrugCentral indications data
- **Data**: Contains 9,651,040 edges in training set with drug mechanism and indication relationships

**Products Included:**
1. Training data (train.txt) - 9,651,040 edges
2. Test data (test.txt) - DrugCentral indications for evaluation  
3. Validation data (valid.txt) - DrugCentral indications for validation
4. Entities dictionary (entities.dict) - Entity mappings
5. Relations dictionary (relations.dict) - Relationship mappings

**Sources:**
- **Zenodo**: https://zenodo.org/records/8117748
- **Publication**: https://doi.org/10.1101/2023.05.12.540594 (bioRxiv preprint)
- **Repository**: https://github.com/SuLab/KnowledgeGraphEmbedding
- **License**: CC-BY-4.0

**Contact Information:**
- Roger Tu (ORCID: 0000-0002-7899-1604)
- Meghamala Sinha (ORCID: 0000-0002-6422-3313)  
- Ander I Su (ORCID: 0000-0002-9859-4104)

This resource supports drug repositioning research through knowledge graph embeddings and provides a valuable dataset for machine learning approaches in drug discovery.

Resolves #287