### PR TITLE
Add skills for agentic curation

### DIFF
--- a/.agents/commands/curate-next.md
+++ b/.agents/commands/curate-next.md
@@ -1,0 +1,8 @@
+---
+description: Curate the next N stub resources from KG-Registry, skipping resources already logged as blocked in reports/curation_problems.tsv.
+argument-hint: [N]
+---
+
+Curate the next $ARGUMENTS stub resources.
+
+IMPORTANT: you MUST consult the curate-next skill for selection, dispatch, and validation instructions.

--- a/.agents/commands/curate-next.md
+++ b/.agents/commands/curate-next.md
@@ -5,4 +5,6 @@ argument-hint: [N]
 
 Curate the next $ARGUMENTS stub resources.
 
+PREREQUISITE: this workflow must be run from a local clone of the KG-Registry repository. These curation steps depend on editing and validating files in a checked-out working copy.
+
 IMPORTANT: you MUST consult the curate-next skill for selection, dispatch, and validation instructions.

--- a/.agents/commands/curate.md
+++ b/.agents/commands/curate.md
@@ -5,6 +5,8 @@ argument-hint: [RESOURCE_ID_OR_NAME]
 
 Curate the resource specified in $ARGUMENTS.
 
+PREREQUISITE: this workflow must be run from a local clone of the KG-Registry repository. These curation steps depend on editing and validating files in a checked-out working copy.
+
 IMPORTANT: you MUST consult the kg-registry-curation skill for the full workflow.
 
 Use the existing page in `resource/<id>/<id>.md` when one already exists. Keep the work focused on the named resource, validate the file before finishing, and do not edit anything under `registry/`.

--- a/.agents/commands/curate.md
+++ b/.agents/commands/curate.md
@@ -1,0 +1,10 @@
+---
+description: Curate a given KG-Registry resource page, either by expanding a stub entry or improving an existing page.
+argument-hint: [RESOURCE_ID_OR_NAME]
+---
+
+Curate the resource specified in $ARGUMENTS.
+
+IMPORTANT: you MUST consult the kg-registry-curation skill for the full workflow.
+
+Use the existing page in `resource/<id>/<id>.md` when one already exists. Keep the work focused on the named resource, validate the file before finishing, and do not edit anything under `registry/`.

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rg:*)",
+      "Bash(cut:*)",
+      "Bash(sort:*)",
+      "Bash(find resource:*)",
+      "Bash(uv run make validate-file:*)",
+      "Bash(uv run make prettify-file:*)",
+      "Bash(cat reports/curation_problems.tsv:*)",
+      "Bash(git diff:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)"
+    ]
+  }
+}

--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -5,6 +5,7 @@
       "Bash(cut:*)",
       "Bash(sort:*)",
       "Bash(find resource:*)",
+      "Bash(curl:*)",
       "Bash(uv run make validate-file:*)",
       "Bash(uv run make prettify-file:*)",
       "Bash(cat reports/curation_problems.tsv:*)",

--- a/.agents/skills/curate-next/SKILL.md
+++ b/.agents/skills/curate-next/SKILL.md
@@ -7,6 +7,12 @@ description: Use when asked to curate the next N KG-Registry stub resources. Sel
 
 Curate the next N stub resources in KG-Registry.
 
+## Prerequisite
+
+- Run this skill only from a local clone of the KG-Registry repository.
+- The workflow depends on scanning local files under `resource/`, reading `reports/curation_problems.tsv`, editing checked-out pages, and running local validation commands.
+- If the repository is not cloned locally, stop and clone it before attempting batch curation.
+
 ## When to use
 
 - "Curate the next 3 stub resources"

--- a/.agents/skills/curate-next/SKILL.md
+++ b/.agents/skills/curate-next/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: curate-next
+description: Use when asked to curate the next N KG-Registry stub resources. Selects uncatalogued stub pages not already listed in reports/curation_problems.tsv and dispatches single-resource curation in parallel.
+---
+
+# curate-next
+
+Curate the next N stub resources in KG-Registry.
+
+## When to use
+
+- "Curate the next 3 stub resources"
+- "/curate-next 5"
+- "Work through a batch of KG-Registry stubs"
+
+Skip when:
+
+- The user names a specific resource. Use the single-resource curation workflow instead.
+- The task is to generate new stub pages. That is a separate maintenance flow.
+- The task is purely about reviewing `reports/curation_problems.tsv` without curating pages.
+
+## Inputs
+
+- Required positional argument `N`: number of resources to curate.
+- `N` must be a positive integer between 1 and 5 inclusive.
+- If `N` is missing, non-integer, `<= 0`, or `> 5`, ask the user to clarify rather than guessing.
+
+The cap keeps the batch small enough to curate, validate, and summarize cleanly.
+
+## Workflow
+
+1. Validate `N`.
+   - Never default to a value the user did not provide.
+
+2. Build the candidate stub list.
+   - Find stub pages from `resource/` by looking for `stub` in the `domains` list.
+   - Prefer a command such as:
+     ```bash
+     rg -l '^\s*-\s*stub\s*$' resource
+     ```
+   - Sort the results for deterministic selection.
+
+3. Exclude resources already logged as blocked.
+   - Read `reports/curation_problems.tsv` and collect the `resource_id` values from the first column.
+   - Drop any candidate whose directory or file stem matches an existing blocked `resource_id`.
+
+4. Select the next `N` candidates.
+   - Use the first `N` survivors after sorting.
+   - If fewer than `N` candidates remain, do not pad with blocked or non-stub files. Report the shortfall.
+
+5. Dispatch single-resource curation.
+   - For each selected resource, invoke the `kg-registry-curation` workflow.
+   - If the environment supports parallel sub-agents safely, dispatch the selected resources in parallel.
+   - If parallel execution is used, isolate each worker from the others before editing. Separate git worktrees are preferred for true parallel edits.
+   - Keep each worker focused on one resource file and its direct validation.
+   - Make it explicit in each dispatched prompt that web search will likely be necessary for stub expansion and provenance resolution.
+   - Make it explicit in each dispatched prompt that `original_source` and `secondary_source` must use KG-Registry identifiers, minting a new unique KG-Registry ID when an upstream resource is referenced but not yet present in the registry.
+
+6. Validate each curated file.
+   - Each resource must pass `uv run make validate-file FILE=<target-file>` before being reported complete.
+   - If prettification changes the file, validate again afterward.
+   - Use the `kg-registry-validation` skill for the post-edit validation workflow when additional checking is needed.
+
+7. Report outcomes.
+   - List curated resources and whether each completed successfully.
+   - List blocked resources and whether they were logged to `reports/curation_problems.tsv`.
+   - State any shortfall if fewer than `N` resources were actually curated.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| List stub files | `rg -l '^\s*-\s*stub\s*$' resource | sort` |
+| View blocked resource IDs | `cut -f1 reports/curation_problems.tsv` |
+| Validate one curated file | `uv run make validate-file FILE=resource/<id>/<id>.md` |
+
+## Common mistakes
+
+- Treating every incomplete page as a stub. This workflow is driven specifically by `domains` containing `stub`.
+- Re-curating resources already documented in `reports/curation_problems.tsv`.
+- Padding the batch with arbitrary resources when fewer than `N` valid stub candidates remain.
+- Dispatching multiple curations into one shared working tree without isolation.
+- Dispatching workers without telling them to use web search when the stub itself lacks enough evidence.
+- Letting workers write provenance with raw labels or URLs instead of KG-Registry IDs.
+- Reporting success before each file has passed validation.
+
+## Relationship to other skills
+
+- `kg-registry-curation` performs the actual per-resource edit and validation steps.
+- `kg-registry-validation` performs the focused validation and quality checks for curated files.
+- `curate-next` is the batch selector and dispatcher.

--- a/.agents/skills/kg-registry-curation/SKILL.md
+++ b/.agents/skills/kg-registry-curation/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: kg-registry-curation
+description: Use when curating or expanding a KG-Registry resource page. Applies to stub resources and incomplete existing pages stored as Markdown with YAML front matter under resource/.
+---
+
+# kg-registry-curation
+
+Curate a single KG-Registry resource page end to end.
+
+## When to use
+
+- The user names a specific resource to curate.
+- The user asks to expand a stub entry in `resource/`.
+- The user asks to improve metadata completeness for one existing resource page.
+- A batch workflow has already selected a specific target file and now needs the single-resource curation procedure.
+
+Skip when:
+
+- The task is about generated outputs under `registry/`.
+- The task is about schema code changes rather than resource metadata.
+- The task is about creating standalone Product pages. KG-Registry product pages are generated automatically from the parent Resource entry.
+
+## Inputs
+
+- Required: a resource identifier, resource name, or direct resource file path.
+- Preferred final target: exactly one file under `resource/<id>/<id>.md`.
+
+If the input is ambiguous, resolve it before editing. Do not guess between multiple candidate resources.
+
+## Workflow
+
+1. Resolve the target file.
+   - If the user gave a path, use it directly.
+   - If the user gave an ID or name, find the matching file under `resource/`.
+   - Read the current file first and confirm whether it is a stub or an incomplete curated page.
+
+2. Confirm the governing constraints before editing.
+   - Follow the LinkML schema in `src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml`.
+   - Do not invent enum values, categories, or product types not present in the schema.
+   - Do not edit anything under `registry/`; those files are generated.
+   - Do not create standalone Product files.
+   - Ensure the resource retains at least one `products` entry.
+   - Do not fill in the `curators` field.
+   - Treat `creation_date` as the date the KG-Registry metadata page was created.
+   - Set `last_modified_date` to today when making updates.
+
+3. Gather only the minimum evidence needed for this resource.
+   - Start from the page's existing metadata, especially `homepage_url`, `repository`, existing products, publications, and warnings.
+   - Use similar curated files in `resource/` as structural examples.
+   - Prefer the resource homepage, project documentation, repository, and authoritative download/API pages over broad research.
+   - Expect web search to be necessary for many stubs and incomplete pages. Use it early when the current page does not already provide enough authoritative information.
+   - When you use web search, prefer authoritative sources first: the project homepage, official documentation, maintained repository, release pages, papers, and organizational pages that directly own the resource.
+
+4. Expand or correct the YAML front matter.
+   - Keep the file as Markdown with YAML front matter; do not convert it to `.yaml`.
+   - Replace stub text and warnings with real metadata when possible.
+   - Keep `layout: resource_detail` unless the file already uses a different valid resource layout.
+   - Use an existing schema class for `category`.
+   - Add or improve fields such as `description`, `homepage_url`, `repository`, `license`, `contacts`, `publications`, `domains`, `tags`, `taxon`, and `products` when supported by evidence.
+   - Preserve useful existing products. Do not remove valid products just because the page began as a stub.
+   - Fill `original_source` and `secondary_source` as lists of `SourceAssociation` objects with both `source` and `relation_type`.
+   - Use KG-Registry identifiers in `source`, not homepage URLs, INFORES IDs, free text labels, or citations.
+   - When the source is another resource already present in KG-Registry, use that resource's KG-Registry ID.
+   - When the source is a specific product rather than the whole resource, use the KG-Registry product ID if it already exists.
+   - If a referenced source does not already exist in KG-Registry, you may mint a new KG-Registry resource ID as long as it is unique, stable, and filename-safe. The build tooling can generate a new stub page for that referenced ID later.
+   - Prefer lowercase identifiers using the repository's existing conventions. Avoid spaces and punctuation other than hyphen or underscore unless an established local pattern already exists.
+   - `original_source` is for the direct primary source or sources of the product. The default relation type is `prov:hadPrimarySource`.
+   - `secondary_source` is for additional upstream influences, aggregators, or contextual sources that affected the product without being the primary source. The default relation type is `prov:wasInfluencedBy`.
+   - Use a more specific allowed PROV-O relation when the provenance is clear. In practice, `prov:wasDerivedFrom` fits transformed or re-packaged products and `prov:wasInformedBy` fits informative but indirect inputs.
+   - Keep the parent resource itself in `original_source` for products that are owned directly by that resource.
+   - Do not place the parent resource in `secondary_source` when it is the direct owner of the product.
+   - If a product description mentions another Resource as an upstream input, represent that relationship in provenance rather than burying it only in prose.
+   - If no specialized product category is clearly appropriate, use `Product`.
+
+5. Update the Markdown body only as needed.
+   - Replace placeholder stub prose with a concise human-readable summary.
+   - Keep any hand-written sections that remain accurate.
+   - Avoid duplicating every field from front matter in prose.
+
+6. Prettify and validate the file.
+   - Consult the `kg-registry-validation` skill for validation and quality checks.
+   - Run `uv run make prettify-file FILE=<target-file>` after editing when formatting needs normalization.
+   - Run `uv run make validate-file FILE=<target-file>` before finishing.
+   - Fix validation errors in the same file before stopping.
+
+7. If curation is blocked, handle it explicitly.
+   - If you cannot complete the page because the resource lacks a resolvable homepage, has insufficient public documentation, or cannot be confidently identified, add an entry to `reports/curation_problems.tsv`.
+   - Use the columns `resource_id`, `reason`, `details`, and `date_attempted`.
+   - Keep the reason short and concrete, such as `no_homepage`, `insufficient_info`, or `page_unresolvable`.
+   - Do not fabricate metadata just to satisfy validation.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Validate one file | `uv run make validate-file FILE=resource/<id>/<id>.md` |
+| Prettify one file | `uv run make prettify-file FILE=resource/<id>/<id>.md` |
+| Find stub files | `rg -l '^\s*-\s*stub\s*$' resource` |
+| Check prior curation failures | `cut -f1 reports/curation_problems.tsv` |
+
+## Common mistakes
+
+- Editing `registry/` outputs directly instead of the source file under `resource/`.
+- Converting a resource page from Markdown front matter to a standalone YAML file.
+- Inventing a new resource or product category not defined by the schema.
+- Creating a separate Product page file.
+- Removing all existing products from a resource.
+- Using free-text source names, URLs, or INFORES IDs directly in `original_source` or `secondary_source` instead of KG-Registry identifiers.
+- Forgetting that missing source IDs can be intentionally minted as new unique KG-Registry IDs so later tooling can create stub pages for them.
+- Using `secondary_source` where `original_source` is appropriate, or omitting the parent resource from a directly owned product's primary provenance.
+- Filling in `curators` even though that field is reserved for the KG-Registry team.
+- Reusing dates from the external resource for `creation_date` or `last_modified_date`.
+- Leaving `domains: [stub]` in place after a successful curation.
+- Skipping `uv run make validate-file FILE=...` before finishing.
+
+## Relationship to other skills
+
+- `curate-next` selects the next stub resources and dispatches this single-resource workflow.
+- `kg-registry-validation` covers per-file validation, provenance checks, and quality-review steps after editing.
+- `kg-registry-curation` is the core per-resource curation procedure.

--- a/.agents/skills/kg-registry-curation/SKILL.md
+++ b/.agents/skills/kg-registry-curation/SKILL.md
@@ -7,6 +7,12 @@ description: Use when curating or expanding a KG-Registry resource page. Applies
 
 Curate a single KG-Registry resource page end to end.
 
+## Prerequisite
+
+- Run this skill only from a local clone of the KG-Registry repository.
+- The workflow depends on reading and editing files under `resource/`, consulting local repository context, and running local validation commands.
+- If the repository is not cloned locally, stop and clone it before attempting curation.
+
 ## When to use
 
 - The user names a specific resource to curate.

--- a/.agents/skills/kg-registry-product-url-update/SKILL.md
+++ b/.agents/skills/kg-registry-product-url-update/SKILL.md
@@ -7,6 +7,12 @@ description: Use when updating the URL for a specific KG-Registry product, espec
 
 Update a stale or incorrect `product_url` for a specific KG-Registry product while preserving the intended identity of the product.
 
+## Prerequisite
+
+- Run this skill only from a local clone of the KG-Registry repository.
+- The workflow depends on editing a local resource page, checking nearby metadata in the checked-out repository, and running local validation commands after the URL update.
+- If the repository is not cloned locally, stop and clone it before attempting the update.
+
 ## When to use
 
 - The user asks to fix or update the URL for a named product.

--- a/.agents/skills/kg-registry-product-url-update/SKILL.md
+++ b/.agents/skills/kg-registry-product-url-update/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: kg-registry-product-url-update
+description: Use when updating the URL for a specific KG-Registry product, especially when the original URL is dead, redirected, versioned, or replaced by a newer canonical landing or download page.
+---
+
+# kg-registry-product-url-update
+
+Update a stale or incorrect `product_url` for a specific KG-Registry product while preserving the intended identity of the product.
+
+## When to use
+
+- The user asks to fix or update the URL for a named product.
+- A product URL is dead, redirects somewhere unexpected, or no longer matches the intended product.
+- The old URL pointed to a version-specific artifact, but only a newer or more general live URL is now available.
+- A validation or review pass finds an outdated product link that needs curation judgment rather than a mechanical replacement.
+
+Skip when:
+
+- The whole resource page needs broad curation rather than a focused product URL repair.
+- The product itself is mis-modeled and needs to be split, renamed, or re-categorized first.
+- The task is about generated files under `registry/` rather than source files under `resource/`.
+
+## Inputs
+
+- Required: a specific product identifier, or a resource file plus enough detail to identify the target product.
+- Preferred: the owning resource file under `resource/<id>/<id>.md`.
+
+If multiple products in the same file could match, resolve the exact target before editing.
+
+## Workflow
+
+1. Resolve the owning resource file and target product.
+   - Find the resource page under `resource/<id>/<id>.md`.
+   - Identify the exact product entry by `id`, `name`, `description`, or current `product_url`.
+   - Read the surrounding product metadata before changing the URL.
+
+2. Determine what the product is supposed to represent.
+   - Use the product `id`, `name`, `description`, `format`, provenance, and any version fields to infer the intended artifact.
+   - Distinguish between these common cases:
+     - a stable landing page or portal
+     - a versioned downloadable file
+     - an API endpoint
+     - a release directory or canonical "latest" location
+   - Do not replace a URL blindly just because it is live. The replacement must still correspond to the same product concept.
+
+3. Search for the best current live URL.
+   - Expect web search to be necessary in many cases.
+   - Start with authoritative sources: the resource homepage, official documentation, release notes, repository releases, download pages, API docs, and the hosting organization's site.
+   - Use lightweight URL checks for candidate links when helpful, but prefer human-readable confirmation from official pages over status-code checking alone.
+   - Treat redirects carefully. A redirect to a generic homepage may be less accurate than a stable download or release page.
+
+4. Choose the replacement URL based on product identity, not only string similarity.
+   - Prefer the closest live URL that still represents the same product.
+   - If the old URL pointed to a specific version and that exact version is gone, a URL for the current version or canonical latest-download page can be acceptable.
+   - If only a broader landing page remains, use it only when it is the best stable path to the same product and the file-specific URL no longer exists.
+   - If the replacement materially changes what the product represents, stop and reconsider whether the product metadata itself also needs updating.
+
+5. Update nearby metadata when the URL change implies it.
+   - If the new URL clearly points to a newer version, update `latest_version` or version-related description text when supported by evidence.
+   - If the product is now accessed through a landing page rather than a direct file, make sure the `description` still accurately explains what the user reaches there.
+   - Update the parent resource's `last_modified_date` to today, since a product URL change is still a curation edit to the resource page.
+   - Preserve existing provenance unless the source relationship itself has changed.
+   - Do not rewrite unrelated parts of the resource page.
+
+6. Validate the result.
+   - After editing, consult the `kg-registry-validation` skill.
+   - Run:
+     ```bash
+     uv run make validate-file FILE=resource/<id>/<id>.md
+     ```
+   - If formatting drifted, run prettify first and validate again.
+
+## Heuristics
+
+- Prefer official current URLs over mirrors unless the mirror is already the established product host.
+- Prefer durable landing pages over brittle deep links when the deep link no longer exists.
+- Prefer DOI or stable release URLs when they truly identify the same product release.
+- Prefer canonical `latest/` endpoints only when the product is conceptually "current release" rather than a frozen historical version.
+- If the old product was explicitly version-specific and only a new-version URL exists, keep the product only if the product description already tolerates that semantic shift or can be updated narrowly and truthfully.
+
+## Common mistakes
+
+- Replacing a dead URL with the resource homepage even though a more specific product page still exists.
+- Updating the URL to a different product just because its filename looks similar.
+- Treating any HTTP 200 response as sufficient evidence that the link is correct.
+- Keeping stale version-specific description text after changing the URL to a newer release.
+- Changing provenance fields when only the access URL changed.
+
+## Relationship to other skills
+
+- `kg-registry-curation` covers broader resource-page editing.
+- `kg-registry-validation` should be used after the URL update to validate the edited file.

--- a/.agents/skills/kg-registry-validation/SKILL.md
+++ b/.agents/skills/kg-registry-validation/SKILL.md
@@ -7,6 +7,12 @@ description: Use when validating or quality-checking KG-Registry resource pages 
 
 Validate a KG-Registry resource page after editing, with extra attention to provenance and curation-specific quality issues.
 
+## Prerequisite
+
+- Run this skill only from a local clone of the KG-Registry repository.
+- The workflow depends on validating local files in `resource/` and running repository-local commands such as `uv run make validate-file`.
+- If the repository is not cloned locally, stop and clone it before attempting validation.
+
 ## When to use
 
 - After curating or expanding a resource page.

--- a/.agents/skills/kg-registry-validation/SKILL.md
+++ b/.agents/skills/kg-registry-validation/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: kg-registry-validation
+description: Use when validating or quality-checking KG-Registry resource pages after curation, especially for schema compliance, provenance slot correctness, and stub-cleanup issues.
+---
+
+# kg-registry-validation
+
+Validate a KG-Registry resource page after editing, with extra attention to provenance and curation-specific quality issues.
+
+## When to use
+
+- After curating or expanding a resource page.
+- When a resource file fails `validate-file`.
+- When reviewing whether `original_source` and `secondary_source` were filled correctly.
+- When checking that a stub was fully converted into a curated page.
+
+Skip when:
+
+- The task is general application testing unrelated to resource metadata.
+- The task is schema authoring or code changes outside `resource/`.
+
+## Inputs
+
+- Required: a specific resource file path such as `resource/<id>/<id>.md`.
+- Optional: a related concern to emphasize, such as provenance, dates, products, or stub cleanup.
+
+## Workflow
+
+1. Validate the file structurally.
+   - Run:
+     ```bash
+     uv run make validate-file FILE=resource/<id>/<id>.md
+     ```
+   - If the file needs formatting cleanup, run:
+     ```bash
+     uv run make prettify-file FILE=resource/<id>/<id>.md
+     uv run make validate-file FILE=resource/<id>/<id>.md
+     ```
+
+2. Check curation-specific quality rules that matter even when schema validation passes.
+   - Confirm the file remains under `resource/` and not `registry/`.
+   - Confirm the page still has at least one `products` entry.
+   - Confirm `last_modified_date` reflects today for the curation edit.
+   - Confirm `curators` was not filled in.
+   - If the page was formerly a stub, confirm `domains: [stub]`, placeholder warnings, and stub prose were removed or replaced appropriately.
+
+3. Check provenance fields carefully.
+   - Inspect each product's `original_source` and `secondary_source`.
+   - Each provenance entry must be a `SourceAssociation` object with both:
+     - `source`
+     - `relation_type`
+   - `source` must be a KG-Registry resource ID or product ID, not a URL, INFORES ID, or descriptive label.
+   - Use `prov:hadPrimarySource` as the default relation for `original_source`.
+   - Use `prov:wasInfluencedBy` as the default relation for `secondary_source` when no more specific PROV-O relation is known.
+   - Use `prov:wasDerivedFrom` when the product is transformed or repackaged from another source.
+   - Use `prov:wasInformedBy` when another source influenced curation without being a direct derivation input.
+   - Confirm directly owned products include the parent resource in `original_source`.
+   - Confirm the parent resource is not redundantly listed in `secondary_source` for its own direct products.
+
+4. Check referenced IDs for resolvability and intent.
+   - When a provenance `source` references an existing KG-Registry resource, verify that the identifier matches the real registry ID.
+   - When a provenance `source` references a not-yet-existing upstream resource, confirm the newly minted ID is unique, stable, and filename-safe.
+   - A missing referenced ID can be acceptable during curation if it is an intentional new KG-Registry identifier. The tooling can later generate a stub page for it.
+   - Do not silently replace a valid missing intended source ID with a raw URL or free-text label just to avoid creating a new identifier.
+
+5. If validation fails, repair locally and rerun.
+   - Fix the same file first.
+   - Rerun `uv run make validate-file FILE=...` after each substantive fix.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Validate one file | `uv run make validate-file FILE=resource/<id>/<id>.md` |
+| Prettify then validate | `uv run make prettify-file FILE=resource/<id>/<id>.md && uv run make validate-file FILE=resource/<id>/<id>.md` |
+| Find provenance slots in a file | `rg -n 'original_source|secondary_source|relation_type' resource/<id>/<id>.md` |
+
+## Common mistakes
+
+- Treating schema validation success as sufficient even when stub warnings or placeholder prose remain.
+- Writing provenance as strings or labels instead of `SourceAssociation` objects.
+- Using URLs or INFORES IDs in `source` instead of KG-Registry IDs.
+- Forgetting that directly owned products should name their parent resource in `original_source`.
+- Deleting a legitimate newly minted source ID because it does not yet have a page.
+
+## Relationship to other skills
+
+- `kg-registry-curation` is the editing workflow.
+- `curate-next` dispatches batches of curation tasks that should finish with this validation workflow.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Entries in KG-Registry are either *Resources* or *Products*. Resources represent
 For more detail:
 - [Resources](https://kghub.org/kg-registry/docs/intro/resources.html)
 - [Products](https://kghub.org/kg-registry/docs/intro/products.html)
+- [Agent-Assisted Curation](https://kghub.org/kg-registry/docs/intro/agent-skills.html)
 - [Parquet Backend & Advanced Search](docs/parquet_backend.md)
 
 ## Site Development
 
 For developers working on the KG-Registry website and backend:
 - [Site Development Guide](README-sitedev.md) - Setup, deployment, and troubleshooting
+- [Agent Skills Guide](docs/intro/agent-skills.md) - Local agent-assisted curation workflows in `.agents/`
 - [Parquet Backend Documentation](docs/parquet_backend.md) - Database schema and querying
 - [Advanced Search Feature](advanced-search.html) - SQL-based resource discovery interface

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,23 @@
-# Introduction to KG-Registry
+---
+layout: intro_doc
+title: KG-Registry Documentation
+---
+
+# KG-Registry Documentation
+
+Use these guides to navigate KG-Registry as a registry, as a data model, and as a locally curated repository.
+
+## Start Here
+
+- [Introduction](intro/index.html)
+- [Resources](intro/resources.html)
+- [Products](intro/products.html)
+- [Agent Skills](intro/agent-skills.html)
+
+## Additional Documentation
+
+- [Parquet Backend](parquet_backend.html)
+- [External Syncs](external-syncs.html)
+- [Schema Reference](schema/)
 
 KG-Registry is a registry for knowledge graphs.

--- a/docs/intro/agent-skills.md
+++ b/docs/intro/agent-skills.md
@@ -1,0 +1,82 @@
+---
+layout: intro_doc
+title: Agent Skills
+---
+
+# Agent Skills
+
+KG-Registry includes a small set of local agent skills to support curation and maintenance workflows in this repository.
+
+These skills are designed for curators working in a checked-out copy of the repository, not for editing generated site output or for use against the public website alone.
+
+## Prerequisite
+
+Before using any of these skills, clone the KG-Registry repository locally.
+
+The skills rely on:
+
+- reading and editing source files under `resource/`
+- checking nearby repository context such as `reports/curation_problems.tsv`
+- running local validation commands such as `uv run make validate-file FILE=...`
+
+If you are not working in a local clone of the repository, stop and clone it first.
+
+## Where the skills live
+
+The current agent workflows are defined in the repository's `.agents/` directory.
+
+That directory includes:
+
+- command entry points for common tasks
+- skill definitions for curation and validation workflows
+- local permission settings used by the agent when running repository-specific commands
+
+## Available workflows
+
+### Curate a specific resource
+
+Use the `kg-registry-curation` skill, or the matching `curate` command entry point when your agent environment supports commands.
+
+This workflow is for expanding a stub resource or improving a specific existing resource page. It focuses on the source page under `resource/<id>/<id>.md`, expects web search when the current page is incomplete, and finishes with local validation.
+
+### Curate the next batch of stubs
+
+Use the `curate-next` skill, or the matching `curate-next` command entry point when available.
+
+This workflow selects the next stub resources from the local repository, skips resources already listed in `reports/curation_problems.tsv`, and dispatches per-resource curation.
+
+### Validate a curated resource page
+
+Use the `kg-registry-validation` skill.
+
+This workflow checks a curated file for schema validity and curation-specific quality issues such as placeholder stub content, missing provenance structure, missing products, or incorrect source associations.
+
+### Update a product URL
+
+Use the `kg-registry-product-url-update` skill.
+
+This workflow is for replacing a stale `product_url` with the best current live URL for the same product. It is especially useful when an old version-specific URL has disappeared and the best replacement is a newer canonical page, release page, or current download endpoint.
+
+## What these workflows assume
+
+The agent skills are written around a few KG-Registry-specific rules:
+
+- edit source files in `resource/`, not generated output in `registry/`
+- keep resource pages as Markdown files with YAML front matter
+- use the LinkML schema in `src/kg_registry/kg_registry_schema/schema/kg_registry_schema.yaml`
+- validate local edits with repository commands rather than ad hoc checks
+- use KG-Registry identifiers, not free text or raw URLs, in provenance slots such as `original_source` and `secondary_source`
+
+## Typical curation loop
+
+1. Choose a resource or product task.
+2. Use the appropriate skill from the local repository clone.
+3. Search authoritative web sources when the current metadata is incomplete or stale.
+4. Update the source page under `resource/`.
+5. Run local validation before finishing.
+
+## When not to use these skills
+
+These skills are not a substitute for broader project setup or site deployment instructions.
+
+For repository setup, development, and troubleshooting, see the root-level development documentation such as `README-sitedev.md`.

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -59,6 +59,14 @@ Please [open an issue on the Registry's GitHub page](https://github.com/Knowledg
 
 Some resource pages are also maintained through scripted syncs from external registries and release feeds. See [External Syncs](../external-syncs.html) for the current list.
 
+## How does agent-assisted curation work?
+
+KG-Registry also includes local agent skills for curating and validating resource pages from a checked-out copy of the repository.
+
+These workflows live in the repository's `.agents/` directory and are intended for local use by curators working directly on source files under `resource/`.
+
+See [Agent Skills](agent-skills.html) for the available workflows, prerequisites, and usage guidance.
+
 ## Who manages the Registry?
 
 The KG-Registry is built and managed by members of the [Berkeley Bioinformatics Open-source Projects (BBOP) group](https://berkeleybop.github.io/) at the [Lawrence Berkeley National Laboratory](https://www.lbl.gov/).


### PR DESCRIPTION
This pull request introduces new agent workflows, skills, and permissions to support curation and maintenance of KG-Registry resources. The changes add detailed documentation and command definitions for curating individual resources, batch-curating stubs, and updating product URLs, as well as specifying the required permissions for these operations.

**New curation workflows and skills:**

* Added a skill for batch-curating the next N stub resources, including detailed workflow steps, validation requirements, and common mistakes to avoid (`.agents/skills/curate-next/SKILL.md`).
* Added a skill for single-resource curation, outlining how to expand or improve a KG-Registry resource page, with thorough instructions for provenance, validation, and file handling (`.agents/skills/kg-registry-curation/SKILL.md`).
* Added a skill for updating product URLs, providing guidance on selecting the correct replacement URL and updating related metadata responsibly (`.agents/skills/kg-registry-product-url-update/SKILL.md`).

**Command definitions:**

* Introduced new agent commands for curating a specific resource (`.agents/commands/curate.md`) and for batch-curating the next N stub resources (`.agents/commands/curate-next.md`). [[1]](diffhunk://#diff-0d714670df8c145c2436bb790fdf9b03faf752739495df23fcc488bd9bf286feR1-R12) [[2]](diffhunk://#diff-425ae1dd8df540a7a0d993c0386844d042a070a138cfb3d53790bdf2e92968b7R1-R10)

**Agent permissions:**

* Defined a permissions policy allowing the agent to run specific shell commands necessary for resource discovery, validation, and git operations (`.agents/settings.json`).