### PR TITLE
Address AOP-Wiki and AOP-DB metadata

### DIFF
--- a/resource/aop-db/aop-db.md
+++ b/resource/aop-db/aop-db.md
@@ -16,10 +16,13 @@ description: The Adverse Outcome Pathway Database (AOP-DB) is an EPA-developed i
   to human health and ecological risk assessment. It harmonizes data from toxicology,
   high‑throughput screening, pathway, gene/protein, and phenotype resources to enable
   computational toxicology, mode-of-action analysis, and predictive risk prioritization.
-domains: []
+domains:
+- toxicology
+- environment
+- pathways
 homepage_url: https://www.epa.gov/healthresearch/adverse-outcome-pathway-database-aop-db
 id: aop-db
-last_modified_date: '2025-09-04T00:00:00Z'
+last_modified_date: '2026-05-04T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.epa.gov/healthresearch/adverse-outcome-pathway-database-aop-db
@@ -35,6 +38,19 @@ products:
   original_source:
   - aop-db
   product_url: https://www.epa.gov/healthresearch/adverse-outcome-pathway-database-aop-db
+- category: ProgrammingInterface
+  connection_url: https://aopdb.rdf.bigcat-bioinformatics.org/
+  description: OpenRiskNet Virtuoso SPARQL endpoint loaded with RDF of the EPA AOP-DB
+    for querying integrated AOP, gene, chemical, disease, tissue, pathway, orthology,
+    ontology, and gene interaction relationships.
+  format: http
+  id: aop-db.sparql
+  is_public: true
+  name: AOP-DB SPARQL Endpoint
+  original_source:
+  - aop-db
+  - aop-wiki
+  product_url: https://openrisknet.org/e-infrastructure/services/147/
 - category: Product
   description: The EPA has developed the Adverse Outcome Pathway Database (AOP-DB)
     to better characterize adverse outcomes of toxicological interest that are relevant
@@ -167,8 +183,33 @@ products:
   secondary_source:
   - alzkb
   - hetionet
+publications:
+- authors:
+  - Mortensen HM
+  - Senn J
+  - Levey T
+  - Langley P
+  - Williams AJ
+  doi: 10.1038/s41597-021-00962-3
+  id: doi:10.1038/s41597-021-00962-3
+  journal: Scientific Data
+  preferred: true
+  title: The 2021 update of the EPA's adverse outcome pathway database
+  year: '2021'
+- authors:
+  - Pittman ME
+  - Edwards SW
+  - Ives C
+  - Mortensen HM
+  doi: 10.1016/j.taap.2018.02.006
+  id: doi:10.1016/j.taap.2018.02.006
+  journal: Toxicology and Applied Pharmacology
+  title: 'AOP-DB: A database resource for the exploration of Adverse Outcome Pathways
+    through integrated association networks'
+  year: '2018'
 taxon:
 - NCBITaxon:9606
+version: '2'
 ---
 # AOP-DB
 

--- a/resource/aop-wiki/aop-wiki.md
+++ b/resource/aop-wiki/aop-wiki.md
@@ -16,10 +16,13 @@ description: The AOP-Wiki is the primary collaborative authoring and curation in
   initiating events through key events to adverse outcomes relevant to human and ecological
   risk assessment. Structured exports (XML and tabular subsets) support computational
   toxicology, ontology mapping, and integration into predictive assessment workflows.
-domains: []
+domains:
+- toxicology
+- environment
+- pathways
 homepage_url: https://aopwiki.org/
 id: aop-wiki
-last_modified_date: '2025-09-04T00:00:00Z'
+last_modified_date: '2026-05-04T00:00:00Z'
 layout: resource_detail
 license:
   id: https://aopwiki.org/
@@ -35,11 +38,24 @@ products:
   original_source:
   - aop-wiki
   product_url: https://aopwiki.org/
+- category: ProgrammingInterface
+  connection_url: https://aopwiki-rdf.prod.openrisknet.org/
+  description: OpenRiskNet SPARQL endpoint loaded with RDF converted from AOP-Wiki
+    quarterly XML dumps for querying AOPs, key events, key event relationships,
+    and stressors.
+  format: http
+  id: aop-wiki.sparql
+  is_public: true
+  name: AOP-Wiki SPARQL Endpoint
+  original_source:
+  - aop-wiki
+  product_url: https://openrisknet.org/e-infrastructure/services/133/
 - category: Product
   description: Quarterly permanent XML snapshot (versioned) of AOP-Wiki content suitable
     for citation and archival use
   format: xml
   id: aop-wiki.quarterly-xml
+  latest_version: '2026-04-01'
   name: AOP-Wiki Quarterly XML Snapshot
   original_source:
   - aop-wiki
@@ -199,6 +215,7 @@ products:
   - aop-db
 taxon:
 - NCBITaxon:9606
+version: '2.8'
 ---
 # AOP-Wiki
 


### PR DESCRIPTION
## Summary
- adds toxicology/environment/pathway domains and current version metadata for AOP-Wiki and AOP-DB
- adds OpenRiskNet SPARQL interface products for AOP-Wiki and AOP-DB
- adds confirmed AOP-DB publications

Closes #493

## Validation
- uv run make validate-file FILE=resource/aop-wiki/aop-wiki.md
- uv run make validate-file FILE=resource/aop-db/aop-db.md
- git diff --check