### PR TITLE
Fix duplicate collectionMetadata declaration causing syntax error

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -56,30 +56,6 @@ jQuery(document).ready(function () {
         }
     };
 
-    // Collection metadata: display names and descriptions
-    const collectionMetadata = {
-        "aop": {
-            displayName: "AOP",
-            description: "This entity incorporates the Adverse Outcome Pathways (AOP) framework in some manner."
-        },
-        "ber": {
-            displayName: "BER",
-            description: "A resource or product relevant to the US Department of Energy Biological and Environmental Research (BER) program."
-        },
-        "translator": {
-            displayName: "Translator",
-            description: "This entity is part of those developed and used by the NCATS Biomedical Translator program."
-        },
-        "obo-foundry": {
-            displayName: "OBO Foundry",
-            description: "This entity is an ontology from the OBO Foundry, a collaborative effort to create reference ontologies in the biomedical domain."
-        },
-        "okn": {
-            displayName: "OKN",
-            description: "This entity is part of the Prototype Open Knowledge Network (OKN), a knowledge graph network supported by the National Science Foundation (NSF)."
-        }
-    };
-
     // Cache frequently accessed DOM elements
     const $tableDiv = $("#tableDiv");
     const $tableMain = $('#table-main');


### PR DESCRIPTION
The collectionMetadata object was declared twice in custom.js (lines 36-57 and 60-81), causing the error "Identifier 'collectionMetadata' has already been declared". This prevented the main page table from loading.

Fixed by removing the duplicate declaration, keeping only the first instance.

Resolves the table loading issue on the main page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)