### PR TITLE
Add diagram to enumerate product types and sources on Resource pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -120,7 +120,7 @@ Custom blockquote formatting
 }
 
 .resource-product-summary-treemap {
-    min-height: 14rem;
+    min-height: 8rem;
     border: 1px solid #dbe5ef;
     border-radius: 0.85rem;
     background:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -112,76 +112,7 @@ Custom blockquote formatting
 }
 
 .resource-product-summary {
-    display: grid;
-    grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.95fr);
-    gap: 1.25rem;
-    align-items: start;
-}
-
-.resource-product-summary-copy {
-    min-width: 0;
-}
-
-.resource-product-summary-total {
-    color: #4f6173;
-}
-
-.resource-product-summary-lists {
-    display: grid;
-    gap: 1rem;
-}
-
-.resource-product-summary-heading {
-    margin-bottom: 0.5rem;
-    font-size: 1rem;
-}
-
-.resource-product-summary-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.55rem;
-}
-
-.resource-product-summary-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.45rem 0.75rem;
-    border: 1px solid #d9e4ef;
-    border-radius: 999px;
-    background: linear-gradient(180deg, #fbfdff 0%, #eef5fb 100%);
-    color: #2d4257;
-    font-size: 0.95rem;
-    line-height: 1.2;
-}
-
-.resource-product-summary-chip:hover {
-    text-decoration: none;
-    color: #203244;
-    border-color: #bfd3e4;
-    background: linear-gradient(180deg, #ffffff 0%, #e8f2fb 100%);
-}
-
-.resource-product-summary-chip-count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 1.75rem;
-    padding: 0.1rem 0.45rem;
-    border-radius: 999px;
-    background: #dceaf7;
-    color: #234b6f;
-    font-weight: 700;
-}
-
-.resource-product-summary-chip-label {
-    overflow-wrap: normal;
-    word-break: normal;
-}
-
-.resource-product-summary-empty {
-    color: #6c757d;
-    font-style: italic;
+    display: block;
 }
 
 .resource-product-summary-chart {
@@ -202,12 +133,6 @@ Custom blockquote formatting
     display: block;
     width: 100%;
     height: auto;
-}
-
-@media (max-width: 992px) {
-    .resource-product-summary {
-        grid-template-columns: 1fr;
-    }
 }
 
 .registry-counts {

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -107,7 +107,7 @@ Custom blockquote formatting
 }
 
 .header-card-row {
-    max-width: 72rem;
+    max-width: calc(72rem + var(--bs-gutter-x));
     margin-bottom: 1.5rem;
 }
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -111,6 +111,105 @@ Custom blockquote formatting
     margin-bottom: 1.5rem;
 }
 
+.resource-product-summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.95fr);
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.resource-product-summary-copy {
+    min-width: 0;
+}
+
+.resource-product-summary-total {
+    color: #4f6173;
+}
+
+.resource-product-summary-lists {
+    display: grid;
+    gap: 1rem;
+}
+
+.resource-product-summary-heading {
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+}
+
+.resource-product-summary-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.resource-product-summary-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid #d9e4ef;
+    border-radius: 999px;
+    background: linear-gradient(180deg, #fbfdff 0%, #eef5fb 100%);
+    color: #2d4257;
+    font-size: 0.95rem;
+    line-height: 1.2;
+}
+
+.resource-product-summary-chip:hover {
+    text-decoration: none;
+    color: #203244;
+    border-color: #bfd3e4;
+    background: linear-gradient(180deg, #ffffff 0%, #e8f2fb 100%);
+}
+
+.resource-product-summary-chip-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.75rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: #dceaf7;
+    color: #234b6f;
+    font-weight: 700;
+}
+
+.resource-product-summary-chip-label {
+    overflow-wrap: normal;
+    word-break: normal;
+}
+
+.resource-product-summary-empty {
+    color: #6c757d;
+    font-style: italic;
+}
+
+.resource-product-summary-chart {
+    min-width: 0;
+}
+
+.resource-product-summary-treemap {
+    min-height: 14rem;
+    border: 1px solid #dbe5ef;
+    border-radius: 0.85rem;
+    background:
+        radial-gradient(circle at top left, rgba(221, 235, 247, 0.8), transparent 42%),
+        linear-gradient(180deg, #fbfdff 0%, #f3f7fb 100%);
+    padding: 0.5rem;
+}
+
+.resource-product-summary-treemap svg {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+@media (max-width: 992px) {
+    .resource-product-summary {
+        grid-template-columns: 1fr;
+    }
+}
+
 .registry-counts {
     display: flex;
     flex-wrap: wrap;

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -453,6 +453,19 @@
         return `${text.slice(0, Math.max(5, maxChars - 1)).trimEnd()}…`;
     }
 
+    function buildTreemapSourceLabelLines(name, count, width) {
+        const countLabel = `(${count})`;
+
+        if (width >= 150) {
+            return [truncateSummaryLabel(`${name} ${countLabel}`, width)];
+        }
+
+        return [
+            truncateSummaryLabel(name, width),
+            truncateSummaryLabel(countLabel, width)
+        ];
+    }
+
     function renderResourceProductSummaries() {
         const summaryContainers = document.querySelectorAll('.resource-product-summary');
 
@@ -617,6 +630,69 @@
         });
     }
 
+    function tileTreemapSourceGroups(node, x0, y0, x1, y1) {
+        const children = node.children || [];
+        if (children.length === 0) {
+            return;
+        }
+
+        if (children.length === 1) {
+            const [child] = children;
+            child.x0 = x0;
+            child.x1 = x1;
+            child.y0 = y0;
+            child.y1 = y1;
+            return;
+        }
+
+        const totalValue = children.reduce((sum, child) => sum + (child.value || 0), 0);
+        const totalWidth = x1 - x0;
+        let leftX = x0;
+        let rightX = x1;
+        let middleChildren = children;
+
+        const firstChild = children[0];
+        if (firstChild?.data?.isCurrent) {
+            const leftWidth = totalValue > 0 ? totalWidth * ((firstChild.value || 0) / totalValue) : 0;
+            firstChild.x0 = leftX;
+            firstChild.x1 = leftX + leftWidth;
+            firstChild.y0 = y0;
+            firstChild.y1 = y1;
+            leftX += leftWidth;
+            middleChildren = children.slice(1);
+        }
+
+        const lastChild = middleChildren[middleChildren.length - 1];
+        if (lastChild?.data?.isAggregate) {
+            const rightWidth = totalValue > 0 ? totalWidth * ((lastChild.value || 0) / totalValue) : 0;
+            lastChild.x0 = rightX - rightWidth;
+            lastChild.x1 = rightX;
+            lastChild.y0 = y0;
+            lastChild.y1 = y1;
+            rightX -= rightWidth;
+            middleChildren = middleChildren.slice(0, -1);
+        }
+
+        if (middleChildren.length === 0) {
+            return;
+        }
+
+        if (middleChildren.length === 1) {
+            const [child] = middleChildren;
+            child.x0 = leftX;
+            child.x1 = rightX;
+            child.y0 = y0;
+            child.y1 = y1;
+            return;
+        }
+
+        const middleNode = {
+            children: middleChildren,
+            value: middleChildren.reduce((sum, child) => sum + (child.value || 0), 0)
+        };
+        d3.treemapBinary(middleNode, leftX, y0, rightX, y1);
+    }
+
     function renderResourceProductTreemap(container, summary) {
         if (!container) {
             return;
@@ -680,10 +756,10 @@
             .size([width, height])
             .paddingOuter(6)
             .paddingInner(4)
-            .paddingTop(node => (node.depth === 1 ? 24 : 0))
+            .paddingTop(node => (node.depth === 1 ? 32 : 0))
             .tile((node, x0, y0, x1, y1) => {
                 if (node.depth === 0) {
-                    d3.treemapDice(node, x0, y0, x1, y1);
+                    tileTreemapSourceGroups(node, x0, y0, x1, y1);
                 } else {
                     sourceTile(node, x0, y0, x1, y1);
                 }
@@ -729,7 +805,7 @@
 
         const sourceLabels = svg.append('g')
             .selectAll('g')
-            .data((root.children || []).filter(d => (d.x1 - d.x0) > 96 && (d.y1 - d.y0) > 28))
+            .data((root.children || []).filter(d => (d.x1 - d.x0) > 56 && (d.y1 - d.y0) > 36))
             .enter()
             .append('g');
 
@@ -741,15 +817,22 @@
                     .attr('target', '_self')
                 : selection;
 
-            textTarget.append('text')
+            const lines = buildTreemapSourceLabelLines(d.data.name, d.value, d.x1 - d.x0 - 14);
+            const text = textTarget.append('text')
                 .attr('x', d.x0 + 8)
-                .attr('y', d.y0 + 16)
+                .attr('y', d.y0 + 15)
                 .attr('fill', sourceColor(d.data.sourceId))
                 .attr('font-size', 14)
                 .attr('font-weight', 700)
                 .style('text-decoration', (!d.data.isCurrent && d.data.sourceUrl) ? 'underline' : null)
-                .style('cursor', (!d.data.isCurrent && d.data.sourceUrl) ? 'pointer' : null)
-                .text(truncateSummaryLabel(`${d.data.name} (${d.value})`, d.x1 - d.x0 - 12));
+                .style('cursor', (!d.data.isCurrent && d.data.sourceUrl) ? 'pointer' : null);
+
+            lines.forEach((line, index) => {
+                text.append('tspan')
+                    .attr('x', d.x0 + 8)
+                    .attr('dy', index === 0 ? 0 : 13)
+                    .text(line);
+            });
 
             const sourceTitle = d.data.isAggregate && d.data.aggregatedSourceIds.length > 0
                 ? `${d.data.name} (${d.value}): ${d.data.aggregatedSourceIds.join(', ')}`
@@ -791,6 +874,7 @@
             const width = d.x1 - d.x0;
             const height = d.y1 - d.y0;
             const label = `${d.data.value} ${d.data.name}`;
+            const countOnlyLabel = `${d.data.value}`;
 
             if (width < 64 || height < 28) {
                 return;
@@ -814,7 +898,15 @@
                     .attr('dy', 16)
                     .text(truncateSummaryLabel(d.data.name, width - 16));
             } else {
-                text.text(truncateSummaryLabel(label, width - 16));
+                const fullLabel = truncateSummaryLabel(label, width - 16);
+                const countFits = countOnlyLabel.length <= Math.max(1, Math.floor((width - 16) / 7));
+                const fullLabelLooksTruncated = fullLabel.includes('…');
+
+                text.text(
+                    fullLabelLooksTruncated && countFits
+                        ? countOnlyLabel
+                        : fullLabel
+                );
             }
         });
     }

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -469,18 +469,9 @@
 
     function renderResourceProductSummary(container, products) {
         const resourceId = container.getAttribute('data-resource-id');
-        const resourceUrl = container.getAttribute('data-resource-url') || '';
-        const totalEl = container.querySelector('[data-summary-total]');
-        const sourcesEl = container.querySelector('[data-summary-sources]');
-        const typesEl = container.querySelector('[data-summary-types]');
         const treemapEl = container.querySelector('[data-summary-treemap]');
 
         if (!Array.isArray(products) || products.length === 0) {
-            if (totalEl) {
-                totalEl.textContent = 'No products summarized yet.';
-            }
-            renderSummaryChips(sourcesEl, []);
-            renderSummaryChips(typesEl, []);
             if (treemapEl) {
                 treemapEl.innerHTML = '';
             }
@@ -488,13 +479,12 @@
         }
 
         const sourceCounts = new Map();
-        const typeCounts = new Map();
         const sourceTypeCounts = new Map();
 
         products.forEach(product => {
             const category = product.category || 'Product';
             const sourceId = product.sourceId || resourceId;
-            const sourceUrl = product.sourceUrl || resourceUrl;
+            const sourceUrl = product.sourceUrl || '';
 
             if (!sourceCounts.has(sourceId)) {
                 sourceCounts.set(sourceId, {
@@ -505,14 +495,6 @@
                 });
             }
             sourceCounts.get(sourceId).count += 1;
-
-            if (!typeCounts.has(category)) {
-                typeCounts.set(category, {
-                    category,
-                    count: 0
-                });
-            }
-            typeCounts.get(category).count += 1;
 
             if (!sourceTypeCounts.has(sourceId)) {
                 sourceTypeCounts.set(sourceId, new Map());
@@ -538,79 +520,10 @@
             return a.id.localeCompare(b.id);
         });
 
-        const typeEntries = Array.from(typeCounts.values()).sort((a, b) => {
-            if (b.count !== a.count) {
-                return b.count - a.count;
-            }
-            return getProductCategoryDisplayName(a.category, a.count)
-                .localeCompare(getProductCategoryDisplayName(b.category, b.count));
-        });
-
-        if (totalEl) {
-            const productCountLabel = products.length === 1 ? 'product' : 'products';
-            const sourceCountLabel = sourceEntries.length === 1 ? 'source' : 'sources';
-            const typeCountLabel = typeEntries.length === 1 ? 'product type' : 'product types';
-            totalEl.textContent = `${products.length} ${productCountLabel} across ${sourceEntries.length} ${sourceCountLabel} and ${typeEntries.length} ${typeCountLabel}.`;
-        }
-
-        renderSummaryChips(
-            sourcesEl,
-            sourceEntries.map(entry => ({
-                count: entry.count,
-                label: entry.isCurrent ? 'This Resource' : entry.id,
-                href: entry.isCurrent ? null : entry.url
-            }))
-        );
-
-        renderSummaryChips(
-            typesEl,
-            typeEntries.map(entry => ({
-                count: entry.count,
-                label: getProductCategoryDisplayName(entry.category, entry.count)
-            }))
-        );
-
         renderResourceProductTreemap(treemapEl, {
             products,
             sourceEntries,
             sourceTypeCounts
-        });
-    }
-
-    function renderSummaryChips(container, items) {
-        if (!container) {
-            return;
-        }
-
-        container.innerHTML = '';
-
-        if (!items || items.length === 0) {
-            const empty = document.createElement('span');
-            empty.className = 'resource-product-summary-empty';
-            empty.textContent = 'None.';
-            container.appendChild(empty);
-            return;
-        }
-
-        items.forEach(item => {
-            const chip = item.href ? document.createElement('a') : document.createElement('span');
-            chip.className = 'resource-product-summary-chip';
-
-            if (item.href) {
-                chip.href = item.href;
-            }
-
-            const count = document.createElement('span');
-            count.className = 'resource-product-summary-chip-count';
-            count.textContent = item.count;
-
-            const label = document.createElement('span');
-            label.className = 'resource-product-summary-chip-label';
-            label.textContent = item.label;
-
-            chip.appendChild(count);
-            chip.appendChild(label);
-            container.appendChild(chip);
         });
     }
 
@@ -635,7 +548,8 @@
             children: summary.sourceEntries.map(source => ({
                 name: source.isCurrent ? 'This Resource' : source.id,
                 sourceId: source.id,
-                value: source.count,
+                sourceUrl: source.url,
+                isCurrent: source.isCurrent,
                 children: Array.from(summary.sourceTypeCounts.get(source.id).values())
                     .sort((a, b) => {
                         if (b.count !== a.count) {
@@ -701,17 +615,30 @@
             .attr('stroke-width', 1.5)
             .attr('opacity', 0.55);
 
-        svg.append('g')
-            .selectAll('text')
+        const sourceLabels = svg.append('g')
+            .selectAll('g')
             .data((root.children || []).filter(d => (d.x1 - d.x0) > 96 && (d.y1 - d.y0) > 28))
             .enter()
-            .append('text')
-            .attr('x', d => d.x0 + 8)
-            .attr('y', d => d.y0 + 16)
-            .attr('fill', d => sourceColor(d.data.sourceId))
-            .attr('font-size', 12)
-            .attr('font-weight', 700)
-            .text(d => truncateSummaryLabel(`${d.data.name} (${d.value})`, d.x1 - d.x0 - 12));
+            .append('g');
+
+        sourceLabels.each(function(d) {
+            const selection = d3.select(this);
+            const textTarget = (!d.data.isCurrent && d.data.sourceUrl)
+                ? selection.append('a')
+                    .attr('href', d.data.sourceUrl)
+                    .attr('target', '_self')
+                : selection;
+
+            textTarget.append('text')
+                .attr('x', d.x0 + 8)
+                .attr('y', d.y0 + 16)
+                .attr('fill', sourceColor(d.data.sourceId))
+                .attr('font-size', 12)
+                .attr('font-weight', 700)
+                .style('text-decoration', (!d.data.isCurrent && d.data.sourceUrl) ? 'underline' : null)
+                .style('cursor', (!d.data.isCurrent && d.data.sourceUrl) ? 'pointer' : null)
+                .text(truncateSummaryLabel(`${d.data.name} (${d.value})`, d.x1 - d.x0 - 12));
+        });
 
         const leaves = svg.append('g')
             .selectAll('g')

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -421,6 +421,10 @@
         "Product": { singular: "Product", plural: "Products" }
     };
 
+    const maxTreemapSourceGroups = 8;
+    const initialAggregateSourceThreshold = 1;
+    const maxAggregateSourceThreshold = 3;
+
     function getProductCategoryLabels(category) {
         if (productCategoryLabels[category]) {
             return productCategoryLabels[category];
@@ -520,11 +524,99 @@
             return a.id.localeCompare(b.id);
         });
 
+        const treemapSummary = buildTreemapSourceSummary(sourceEntries, sourceTypeCounts);
+
         renderResourceProductTreemap(treemapEl, {
-            products,
-            sourceEntries,
-            sourceTypeCounts
+            sourceEntries: treemapSummary.sourceEntries,
+            sourceTypeCounts: treemapSummary.sourceTypeCounts
         });
+    }
+
+    function buildTreemapSourceSummary(sourceEntries, sourceTypeCounts) {
+        if (sourceEntries.length <= maxTreemapSourceGroups) {
+            return { sourceEntries, sourceTypeCounts };
+        }
+
+        const externalEntries = sourceEntries.filter(entry => !entry.isCurrent);
+        if (externalEntries.length === 0) {
+            return { sourceEntries, sourceTypeCounts };
+        }
+
+        let aggregateThreshold = initialAggregateSourceThreshold;
+        let aggregatedSourceIds = [];
+
+        while (aggregateThreshold <= maxAggregateSourceThreshold) {
+            aggregatedSourceIds = externalEntries
+                .filter(entry => entry.count <= aggregateThreshold)
+                .map(entry => entry.id);
+
+            if (aggregatedSourceIds.length > 0) {
+                const remainingGroups = sourceEntries.length - aggregatedSourceIds.length + 1;
+                if (remainingGroups <= maxTreemapSourceGroups || aggregateThreshold === maxAggregateSourceThreshold) {
+                    break;
+                }
+            }
+
+            aggregateThreshold += 1;
+        }
+
+        if (aggregatedSourceIds.length === 0) {
+            return { sourceEntries, sourceTypeCounts };
+        }
+
+        const aggregatedSourceSet = new Set(aggregatedSourceIds);
+        const aggregatedTypeCounts = new Map();
+        let aggregatedCount = 0;
+
+        aggregatedSourceIds.forEach(sourceId => {
+            aggregatedCount += sourceTypeCounts.get(sourceId)
+                ? Array.from(sourceTypeCounts.get(sourceId).values()).reduce((sum, entry) => sum + entry.count, 0)
+                : 0;
+
+            (sourceTypeCounts.get(sourceId) || new Map()).forEach((typeEntry, category) => {
+                if (!aggregatedTypeCounts.has(category)) {
+                    aggregatedTypeCounts.set(category, {
+                        category,
+                        count: 0
+                    });
+                }
+                aggregatedTypeCounts.get(category).count += typeEntry.count;
+            });
+        });
+
+        const nextSourceEntries = sourceEntries
+            .filter(entry => !aggregatedSourceSet.has(entry.id))
+            .concat([{
+                id: '__other_resources__',
+                name: 'Other Resources',
+                url: '',
+                isCurrent: false,
+                isAggregate: true,
+                count: aggregatedCount,
+                aggregatedSourceIds
+            }])
+            .sort((a, b) => {
+                if (a.isCurrent !== b.isCurrent) {
+                    return a.isCurrent ? -1 : 1;
+                }
+                if (b.count !== a.count) {
+                    return b.count - a.count;
+                }
+                return (a.name || a.id).localeCompare(b.name || b.id);
+            });
+
+        const nextSourceTypeCounts = new Map();
+        sourceTypeCounts.forEach((value, key) => {
+            if (!aggregatedSourceSet.has(key)) {
+                nextSourceTypeCounts.set(key, value);
+            }
+        });
+        nextSourceTypeCounts.set('__other_resources__', aggregatedTypeCounts);
+
+        return {
+            sourceEntries: nextSourceEntries,
+            sourceTypeCounts: nextSourceTypeCounts
+        };
     }
 
     function renderResourceProductTreemap(container, summary) {
@@ -534,22 +626,29 @@
 
         container.innerHTML = '';
 
+        const leafCount = summary.sourceEntries.reduce((sum, source) => {
+            const typeCountMap = summary.sourceTypeCounts.get(source.id);
+            return sum + (typeCountMap ? typeCountMap.size : 0);
+        }, 0);
+
         const width = Math.max(280, Math.floor(container.getBoundingClientRect().width) - 16);
         const height = Math.max(
-            224,
+            120,
             Math.min(
                 340,
-                summary.sourceEntries.length * 56 + summary.products.length * 18 + 72
+                summary.sourceEntries.length * 30 + leafCount * 12 + 36
             )
         );
 
         const hierarchyData = {
             name: 'Products',
             children: summary.sourceEntries.map(source => ({
-                name: source.isCurrent ? 'This Resource' : source.id,
+                name: source.name || (source.isCurrent ? 'This Resource' : source.id),
                 sourceId: source.id,
                 sourceUrl: source.url,
                 isCurrent: source.isCurrent,
+                isAggregate: source.isAggregate,
+                aggregatedSourceIds: source.aggregatedSourceIds || [],
                 children: Array.from(summary.sourceTypeCounts.get(source.id).values())
                     .sort((a, b) => {
                         if (b.count !== a.count) {
@@ -633,11 +732,18 @@
                 .attr('x', d.x0 + 8)
                 .attr('y', d.y0 + 16)
                 .attr('fill', sourceColor(d.data.sourceId))
-                .attr('font-size', 12)
+                .attr('font-size', 14)
                 .attr('font-weight', 700)
                 .style('text-decoration', (!d.data.isCurrent && d.data.sourceUrl) ? 'underline' : null)
                 .style('cursor', (!d.data.isCurrent && d.data.sourceUrl) ? 'pointer' : null)
                 .text(truncateSummaryLabel(`${d.data.name} (${d.value})`, d.x1 - d.x0 - 12));
+
+            const sourceTitle = d.data.isAggregate && d.data.aggregatedSourceIds.length > 0
+                ? `${d.data.name} (${d.value}): ${d.data.aggregatedSourceIds.join(', ')}`
+                : `${d.data.name} (${d.value})`;
+
+            selection.append('title')
+                .text(sourceTitle);
         });
 
         const leaves = svg.append('g')
@@ -681,7 +787,7 @@
                 .attr('x', d.x0 + 8)
                 .attr('y', d.y0 + 18)
                 .attr('fill', '#102a43')
-                .attr('font-size', width > 140 && height > 54 ? 13 : 11)
+                .attr('font-size', width > 140 && height > 54 ? 15 : 13)
                 .attr('font-weight', 600);
 
             if (width > 140 && height > 54) {

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -12,6 +12,9 @@
         // Create rotating network logo
         createNetworkLogo();
         
+        // Render product summaries on resource pages
+        renderResourceProductSummaries();
+
         // Call the async function without waiting for it
         renderProvenanceDiagrams().catch(console.error);
 
@@ -20,6 +23,7 @@
             // Debounce the resize event
             if (this.resizeTimeout) clearTimeout(this.resizeTimeout);
             this.resizeTimeout = setTimeout(function () {
+                renderResourceProductSummaries();
                 renderProvenanceDiagrams().catch(console.error);
             }, 200);
         });
@@ -403,6 +407,371 @@
         "GraphicalInterface": "window",
         "ProgrammingInterface": "code-square"
     };
+
+    const productCategoryLabels = {
+        "DataProduct": { singular: "Data Product", plural: "Data Products" },
+        "GraphProduct": { singular: "Graph Product", plural: "Graph Products" },
+        "MappingProduct": { singular: "Mapping Product", plural: "Mapping Products" },
+        "ProcessProduct": { singular: "Process Product", plural: "Process Products" },
+        "DataModelProduct": { singular: "Data Model Product", plural: "Data Model Products" },
+        "OntologyProduct": { singular: "Ontology Product", plural: "Ontology Products" },
+        "GraphicalInterface": { singular: "Graphical Interface", plural: "Graphical Interfaces" },
+        "ProgrammingInterface": { singular: "Programming Interface", plural: "Programming Interfaces" },
+        "DocumentationProduct": { singular: "Documentation Product", plural: "Documentation Products" },
+        "Product": { singular: "Product", plural: "Products" }
+    };
+
+    function getProductCategoryLabels(category) {
+        if (productCategoryLabels[category]) {
+            return productCategoryLabels[category];
+        }
+
+        const fallback = (category || 'Product')
+            .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+            .trim();
+
+        return {
+            singular: fallback,
+            plural: fallback.endsWith('s') ? fallback : `${fallback}s`
+        };
+    }
+
+    function getProductCategoryDisplayName(category, count) {
+        const labels = getProductCategoryLabels(category);
+        return count === 1 ? labels.singular : labels.plural;
+    }
+
+    function truncateSummaryLabel(text, width) {
+        const maxChars = Math.max(8, Math.floor(width / 7));
+        if (text.length <= maxChars) {
+            return text;
+        }
+        return `${text.slice(0, Math.max(5, maxChars - 1)).trimEnd()}…`;
+    }
+
+    function renderResourceProductSummaries() {
+        const summaryContainers = document.querySelectorAll('.resource-product-summary');
+
+        summaryContainers.forEach(container => {
+            const dataEl = container.querySelector('.resource-product-summary-data');
+            if (!dataEl) {
+                return;
+            }
+
+            try {
+                const products = JSON.parse(dataEl.textContent);
+                renderResourceProductSummary(container, products);
+            } catch (error) {
+                console.error('Error rendering resource product summary:', error);
+            }
+        });
+    }
+
+    function renderResourceProductSummary(container, products) {
+        const resourceId = container.getAttribute('data-resource-id');
+        const resourceUrl = container.getAttribute('data-resource-url') || '';
+        const totalEl = container.querySelector('[data-summary-total]');
+        const sourcesEl = container.querySelector('[data-summary-sources]');
+        const typesEl = container.querySelector('[data-summary-types]');
+        const treemapEl = container.querySelector('[data-summary-treemap]');
+
+        if (!Array.isArray(products) || products.length === 0) {
+            if (totalEl) {
+                totalEl.textContent = 'No products summarized yet.';
+            }
+            renderSummaryChips(sourcesEl, []);
+            renderSummaryChips(typesEl, []);
+            if (treemapEl) {
+                treemapEl.innerHTML = '';
+            }
+            return;
+        }
+
+        const sourceCounts = new Map();
+        const typeCounts = new Map();
+        const sourceTypeCounts = new Map();
+
+        products.forEach(product => {
+            const category = product.category || 'Product';
+            const sourceId = product.sourceId || resourceId;
+            const sourceUrl = product.sourceUrl || resourceUrl;
+
+            if (!sourceCounts.has(sourceId)) {
+                sourceCounts.set(sourceId, {
+                    id: sourceId,
+                    url: sourceUrl,
+                    isCurrent: sourceId === resourceId,
+                    count: 0
+                });
+            }
+            sourceCounts.get(sourceId).count += 1;
+
+            if (!typeCounts.has(category)) {
+                typeCounts.set(category, {
+                    category,
+                    count: 0
+                });
+            }
+            typeCounts.get(category).count += 1;
+
+            if (!sourceTypeCounts.has(sourceId)) {
+                sourceTypeCounts.set(sourceId, new Map());
+            }
+
+            const nestedTypeCounts = sourceTypeCounts.get(sourceId);
+            if (!nestedTypeCounts.has(category)) {
+                nestedTypeCounts.set(category, {
+                    category,
+                    count: 0
+                });
+            }
+            nestedTypeCounts.get(category).count += 1;
+        });
+
+        const sourceEntries = Array.from(sourceCounts.values()).sort((a, b) => {
+            if (a.isCurrent !== b.isCurrent) {
+                return a.isCurrent ? -1 : 1;
+            }
+            if (b.count !== a.count) {
+                return b.count - a.count;
+            }
+            return a.id.localeCompare(b.id);
+        });
+
+        const typeEntries = Array.from(typeCounts.values()).sort((a, b) => {
+            if (b.count !== a.count) {
+                return b.count - a.count;
+            }
+            return getProductCategoryDisplayName(a.category, a.count)
+                .localeCompare(getProductCategoryDisplayName(b.category, b.count));
+        });
+
+        if (totalEl) {
+            const productCountLabel = products.length === 1 ? 'product' : 'products';
+            const sourceCountLabel = sourceEntries.length === 1 ? 'source' : 'sources';
+            const typeCountLabel = typeEntries.length === 1 ? 'product type' : 'product types';
+            totalEl.textContent = `${products.length} ${productCountLabel} across ${sourceEntries.length} ${sourceCountLabel} and ${typeEntries.length} ${typeCountLabel}.`;
+        }
+
+        renderSummaryChips(
+            sourcesEl,
+            sourceEntries.map(entry => ({
+                count: entry.count,
+                label: entry.isCurrent ? 'This Resource' : entry.id,
+                href: entry.isCurrent ? null : entry.url
+            }))
+        );
+
+        renderSummaryChips(
+            typesEl,
+            typeEntries.map(entry => ({
+                count: entry.count,
+                label: getProductCategoryDisplayName(entry.category, entry.count)
+            }))
+        );
+
+        renderResourceProductTreemap(treemapEl, {
+            products,
+            sourceEntries,
+            sourceTypeCounts
+        });
+    }
+
+    function renderSummaryChips(container, items) {
+        if (!container) {
+            return;
+        }
+
+        container.innerHTML = '';
+
+        if (!items || items.length === 0) {
+            const empty = document.createElement('span');
+            empty.className = 'resource-product-summary-empty';
+            empty.textContent = 'None.';
+            container.appendChild(empty);
+            return;
+        }
+
+        items.forEach(item => {
+            const chip = item.href ? document.createElement('a') : document.createElement('span');
+            chip.className = 'resource-product-summary-chip';
+
+            if (item.href) {
+                chip.href = item.href;
+            }
+
+            const count = document.createElement('span');
+            count.className = 'resource-product-summary-chip-count';
+            count.textContent = item.count;
+
+            const label = document.createElement('span');
+            label.className = 'resource-product-summary-chip-label';
+            label.textContent = item.label;
+
+            chip.appendChild(count);
+            chip.appendChild(label);
+            container.appendChild(chip);
+        });
+    }
+
+    function renderResourceProductTreemap(container, summary) {
+        if (!container) {
+            return;
+        }
+
+        container.innerHTML = '';
+
+        const width = Math.max(280, Math.floor(container.getBoundingClientRect().width) - 16);
+        const height = Math.max(
+            224,
+            Math.min(
+                340,
+                summary.sourceEntries.length * 56 + summary.products.length * 18 + 72
+            )
+        );
+
+        const hierarchyData = {
+            name: 'Products',
+            children: summary.sourceEntries.map(source => ({
+                name: source.isCurrent ? 'This Resource' : source.id,
+                sourceId: source.id,
+                value: source.count,
+                children: Array.from(summary.sourceTypeCounts.get(source.id).values())
+                    .sort((a, b) => {
+                        if (b.count !== a.count) {
+                            return b.count - a.count;
+                        }
+                        return getProductCategoryDisplayName(a.category, a.count)
+                            .localeCompare(getProductCategoryDisplayName(b.category, b.count));
+                    })
+                    .map(typeEntry => ({
+                        name: getProductCategoryDisplayName(typeEntry.category, typeEntry.count),
+                        category: typeEntry.category,
+                        sourceId: source.id,
+                        value: typeEntry.count
+                    }))
+            }))
+        };
+
+        const root = d3.hierarchy(hierarchyData)
+            .sum(d => d.value || 0)
+            .sort((a, b) => (b.value || 0) - (a.value || 0));
+
+        d3.treemap()
+            .size([width, height])
+            .paddingOuter(6)
+            .paddingInner(4)
+            .paddingTop(node => (node.depth === 1 ? 24 : 0))
+            .round(true)(root);
+
+        const svg = d3.select(container)
+            .append('svg')
+            .attr('viewBox', `0 0 ${width} ${height}`)
+            .attr('role', 'img')
+            .attr('aria-label', 'Products grouped by source and product type');
+
+        const sourcePalette = [
+            '#4c78a8',
+            '#f58518',
+            '#54a24b',
+            '#e45756',
+            '#72b7b2',
+            '#b279a2',
+            '#ff9da6',
+            '#9d755d'
+        ];
+
+        const sourceColor = d3.scaleOrdinal()
+            .domain(summary.sourceEntries.map(entry => entry.id))
+            .range(sourcePalette);
+
+        svg.append('g')
+            .selectAll('rect')
+            .data(root.children || [])
+            .enter()
+            .append('rect')
+            .attr('x', d => d.x0)
+            .attr('y', d => d.y0)
+            .attr('width', d => Math.max(0, d.x1 - d.x0))
+            .attr('height', d => Math.max(0, d.y1 - d.y0))
+            .attr('rx', 10)
+            .attr('ry', 10)
+            .attr('fill', 'none')
+            .attr('stroke', d => sourceColor(d.data.sourceId))
+            .attr('stroke-width', 1.5)
+            .attr('opacity', 0.55);
+
+        svg.append('g')
+            .selectAll('text')
+            .data((root.children || []).filter(d => (d.x1 - d.x0) > 96 && (d.y1 - d.y0) > 28))
+            .enter()
+            .append('text')
+            .attr('x', d => d.x0 + 8)
+            .attr('y', d => d.y0 + 16)
+            .attr('fill', d => sourceColor(d.data.sourceId))
+            .attr('font-size', 12)
+            .attr('font-weight', 700)
+            .text(d => truncateSummaryLabel(`${d.data.name} (${d.value})`, d.x1 - d.x0 - 12));
+
+        const leaves = svg.append('g')
+            .selectAll('g')
+            .data(root.leaves())
+            .enter()
+            .append('g');
+
+        leaves.append('rect')
+            .attr('x', d => d.x0)
+            .attr('y', d => d.y0)
+            .attr('width', d => Math.max(0, d.x1 - d.x0))
+            .attr('height', d => Math.max(0, d.y1 - d.y0))
+            .attr('rx', 8)
+            .attr('ry', 8)
+            .attr('fill', d => {
+                const base = d3.color(sourceColor(d.data.sourceId));
+                if (!base) {
+                    return '#d7e6f4';
+                }
+                base.opacity = 0.82;
+                return base.formatRgb();
+            })
+            .attr('stroke', '#ffffff')
+            .attr('stroke-width', 1.25);
+
+        leaves.append('title')
+            .text(d => `${d.data.value} ${d.data.name} from ${d.parent.data.name}`);
+
+        leaves.each(function(d) {
+            const leaf = d3.select(this);
+            const width = d.x1 - d.x0;
+            const height = d.y1 - d.y0;
+            const label = `${d.data.value} ${d.data.name}`;
+
+            if (width < 64 || height < 28) {
+                return;
+            }
+
+            const text = leaf.append('text')
+                .attr('x', d.x0 + 8)
+                .attr('y', d.y0 + 18)
+                .attr('fill', '#102a43')
+                .attr('font-size', width > 140 && height > 54 ? 13 : 11)
+                .attr('font-weight', 600);
+
+            if (width > 140 && height > 54) {
+                text.append('tspan')
+                    .attr('x', d.x0 + 8)
+                    .attr('dy', 0)
+                    .text(d.data.value);
+
+                text.append('tspan')
+                    .attr('x', d.x0 + 8)
+                    .attr('dy', 16)
+                    .text(truncateSummaryLabel(d.data.name, width - 16));
+            } else {
+                text.text(truncateSummaryLabel(label, width - 16));
+            }
+        });
+    }
 
     // Function to validate PROV export data
     function validateProvData(data) {

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -514,15 +514,7 @@
             nestedTypeCounts.get(category).count += 1;
         });
 
-        const sourceEntries = Array.from(sourceCounts.values()).sort((a, b) => {
-            if (a.isCurrent !== b.isCurrent) {
-                return a.isCurrent ? -1 : 1;
-            }
-            if (b.count !== a.count) {
-                return b.count - a.count;
-            }
-            return a.id.localeCompare(b.id);
-        });
+        const sourceEntries = sortTreemapSourceEntries(Array.from(sourceCounts.values()));
 
         const treemapSummary = buildTreemapSourceSummary(sourceEntries, sourceTypeCounts);
 
@@ -594,16 +586,7 @@
                 isAggregate: true,
                 count: aggregatedCount,
                 aggregatedSourceIds
-            }])
-            .sort((a, b) => {
-                if (a.isCurrent !== b.isCurrent) {
-                    return a.isCurrent ? -1 : 1;
-                }
-                if (b.count !== a.count) {
-                    return b.count - a.count;
-                }
-                return (a.name || a.id).localeCompare(b.name || b.id);
-            });
+            }]);
 
         const nextSourceTypeCounts = new Map();
         sourceTypeCounts.forEach((value, key) => {
@@ -614,9 +597,24 @@
         nextSourceTypeCounts.set('__other_resources__', aggregatedTypeCounts);
 
         return {
-            sourceEntries: nextSourceEntries,
+            sourceEntries: sortTreemapSourceEntries(nextSourceEntries),
             sourceTypeCounts: nextSourceTypeCounts
         };
+    }
+
+    function sortTreemapSourceEntries(sourceEntries) {
+        return [...sourceEntries].sort((a, b) => {
+            if (!!a.isCurrent !== !!b.isCurrent) {
+                return a.isCurrent ? -1 : 1;
+            }
+            if (!!a.isAggregate !== !!b.isAggregate) {
+                return a.isAggregate ? 1 : -1;
+            }
+            if (b.count !== a.count) {
+                return b.count - a.count;
+            }
+            return (a.name || a.id).localeCompare(b.name || b.id);
+        });
     }
 
     function renderResourceProductTreemap(container, summary) {
@@ -642,12 +640,13 @@
 
         const hierarchyData = {
             name: 'Products',
-            children: summary.sourceEntries.map(source => ({
+            children: summary.sourceEntries.map((source, index) => ({
                 name: source.name || (source.isCurrent ? 'This Resource' : source.id),
                 sourceId: source.id,
                 sourceUrl: source.url,
                 isCurrent: source.isCurrent,
                 isAggregate: source.isAggregate,
+                order: index,
                 aggregatedSourceIds: source.aggregatedSourceIds || [],
                 children: Array.from(summary.sourceTypeCounts.get(source.id).values())
                     .sort((a, b) => {
@@ -668,13 +667,27 @@
 
         const root = d3.hierarchy(hierarchyData)
             .sum(d => d.value || 0)
-            .sort((a, b) => (b.value || 0) - (a.value || 0));
+            .sort((a, b) => {
+                if (a.depth === 1 && b.depth === 1) {
+                    return (a.data.order || 0) - (b.data.order || 0);
+                }
+                return (b.value || 0) - (a.value || 0);
+            });
+
+        const sourceTile = d3.treemapSquarify.ratio(1.1);
 
         d3.treemap()
             .size([width, height])
             .paddingOuter(6)
             .paddingInner(4)
             .paddingTop(node => (node.depth === 1 ? 24 : 0))
+            .tile((node, x0, y0, x1, y1) => {
+                if (node.depth === 0) {
+                    d3.treemapDice(node, x0, y0, x1, y1);
+                } else {
+                    sourceTile(node, x0, y0, x1, y1);
+                }
+            })
             .round(true)(root);
 
         const svg = d3.select(container)

--- a/_layouts/resource_detail.html
+++ b/_layouts/resource_detail.html
@@ -236,19 +236,6 @@ layout: default
 	      <div class="card-body resource-product-summary"
 	        data-resource-id="{{ page.id }}"
 	        data-resource-url="{{ page.url | relative_url }}">
-	        <div class="resource-product-summary-copy">
-	          <p class="resource-product-summary-total mb-3" data-summary-total></p>
-	          <div class="resource-product-summary-lists">
-	            <div>
-	              <h5 class="resource-product-summary-heading">By source</h5>
-	              <div class="resource-product-summary-chips" data-summary-sources></div>
-	            </div>
-	            <div>
-	              <h5 class="resource-product-summary-heading">By type</h5>
-	              <div class="resource-product-summary-chips" data-summary-types></div>
-	            </div>
-	          </div>
-	        </div>
 	        <div class="resource-product-summary-chart">
 	          <div class="resource-product-summary-treemap" data-summary-treemap aria-label="Treemap of products by source and type"></div>
 	        </div>

--- a/_layouts/resource_detail.html
+++ b/_layouts/resource_detail.html
@@ -195,18 +195,72 @@ layout: default
       </div>
     </div>
 
-    {% if page.warnings %}
-    {% for warning in page.warnings %}
-    <div class="alert alert-warning" style="max-width: 72rem" role="alert">
-      ⚠ {{warning}}
-    </div>
-    {% endfor %}
-    {% endif %}
+	    {% if page.warnings %}
+	    {% for warning in page.warnings %}
+	    <div class="alert alert-warning" style="max-width: 72rem" role="alert">
+	      ⚠ {{warning}}
+	    </div>
+	    {% endfor %}
+	    {% endif %}
 
-    {% if page.contacts %}
-    <div class="card px-0" style="margin-bottom: 1.5em; max-width: 72rem" id="contacts">
-      <div class="card-header">
-        <h4><i class="bi bi-person-workspace"></i> Contacts</h4>
+	    {% if page.products and page.products.size > 0 %}
+	    {% capture resource_product_summary_json %}
+	    [
+	      {% for p in page.products %}
+	        {% assign first_segment = p.id | split: '.' | first %}
+	        {% assign summary_source_id = first_segment %}
+	        {% assign summary_source_url = "/resource/" | append: first_segment | append: "/" | append: first_segment | append: ".html" %}
+	        {% if p.secondary_source and p.secondary_source contains page.id %}
+	          {% assign summary_source_id = page.id %}
+	          {% assign summary_source_url = page.url %}
+	        {% elsif p.secondary_source %}
+	          {% assign summary_source_id = p.secondary_source | first %}
+	          {% assign summary_source_url = "/resource/" | append: summary_source_id | append: "/" | append: summary_source_id | append: ".html" %}
+	        {% elsif p.id == page.id or first_segment == page.id %}
+	          {% assign summary_source_id = page.id %}
+	          {% assign summary_source_url = page.url %}
+	        {% endif %}
+	        {
+	          "id": {{ p.id | jsonify }},
+	          "category": {{ p.category | default: "Product" | jsonify }},
+	          "sourceId": {{ summary_source_id | jsonify }},
+	          "sourceUrl": {{ summary_source_url | relative_url | jsonify }}
+	        }{% unless forloop.last %},{% endunless %}
+	      {% endfor %}
+	    ]
+	    {% endcapture %}
+	    <div class="card px-0 resource-product-summary-card" style="margin-bottom: 1.5em; max-width: 72rem" id="product-summary">
+	      <div class="card-header">
+	        <h4><i class="bi bi-grid-1x2-fill"></i> Product Summary</h4>
+	      </div>
+	      <div class="card-body resource-product-summary"
+	        data-resource-id="{{ page.id }}"
+	        data-resource-url="{{ page.url | relative_url }}">
+	        <div class="resource-product-summary-copy">
+	          <p class="resource-product-summary-total mb-3" data-summary-total></p>
+	          <div class="resource-product-summary-lists">
+	            <div>
+	              <h5 class="resource-product-summary-heading">By source</h5>
+	              <div class="resource-product-summary-chips" data-summary-sources></div>
+	            </div>
+	            <div>
+	              <h5 class="resource-product-summary-heading">By type</h5>
+	              <div class="resource-product-summary-chips" data-summary-types></div>
+	            </div>
+	          </div>
+	        </div>
+	        <div class="resource-product-summary-chart">
+	          <div class="resource-product-summary-treemap" data-summary-treemap aria-label="Treemap of products by source and type"></div>
+	        </div>
+	        <script type="application/json" class="resource-product-summary-data">{{ resource_product_summary_json | strip }}</script>
+	      </div>
+	    </div>
+	    {% endif %}
+
+	    {% if page.contacts %}
+	    <div class="card px-0" style="margin-bottom: 1.5em; max-width: 72rem" id="contacts">
+	      <div class="card-header">
+	        <h4><i class="bi bi-person-workspace"></i> Contacts</h4>
       </div>
       <div class="list-group list-group-flush">
         {% for c in page.contacts %}


### PR DESCRIPTION
This pull request introduces a new "Product Summary" section to the Resource detail page, providing a visual treemap summary of related products. It also adds the necessary CSS styles to support the new summary card and treemap visualization.

**Feature Addition: Product Summary Section**

* Adds a "Product Summary" card to the resource detail page (`_layouts/resource_detail.html`), which displays a treemap visualization of related products if any exist. The section includes logic to generate a JSON data structure summarizing the products by category and source.

**Styling and Layout Enhancements**

* Introduces new CSS classes for the product summary card and treemap visualization in `_includes/head.html`, including layout, border, background gradients, and responsive sizing for the treemap SVG.