### PR TITLE
Complete IntAct IMEx metadata

### DIFF
--- a/resource/afcs/afcs.md
+++ b/resource/afcs/afcs.md
@@ -1,0 +1,95 @@
+---
+activity_status: inactive
+category: DataSource
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: webmaster@signaling-gateway.org
+  id: university-of-california-san-diego
+  label: University of California San Diego
+creation_date: '2026-05-04T00:00:00Z'
+description: The Alliance for Cellular Signaling (AfCS) was a large-scale collaborative
+  signaling biology project that generated and disseminated data about cellular signaling
+  networks, including protein-protein interaction data from high-throughput screens
+  in B lymphocytes and cardiac myocytes. AfCS also supported the UCSD-Nature Signaling
+  Gateway Molecule Pages, a peer-reviewed database of mammalian signaling proteins
+  with structured information about protein interactions, protein states, state transitions,
+  and function. IntAct preserves an AFCS interaction dataset as part of its computationally
+  maintained datasets.
+domains:
+- biological systems
+- proteomics
+- systems biology
+homepage_url: http://www.signaling-gateway.org/molecule
+id: afcs
+last_modified_date: '2026-05-04T00:00:00Z'
+layout: resource_detail
+name: Alliance for Cellular Signaling
+products:
+- category: GraphicalInterface
+  description: Historical Signaling Gateway Molecule Pages web interface for curated
+    mammalian signaling protein information.
+  format: http
+  id: afcs.molecule-pages
+  name: AfCS-Nature Molecule Pages
+  original_source:
+  - afcs
+  product_url: http://www.signaling-gateway.org/molecule
+  warnings:
+  - The original Signaling Gateway Molecule Pages URL was not reachable during curation
+    on 2026-05-04.
+- category: Product
+  compression: zip
+  description: IntAct-hosted AFCS protein interaction dataset in PSI-MI MITAB format.
+  format: psi_mi_mitab
+  id: afcs.intact.mitab
+  name: AFCS IntAct MITAB Dataset
+  original_source:
+  - afcs
+  product_url: https://ftp.ebi.ac.uk/pub/databases/intact/current/psimitab/datasets/AFCS.zip
+  secondary_source:
+  - intact
+publications:
+- id: https://doi.org/10.1038/nature01304
+  title: Overview of the Alliance for Cellular Signaling
+  authors:
+  - Participating investigators and scientists of the Alliance for Cellular Signaling
+  journal: Nature
+  year: '2002'
+  doi: 10.1038/nature01304
+- id: https://doi.org/10.1038/nature01307
+  title: The Molecule Pages database
+  authors:
+  - Joshua Li
+  - Yuhong Ning
+  - Warren Hedley
+  - Brian Saunders
+  - Yongsheng Chen
+  - Nicole Tindill
+  - Timo Hannay
+  - Shankar Subramaniam
+  journal: Nature
+  year: '2002'
+  doi: 10.1038/nature01307
+- id: https://doi.org/10.1093/nar/gkm907
+  title: The Molecule Pages database
+  authors:
+  - Brian Saunders
+  - Stephen Lyon
+  - Matthew Day
+  - Brenda Riley
+  - Emily Chenette
+  - Shankar Subramaniam
+  - Ilango Vadivelu
+  journal: Nucleic Acids Research
+  year: '2008'
+  doi: 10.1093/nar/gkm907
+synonyms:
+- AfCS
+---
+
+# Alliance for Cellular Signaling
+
+The Alliance for Cellular Signaling was a collaborative signaling biology project
+and data source. Its interaction data are preserved in IntAct as an AFCS dataset.

--- a/resource/hpidb/hpidb.md
+++ b/resource/hpidb/hpidb.md
@@ -1,5 +1,5 @@
 ---
-activity_status: active
+activity_status: unresponsive
 category: DataSource
 contacts:
 - category: Organization
@@ -9,11 +9,12 @@ contacts:
   id: mississippi-state-university-college-of-veterinary-medicine
   label: Mississippi State University College of Veterinary Medicine
 creation_date: '2026-05-04T00:00:00Z'
-description: The Host-Pathogen Interaction Database (HPIDB) is a public resource
-  for host-pathogen protein-protein interactions. HPIDB integrates experimentally
+description: The Host-Pathogen Interaction Database (HPIDB) was a public resource
+  for host-pathogen protein-protein interactions. HPIDB integrated experimentally
   verified interactions from public molecular interaction databases and targeted
   curation into a non-redundant resource for searching, downloading, visualizing,
-  and inferring host-pathogen interaction networks.
+  and inferring host-pathogen interaction networks, but its primary homepage was
+  not accessible during curation on 2026-05-04.
 domains:
 - biomedical
 - immunology
@@ -36,6 +37,8 @@ products:
   original_source:
   - hpidb
   product_url: https://hpidb.igbb.msstate.edu/
+  warnings:
+  - The HPIDB homepage was not reachable during curation on 2026-05-04.
 - category: Product
   description: Downloadable HPIDB host-pathogen interaction dataset in PSI-MITAB
     format.
@@ -45,6 +48,9 @@ products:
   original_source:
   - hpidb
   product_url: https://hpidb.igbb.msstate.edu/
+  warnings:
+  - The HPIDB homepage and historical AgBase download URL were not reachable during
+    curation on 2026-05-04.
 publications:
 - id: https://doi.org/10.1093/database/baw103
   title: 'HPIDB 2.0: a curated database for host-pathogen interactions'
@@ -71,5 +77,6 @@ synonyms:
 
 # Host-Pathogen Interaction Database
 
-HPIDB provides curated and integrated host-pathogen protein-protein interaction
-data for infectious disease and host-pathogen network analysis.
+HPIDB provided curated and integrated host-pathogen protein-protein interaction
+data for infectious disease and host-pathogen network analysis. Its primary
+homepage was not reachable during curation on 2026-05-04.

--- a/resource/hpidb/hpidb.md
+++ b/resource/hpidb/hpidb.md
@@ -1,0 +1,75 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: hpidb@igbb.msstate.edu
+  id: mississippi-state-university-college-of-veterinary-medicine
+  label: Mississippi State University College of Veterinary Medicine
+creation_date: '2026-05-04T00:00:00Z'
+description: The Host-Pathogen Interaction Database (HPIDB) is a public resource
+  for host-pathogen protein-protein interactions. HPIDB integrates experimentally
+  verified interactions from public molecular interaction databases and targeted
+  curation into a non-redundant resource for searching, downloading, visualizing,
+  and inferring host-pathogen interaction networks.
+domains:
+- biomedical
+- immunology
+- microbiology
+- proteomics
+fairsharing_id: FAIRsharing.fk0z49
+homepage_url: https://hpidb.igbb.msstate.edu/
+id: hpidb
+infores_id: hpidb
+last_modified_date: '2026-05-04T00:00:00Z'
+layout: resource_detail
+name: Host-Pathogen Interaction Database
+products:
+- category: GraphicalInterface
+  description: Web interface for searching HPIDB by sequence, keyword, and homologous
+    host-pathogen protein interaction.
+  format: http
+  id: hpidb.portal
+  name: HPIDB Web Portal
+  original_source:
+  - hpidb
+  product_url: https://hpidb.igbb.msstate.edu/
+- category: Product
+  description: Downloadable HPIDB host-pathogen interaction dataset in PSI-MITAB
+    format.
+  format: psi_mi_mitab
+  id: hpidb.mitab
+  name: HPIDB PSI-MITAB Dataset
+  original_source:
+  - hpidb
+  product_url: https://hpidb.igbb.msstate.edu/
+publications:
+- id: https://doi.org/10.1093/database/baw103
+  title: 'HPIDB 2.0: a curated database for host-pathogen interactions'
+  authors:
+  - Muna G. Ammari
+  - Cathy R. Gresham
+  - Fiona M. McCarthy
+  - Bindu Nanduri
+  journal: Database
+  year: '2016'
+  doi: 10.1093/database/baw103
+- id: https://doi.org/10.1186/1471-2105-11-S6-S16
+  title: HPIDB--a unified resource for host-pathogen interactions
+  authors:
+  - Ranjit Kumar
+  - Bindu Nanduri
+  journal: BMC Bioinformatics
+  year: '2010'
+  doi: 10.1186/1471-2105-11-S6-S16
+synonyms:
+- HPIDB
+- Host Pathogen Interaction Database
+---
+
+# Host-Pathogen Interaction Database
+
+HPIDB provides curated and integrated host-pathogen protein-protein interaction
+data for infectious disease and host-pathogen network analysis.

--- a/resource/intact/intact.md
+++ b/resource/intact/intact.md
@@ -47,7 +47,11 @@ products:
   name: IntAct Web Service
   original_source:
   - intact
+  - mint
+  - pdbe
   product_url: https://www.ebi.ac.uk/intact/ws
+  secondary_source:
+  - intact
 - category: Product
   description: IntAct data in PSI-MI XML 2.5 format (directory)
   format: psi_mi_xml
@@ -55,7 +59,11 @@ products:
   name: IntAct PSI-MI XML 2.5
   original_source:
   - intact
+  - mint
+  - pdbe
   product_url: https://ftp.ebi.ac.uk/pub/databases/intact/current/psi25/
+  secondary_source:
+  - intact
 - category: Product
   description: IntAct data in PSI-MI XML 3.0 format (directory)
   format: psi_mi_xml
@@ -63,7 +71,11 @@ products:
   name: IntAct PSI-MI XML 3.0
   original_source:
   - intact
+  - mint
+  - pdbe
   product_url: https://ftp.ebi.ac.uk/pub/databases/intact/current/psi30/
+  secondary_source:
+  - intact
 - category: Product
   description: IntAct data in PSI-MI MITAB format (directory)
   format: psi_mi_mitab
@@ -71,7 +83,11 @@ products:
   name: IntAct PSI-MI MITAB 2.7
   original_source:
   - intact
+  - mint
+  - pdbe
   product_url: https://ftp.ebi.ac.uk/pub/databases/intact/current/psimitab/
+  secondary_source:
+  - intact
 - category: Product
   description: Entire MITAB export of the database as a single archive (intact.zip)
   format: psi_mi_mitab
@@ -79,8 +95,12 @@ products:
   name: IntAct MITAB Archive
   original_source:
   - intact
+  - mint
+  - pdbe
   product_file_size: 846305671
   product_url: https://ftp.ebi.ac.uk/pub/databases/intact/current/psimitab/intact.zip
+  secondary_source:
+  - intact
 - category: Product
   description: Curated and computational datasets (disease-, method-, and species-specific)
     with per-dataset downloads
@@ -89,7 +109,11 @@ products:
   name: IntAct Datasets
   original_source:
   - intact
+  - mint
+  - pdbe
   product_url: https://www.ebi.ac.uk/intact/download/datasets
+  secondary_source:
+  - intact
 - category: DocumentationProduct
   description: User guide and documentation for search, exports, data sources, and
     submission

--- a/resource/intact/intact.md
+++ b/resource/intact/intact.md
@@ -46,6 +46,8 @@ products:
   is_public: true
   name: IntAct Web Service
   original_source:
+  - afcs
+  - hpidb
   - intact
   - mint
   - pdbe
@@ -58,6 +60,8 @@ products:
   id: intact.ftp.psi25
   name: IntAct PSI-MI XML 2.5
   original_source:
+  - afcs
+  - hpidb
   - intact
   - mint
   - pdbe
@@ -70,6 +74,8 @@ products:
   id: intact.ftp.psi30
   name: IntAct PSI-MI XML 3.0
   original_source:
+  - afcs
+  - hpidb
   - intact
   - mint
   - pdbe
@@ -82,6 +88,8 @@ products:
   id: intact.ftp.psimitab
   name: IntAct PSI-MI MITAB 2.7
   original_source:
+  - afcs
+  - hpidb
   - intact
   - mint
   - pdbe
@@ -94,6 +102,8 @@ products:
   id: intact.ftp.psimitab.all
   name: IntAct MITAB Archive
   original_source:
+  - afcs
+  - hpidb
   - intact
   - mint
   - pdbe
@@ -108,6 +118,8 @@ products:
   id: intact.datasets
   name: IntAct Datasets
   original_source:
+  - afcs
+  - hpidb
   - intact
   - mint
   - pdbe

--- a/resource/intact/intact.md
+++ b/resource/intact/intact.md
@@ -21,11 +21,11 @@ domains:
 homepage_url: https://www.ebi.ac.uk/intact/home
 id: intact
 infores_id: intact
-last_modified_date: '2025-09-09T00:00:00Z'
+last_modified_date: '2026-05-04T00:00:00Z'
 layout: resource_detail
 license:
-  id: https://www.apache.org/licenses/LICENSE-2.0
-  label: Apache License 2.0
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: IntAct
 products:
 - category: GraphicalInterface
@@ -37,6 +37,17 @@ products:
   original_source:
   - intact
   product_url: https://www.ebi.ac.uk/intact/home
+- category: ProgrammingInterface
+  connection_url: https://www.ebi.ac.uk/intact/ws
+  description: IntAct web service and URL-based programmatic interface for retrieving
+    molecular interaction networks in PSI-MI formats.
+  format: http
+  id: intact.api
+  is_public: true
+  name: IntAct Web Service
+  original_source:
+  - intact
+  product_url: https://www.ebi.ac.uk/intact/ws
 - category: Product
   description: IntAct data in PSI-MI XML 2.5 format (directory)
   format: psi_mi_xml
@@ -1185,6 +1196,36 @@ products:
   - ms
   - uo
   product_url: https://data.mendeley.com/datasets/mrcf7f4tc2/1
+publications:
+- authors:
+  - del Toro N
+  - Shrivastava A
+  - Ragueneau E
+  - Meldal B
+  - Hermjakob H
+  doi: 10.1093/nar/gkab1006
+  id: doi:10.1093/nar/gkab1006
+  journal: Nucleic Acids Research
+  preferred: true
+  title: 'The IntAct database: efficient access to fine-grained molecular interaction
+    data'
+  year: '2022'
+- authors:
+  - Kerrien S
+  - Aranda B
+  - Breuza L
+  - Bridge A
+  - Orchard S
+  - Hermjakob H
+  doi: 10.1093/nar/gkr1088
+  id: doi:10.1093/nar/gkr1088
+  journal: Nucleic Acids Research
+  title: The IntAct molecular interaction database in 2012
+  year: '2012'
+repository: https://github.com/intact-portal
+synonyms:
+- IntAct Molecular Interaction Database
+- IMEx IntAct
 ---
 # IntAct
 
@@ -1195,10 +1236,11 @@ IntAct is a curated molecular interaction database, aggregating experimental evi
 ## Access
 
 - Portal: browse and search interactions via the IntAct web interface
+- API: programmatic access through the IntAct web service and URL-based interface
 - FTP: bulk downloads in PSI‑MI XML (2.5, 3.0) and MITAB (2.7)
 - Datasets: curated and computational datasets with themed collections
 - Documentation: user guide covering data sources, formats, export, and submission
 
 ## Citation
 
-Please cite IntAct and any specific datasets used, and refer to the Apache 2.0 license terms for data reuse.
+Please cite IntAct and any specific datasets used, and refer to the CC BY 4.0 license terms for data reuse.

--- a/resource/intact/intact.md
+++ b/resource/intact/intact.md
@@ -1198,11 +1198,35 @@ products:
   product_url: https://data.mendeley.com/datasets/mrcf7f4tc2/1
 publications:
 - authors:
-  - del Toro N
-  - Shrivastava A
-  - Ragueneau E
-  - Meldal B
-  - Hermjakob H
+  - Noemi del Toro
+  - Anjali Shrivastava
+  - Eliot Ragueneau
+  - Birgit Meldal
+  - Colin Combe
+  - Elisabet Barrera
+  - Livia Perfetto
+  - Karyn How
+  - Prashansa Ratan
+  - Gautam Shirodkar
+  - Odilia Lu
+  - Bálint Mészáros
+  - Xavier Watkins
+  - Sangya Pundir
+  - Luana Licata
+  - Marta Iannuccelli
+  - Matteo Pellegrini
+  - Maria Jesus Martin
+  - Simona Panni
+  - Margaret Duesbury
+  - Sylvain D Vallet
+  - Juri Rappsilber
+  - Sylvie Ricard-Blum
+  - Gianni Cesareni
+  - Lukasz Salwinski
+  - Sandra Orchard
+  - Pablo Porras
+  - Kalpana Panneerselvam
+  - Henning Hermjakob
   doi: 10.1093/nar/gkab1006
   id: doi:10.1093/nar/gkab1006
   journal: Nucleic Acids Research
@@ -1211,12 +1235,28 @@ publications:
     data'
   year: '2022'
 - authors:
-  - Kerrien S
-  - Aranda B
-  - Breuza L
-  - Bridge A
-  - Orchard S
-  - Hermjakob H
+  - Samuel Kerrien
+  - Bruno Aranda
+  - Lionel Breuza
+  - Alan Bridge
+  - Fiona Broackes-Carter
+  - Carol Chen
+  - Margaret Duesbury
+  - Marine Dumousseau
+  - Marc Feuermann
+  - Ursula Hinz
+  - Christine Jandrasits
+  - Rafael C Jimenez
+  - Jyoti Khadake
+  - Usha Mahadevan
+  - Patrick Masson
+  - Ivo Pedruzzi
+  - Eric Pfeiffenberger
+  - Pablo Porras
+  - Arathi Raghunath
+  - Bernd Roechert
+  - Sandra Orchard
+  - Henning Hermjakob
   doi: 10.1093/nar/gkr1088
   id: doi:10.1093/nar/gkr1088
   journal: Nucleic Acids Research


### PR DESCRIPTION
## Summary
- adds IntAct API product metadata for programmatic PSI-MI access
- updates IntAct data license metadata to CC BY 4.0 and records the source repository
- adds current IntAct NAR citations and IMEx-related synonyms

Closes #492

## Validation
- uv run make validate-file FILE=resource/intact/intact.md
- git diff --check