### PR TITLE
Add interface to compare resources

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,6 +25,10 @@
                 <li class="nav-item">
                     <a class="nav-link" href="/kg-registry/kg-registry-kg/">KG-Registry-KG</a>
                 </li>
+
+                <li class="nav-item">
+                    <a class="nav-link" href="/kg-registry/compare/">Compare</a>
+                </li>
                 
                 <li class="nav-item">
                     <a class="nav-link" href="/kg-registry/organizations.html">Organizations</a>

--- a/_layouts/resource_detail.html
+++ b/_layouts/resource_detail.html
@@ -84,10 +84,21 @@ layout: default
     {%- endif -%}
   {%- endfor -%}
   {%- if has_eval -%}
-  <div class="mb-3">
+  <div class="mb-3 d-flex flex-wrap gap-2">
+    <a class="btn btn-outline-secondary btn-sm" href="{{ '/compare/' | relative_url }}?resource={{ page.id }}" aria-label="Compare {{ page.id }}" title="Compare">
+      <i class="bi bi-arrow-left-right" aria-hidden="true"></i>
+      <span class="ms-1">Compare</span>
+    </a>
     <a class="btn btn-outline-primary btn-sm" href="{{ eval_file }}" aria-label="View evaluation for {{ page.id }}" title="Evaluation">
       <i class="bi bi-clipboard-check" aria-hidden="true"></i>
       <span class="ms-1">Evaluation</span>
+    </a>
+  </div>
+  {%- else -%}
+  <div class="mb-3">
+    <a class="btn btn-outline-secondary btn-sm" href="{{ '/compare/' | relative_url }}?resource={{ page.id }}" aria-label="Compare {{ page.id }}" title="Compare">
+      <i class="bi bi-arrow-left-right" aria-hidden="true"></i>
+      <span class="ms-1">Compare</span>
     </a>
   </div>
   {%- endif -%}

--- a/assets/js/resource-compare.js
+++ b/assets/js/resource-compare.js
@@ -1,0 +1,494 @@
+(function () {
+  const state = {
+    resources: [],
+    resourceMap: new Map()
+  };
+
+  function getBaseUrl() {
+    const baseUrl = window.kgRegistryBaseUrl || '';
+    return baseUrl === '/' ? '' : baseUrl;
+  }
+
+  function registryPath(path) {
+    return `${getBaseUrl()}${path}`;
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function normalize(value) {
+    return String(value ?? '').trim().toLowerCase();
+  }
+
+  function sourceAssociationId(sourceAssociation) {
+    if (typeof sourceAssociation === 'string') {
+      return sourceAssociation.trim();
+    }
+    if (sourceAssociation && typeof sourceAssociation === 'object' && typeof sourceAssociation.source === 'string') {
+      return sourceAssociation.source.trim();
+    }
+    return '';
+  }
+
+  function collectDomains(resource) {
+    return new Set((resource && Array.isArray(resource.domains) ? resource.domains : []).filter(Boolean).map(domain => String(domain).trim()));
+  }
+
+  function collectOriginalSources(resource) {
+    const originalSources = new Set();
+    const products = resource && Array.isArray(resource.products) ? resource.products : [];
+
+    products.forEach(product => {
+      if (!product || !Array.isArray(product.original_source)) return;
+      product.original_source.forEach(sourceAssociation => {
+        const sourceId = sourceAssociationId(sourceAssociation);
+        if (sourceId) {
+          originalSources.add(sourceId);
+        }
+      });
+    });
+
+    return originalSources;
+  }
+
+  function setIntersection(left, right) {
+    const result = [];
+    left.forEach(value => {
+      if (right.has(value)) {
+        result.push(value);
+      }
+    });
+    return result.sort((a, b) => a.localeCompare(b));
+  }
+
+  function setUnion(left, right) {
+    return new Set([...left, ...right]);
+  }
+
+  function compareResources(leftResource, rightResource) {
+    const leftDomains = collectDomains(leftResource);
+    const rightDomains = collectDomains(rightResource);
+    const leftSources = collectOriginalSources(leftResource);
+    const rightSources = collectOriginalSources(rightResource);
+
+    const sharedDomains = setIntersection(leftDomains, rightDomains);
+    const sharedOriginalSources = setIntersection(leftSources, rightSources);
+
+    const domainUnion = setUnion(leftDomains, rightDomains);
+    const sourceUnion = setUnion(leftSources, rightSources);
+
+    const weightedShared = sharedDomains.length * 2 + sharedOriginalSources.length * 3;
+    const weightedUnion = domainUnion.size * 2 + sourceUnion.size * 3;
+    const similarityScore = weightedUnion ? Number(((weightedShared / weightedUnion) * 100).toFixed(1)) : 0;
+
+    return {
+      similarityScore,
+      sharedDomains,
+      sharedOriginalSources,
+      leftDomains,
+      rightDomains,
+      leftSources,
+      rightSources,
+      sharedFeatureCount: sharedDomains.length + sharedOriginalSources.length
+    };
+  }
+
+  function getResourceUrl(resourceId) {
+    return registryPath(`/resource/${encodeURIComponent(resourceId)}/${encodeURIComponent(resourceId)}.html`);
+  }
+
+  function getSourceUrl(sourceId) {
+    if (!sourceId) return '#';
+    const firstSegment = sourceId.includes('.') ? sourceId.split('.')[0] : sourceId.includes('/') ? sourceId.split('/')[0] : sourceId;
+    return registryPath(`/resource/${encodeURIComponent(firstSegment)}/${encodeURIComponent(sourceId)}.html`);
+  }
+
+  function formatResourceLabel(resource) {
+    return resource.name ? `${resource.name} (${resource.id})` : resource.id;
+  }
+
+  function renderChipList(values, emptyLabel, makeHref) {
+    if (!values.length) {
+      return `<span class="text-muted">${escapeHtml(emptyLabel)}</span>`;
+    }
+
+    return `<div class="compare-chip-list">${values.map(value => {
+      const label = escapeHtml(value);
+      const href = makeHref ? makeHref(value) : null;
+      if (href && href !== '#') {
+        return `<a class="compare-chip text-decoration-none" href="${href}">${label}</a>`;
+      }
+      return `<span class="compare-chip">${label}</span>`;
+    }).join('')}</div>`;
+  }
+
+  function renderResourceCard(resource) {
+    const domains = collectDomains(resource);
+    const originalSources = collectOriginalSources(resource);
+    const productCount = Array.isArray(resource.products) ? resource.products.length : 0;
+    const homepageUrl = resource.homepage_url ? `<a href="${escapeHtml(resource.homepage_url)}" target="_blank" rel="noreferrer">Homepage</a>` : '<span class="text-muted">No homepage listed</span>';
+
+    return `
+      <div class="card h-100 compare-card shadow-sm">
+        <div class="card-body">
+          <div class="d-flex justify-content-between gap-3 align-items-start mb-3">
+            <div>
+              <div class="text-uppercase small compare-muted fw-semibold mb-1">${escapeHtml(resource.category || 'Resource')}</div>
+              <h3 class="h4 mb-1">${escapeHtml(resource.name || resource.id)}</h3>
+              <div class="font-monospace text-muted">${escapeHtml(resource.id)}</div>
+            </div>
+            <a class="btn btn-outline-secondary btn-sm" href="${getResourceUrl(resource.id)}">Open page</a>
+          </div>
+          <p class="mb-3">${escapeHtml(resource.description || 'No description available.')}</p>
+          <div class="row g-3 mb-3">
+            <div class="col-sm-4">
+              <div class="p-3 rounded-3 bg-light h-100">
+                <div class="small compare-muted">Domains</div>
+                <div class="fw-semibold">${domains.size}</div>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="p-3 rounded-3 bg-light h-100">
+                <div class="small compare-muted">Original sources</div>
+                <div class="fw-semibold">${originalSources.size}</div>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="p-3 rounded-3 bg-light h-100">
+                <div class="small compare-muted">Products</div>
+                <div class="fw-semibold">${productCount}</div>
+              </div>
+            </div>
+          </div>
+          <div class="mb-3">
+            <div class="small compare-muted fw-semibold mb-2">Domains</div>
+            ${renderChipList(Array.from(domains).sort((a, b) => a.localeCompare(b)), 'No domains recorded.')}
+          </div>
+          <div class="mb-0">
+            <div class="small compare-muted fw-semibold mb-2">Original sources</div>
+            ${renderChipList(Array.from(originalSources).sort((a, b) => a.localeCompare(b)), 'No original sources recorded.', getSourceUrl)}
+          </div>
+          <div class="mt-3 small">${homepageUrl}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderPairComparison(leftResource, rightResource) {
+    const comparison = compareResources(leftResource, rightResource);
+    const scoreClass = comparison.similarityScore >= 60 ? 'text-success' : comparison.similarityScore >= 25 ? 'text-warning' : 'text-danger';
+
+    const sharedDomains = renderChipList(comparison.sharedDomains, 'No shared domains.');
+    const sharedSources = renderChipList(comparison.sharedOriginalSources, 'No shared original sources.', getSourceUrl);
+
+    return `
+      <div class="card compare-card shadow-sm mb-4">
+        <div class="card-body p-4">
+          <div class="row g-4 align-items-stretch mb-3">
+            <div class="col-lg-5">
+              ${renderResourceCard(leftResource)}
+            </div>
+            <div class="col-lg-2 d-flex align-items-center justify-content-center">
+              <div class="text-center p-3">
+                <div class="small text-uppercase compare-muted fw-semibold mb-2">Similarity</div>
+                <div class="compare-score ${scoreClass}">${comparison.similarityScore.toFixed(1)}</div>
+                <div class="compare-muted mt-2">${comparison.sharedFeatureCount} shared feature${comparison.sharedFeatureCount === 1 ? '' : 's'}</div>
+              </div>
+            </div>
+            <div class="col-lg-5">
+              ${renderResourceCard(rightResource)}
+            </div>
+          </div>
+
+          <div class="row g-3">
+            <div class="col-md-6">
+              <div class="p-3 rounded-3 bg-light h-100">
+                <div class="fw-semibold mb-2">Shared domains</div>
+                ${sharedDomains}
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="p-3 rounded-3 bg-light h-100">
+                <div class="fw-semibold mb-2">Shared original sources</div>
+                ${sharedSources}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderTopMatches(resource) {
+    const matches = state.resources
+      .filter(candidate => candidate.id && candidate.id !== resource.id)
+      .map(candidate => {
+        const comparison = compareResources(resource, candidate);
+        return { candidate, comparison };
+      })
+      .filter(result => result.comparison.sharedFeatureCount > 0)
+      .sort((left, right) => {
+        if (right.comparison.similarityScore !== left.comparison.similarityScore) {
+          return right.comparison.similarityScore - left.comparison.similarityScore;
+        }
+        if (right.comparison.sharedFeatureCount !== left.comparison.sharedFeatureCount) {
+          return right.comparison.sharedFeatureCount - left.comparison.sharedFeatureCount;
+        }
+        return left.candidate.id.localeCompare(right.candidate.id);
+      })
+      .slice(0, 15);
+
+    if (!matches.length) {
+      return `
+        <div class="compare-empty">
+          <h3 class="h5 mb-2">No overlaps found</h3>
+          <p class="mb-0">This resource does not currently share domains or original sources with any other indexed resource.</p>
+        </div>
+      `;
+    }
+
+    return `
+      <div class="card compare-card shadow-sm">
+        <div class="card-body p-4">
+          <div class="d-flex justify-content-between flex-wrap gap-2 align-items-center mb-3">
+            <div>
+              <h2 class="h4 mb-1">Closest matches</h2>
+              <div class="compare-muted">Sorted by weighted overlap of domains and original sources.</div>
+            </div>
+            <div class="compare-muted small">Top ${matches.length} of ${Math.max(state.resources.length - 1, 0)}</div>
+          </div>
+
+          <div class="table-responsive">
+            <table class="table table-hover align-middle compare-table mb-0">
+              <thead>
+                <tr>
+                  <th>Resource</th>
+                  <th>Similarity</th>
+                  <th>Shared domains</th>
+                  <th>Shared original sources</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                ${matches.map(({ candidate, comparison }) => `
+                  <tr>
+                    <td>
+                      <div class="fw-semibold">${escapeHtml(candidate.name || candidate.id)}</div>
+                      <div class="small text-muted font-monospace">${escapeHtml(candidate.id)}</div>
+                    </td>
+                    <td>
+                      <span class="badge text-bg-primary">${comparison.similarityScore.toFixed(1)}</span>
+                    </td>
+                    <td>${comparison.sharedDomains.length}</td>
+                    <td>${comparison.sharedOriginalSources.length}</td>
+                    <td class="text-end">
+                      <a class="btn btn-outline-secondary btn-sm" href="${registryPath(`/compare/?resource=${encodeURIComponent(resource.id)}&compare=${encodeURIComponent(candidate.id)}`)}">Open pair</a>
+                    </td>
+                  </tr>
+                `).join('')}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderMessage(message, type = 'info') {
+    const container = document.getElementById('comparison-message');
+    if (!container) return;
+
+    if (!message) {
+      container.innerHTML = '';
+      return;
+    }
+
+    const alertClass = type === 'danger' ? 'alert-danger' : type === 'warning' ? 'alert-warning' : 'alert-info';
+    container.innerHTML = `<div class="alert ${alertClass} mb-0">${escapeHtml(message)}</div>`;
+  }
+
+  function getSelectedResources() {
+    const primaryInput = document.getElementById('resource-id');
+    const compareInput = document.getElementById('compare-id');
+    return {
+      primaryValue: primaryInput ? primaryInput.value.trim() : '',
+      compareValue: compareInput ? compareInput.value.trim() : ''
+    };
+  }
+
+  function resolveResource(value) {
+    const normalized = normalize(value);
+    if (!normalized) return null;
+
+    const exactId = state.resources.find(resource => normalize(resource.id) === normalized);
+    if (exactId) return exactId;
+
+    const exactName = state.resources.find(resource => normalize(resource.name) === normalized);
+    if (exactName) return exactName;
+
+    const idMatches = state.resources.filter(resource => normalize(resource.id).includes(normalized));
+    if (idMatches.length === 1) return idMatches[0];
+
+    const nameMatches = state.resources.filter(resource => normalize(resource.name).includes(normalized));
+    if (nameMatches.length === 1) return nameMatches[0];
+
+    return null;
+  }
+
+  function populateResourceLists() {
+    const dataListIds = ['resource-id-list', 'compare-id-list'];
+    const sortedResources = [...state.resources].sort((left, right) => {
+      const leftLabel = (left.name || left.id || '').toLowerCase();
+      const rightLabel = (right.name || right.id || '').toLowerCase();
+      return leftLabel.localeCompare(rightLabel);
+    });
+
+    dataListIds.forEach(listId => {
+      const list = document.getElementById(listId);
+      if (!list) return;
+      list.innerHTML = '';
+
+      sortedResources.forEach(resource => {
+        if (!resource.id) return;
+        const option = document.createElement('option');
+        option.value = resource.id;
+        option.label = formatResourceLabel(resource);
+        list.appendChild(option);
+      });
+    });
+  }
+
+  function applyQueryToForm() {
+    const params = new URLSearchParams(window.location.search);
+    const primaryInput = document.getElementById('resource-id');
+    const compareInput = document.getElementById('compare-id');
+
+    if (primaryInput && params.get('resource')) {
+      primaryInput.value = params.get('resource');
+    }
+    if (compareInput && params.get('compare')) {
+      compareInput.value = params.get('compare');
+    }
+  }
+
+  function updateQueryFromForm() {
+    const { primaryValue, compareValue } = getSelectedResources();
+    const url = new URL(window.location.href);
+
+    if (primaryValue) {
+      url.searchParams.set('resource', primaryValue);
+    } else {
+      url.searchParams.delete('resource');
+    }
+
+    if (compareValue) {
+      url.searchParams.set('compare', compareValue);
+    } else {
+      url.searchParams.delete('compare');
+    }
+
+    window.history.replaceState({}, '', url);
+  }
+
+  function renderComparison() {
+    const output = document.getElementById('comparison-output');
+    if (!output) return;
+
+    const { primaryValue, compareValue } = getSelectedResources();
+    const primaryResource = resolveResource(primaryValue);
+    const compareResource = resolveResource(compareValue);
+
+    if (!primaryValue) {
+      renderMessage('Enter a primary resource ID to start comparing.', 'info');
+      output.innerHTML = `
+        <div class="compare-empty">
+          <h2 class="h4 mb-2">Choose a resource</h2>
+          <p class="mb-0">Use the form above to load one resource or a pair of resources. The page will score overlap using shared domains and shared original sources.</p>
+        </div>
+      `;
+      return;
+    }
+
+    if (!primaryResource) {
+      renderMessage(`No KG-Registry resource matched "${primaryValue}".`, 'danger');
+      output.innerHTML = '';
+      return;
+    }
+
+    if (compareValue && !compareResource) {
+      renderMessage(`No KG-Registry resource matched "${compareValue}".`, 'danger');
+      output.innerHTML = '';
+      return;
+    }
+
+    if (compareValue && compareResource) {
+      renderMessage(`Comparing ${primaryResource.id} with ${compareResource.id}.`, 'info');
+      output.innerHTML = renderPairComparison(primaryResource, compareResource);
+      return;
+    }
+
+    renderMessage(`Showing the strongest overlaps for ${primaryResource.id}.`, 'info');
+    output.innerHTML = `
+      <div class="mb-4">
+        ${renderResourceCard(primaryResource)}
+      </div>
+      ${renderTopMatches(primaryResource)}
+    `;
+  }
+
+  async function loadData() {
+    const response = await fetch(registryPath('/registry/kgs.yml'));
+    const text = await response.text();
+    const data = jsyaml.load(text) || {};
+    return Array.isArray(data.resources) ? data.resources : [];
+  }
+
+  async function initialize() {
+    const form = document.getElementById('compare-form');
+    if (!form) return;
+
+    try {
+      state.resources = await loadData();
+      state.resourceMap = new Map(state.resources.filter(resource => resource && resource.id).map(resource => [resource.id, resource]));
+      populateResourceLists();
+      applyQueryToForm();
+      renderComparison();
+    } catch (error) {
+      console.error('Failed to load registry data', error);
+      renderMessage('Unable to load registry data for comparisons.', 'danger');
+      const output = document.getElementById('comparison-output');
+      if (output) {
+        output.innerHTML = '';
+      }
+    }
+
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      updateQueryFromForm();
+      renderComparison();
+    });
+
+    const swapButton = document.getElementById('swap-inputs');
+    if (swapButton) {
+      swapButton.addEventListener('click', () => {
+        const primaryInput = document.getElementById('resource-id');
+        const compareInput = document.getElementById('compare-id');
+        if (!primaryInput || !compareInput) return;
+
+        const primaryValue = primaryInput.value;
+        primaryInput.value = compareInput.value;
+        compareInput.value = primaryValue;
+        updateQueryFromForm();
+        renderComparison();
+      });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', initialize);
+})();

--- a/assets/js/resource-compare.js
+++ b/assets/js/resource-compare.js
@@ -310,7 +310,7 @@
           <div class="d-flex justify-content-between flex-wrap gap-2 align-items-center mb-3">
             <div>
               <h2 class="h4 mb-1">Closest matches</h2>
-              <div class="compare-muted">Sorted by weighted overlap of domains and original sources.</div>
+              <div class="compare-muted">Sorted by weighted overlap of category, domains, and original sources.</div>
             </div>
             <div class="compare-muted small">Top ${matches.length} of ${Math.max(state.resources.length - 1, 0)}</div>
           </div>

--- a/assets/js/resource-compare.js
+++ b/assets/js/resource-compare.js
@@ -113,6 +113,50 @@
     return resource.name ? `${resource.name} (${resource.id})` : resource.id;
   }
 
+  function categoryIcon(category) {
+    const categoryIcons = {
+      Aggregator: 'grid-3x3',
+      Resource: 'archive',
+      KnowledgeGraph: 'globe',
+      DataSource: 'shop',
+      DataModel: 'diagram-3',
+      Ontology: 'diagram-2',
+      GraphProduct: 'globe',
+      Product: 'box',
+      MappingProduct: 'map',
+      ProcessProduct: 'gear',
+      DataModelProduct: 'diagram-3',
+      OntologyProduct: 'diagram-2',
+      GraphicalInterface: 'window',
+      ProgrammingInterface: 'code-square',
+      DocumentationProduct: 'journal-text'
+    };
+
+    return categoryIcons[category] || 'box';
+  }
+
+  function categoryLabel(category) {
+    const categoryLabels = {
+      Aggregator: 'Aggregator',
+      Resource: 'Resource',
+      KnowledgeGraph: 'Knowledge Graph',
+      DataSource: 'Data Source',
+      DataModel: 'Data Model',
+      Ontology: 'Ontology',
+      GraphProduct: 'Graph Product',
+      Product: 'Product',
+      MappingProduct: 'Mapping Product',
+      ProcessProduct: 'Process Product',
+      DataModelProduct: 'Data Model Product',
+      OntologyProduct: 'Ontology Product',
+      GraphicalInterface: 'Graphical Interface',
+      ProgrammingInterface: 'Programming Interface',
+      DocumentationProduct: 'Documentation Product'
+    };
+
+    return categoryLabels[category] || category || 'Resource';
+  }
+
   function renderChipList(values, emptyLabel, makeHref) {
     if (!values.length) {
       return `<span class="text-muted">${escapeHtml(emptyLabel)}</span>`;
@@ -268,6 +312,7 @@
             <table class="table table-hover align-middle compare-table mb-0">
               <thead>
                 <tr>
+                  <th>Category</th>
                   <th>Resource</th>
                   <th>Similarity</th>
                   <th>Shared domains</th>
@@ -278,6 +323,12 @@
               <tbody>
                 ${matches.map(({ candidate, comparison }) => `
                   <tr>
+                    <td>
+                      <div class="d-flex align-items-center gap-2">
+                        <i class="bi bi-${categoryIcon(candidate.category)}"></i>
+                        <span>${escapeHtml(categoryLabel(candidate.category))}</span>
+                      </div>
+                    </td>
                     <td>
                       <div class="fw-semibold">${escapeHtml(candidate.name || candidate.id)}</div>
                       <div class="small text-muted font-monospace">${escapeHtml(candidate.id)}</div>

--- a/assets/js/resource-compare.js
+++ b/assets/js/resource-compare.js
@@ -76,26 +76,31 @@
     const rightDomains = collectDomains(rightResource);
     const leftSources = collectOriginalSources(leftResource);
     const rightSources = collectOriginalSources(rightResource);
+    const leftCategory = normalize(leftResource && leftResource.category);
+    const rightCategory = normalize(rightResource && rightResource.category);
 
     const sharedDomains = setIntersection(leftDomains, rightDomains);
     const sharedOriginalSources = setIntersection(leftSources, rightSources);
+    const sharedCategory = leftCategory && leftCategory === rightCategory ? leftResource.category : '';
 
     const domainUnion = setUnion(leftDomains, rightDomains);
     const sourceUnion = setUnion(leftSources, rightSources);
+    const categoryUnionSize = sharedCategory ? 1 : 2;
 
-    const weightedShared = sharedDomains.length * 2 + sharedOriginalSources.length * 3;
-    const weightedUnion = domainUnion.size * 2 + sourceUnion.size * 3;
+    const weightedShared = sharedDomains.length * 2 + sharedOriginalSources.length * 3 + (sharedCategory ? 4 : 0);
+    const weightedUnion = domainUnion.size * 2 + sourceUnion.size * 3 + categoryUnionSize * 4;
     const similarityScore = weightedUnion ? Number(((weightedShared / weightedUnion) * 100).toFixed(1)) : 0;
 
     return {
       similarityScore,
       sharedDomains,
       sharedOriginalSources,
+      sharedCategory,
       leftDomains,
       rightDomains,
       leftSources,
       rightSources,
-      sharedFeatureCount: sharedDomains.length + sharedOriginalSources.length
+      sharedFeatureCount: sharedDomains.length + sharedOriginalSources.length + (sharedCategory ? 1 : 0)
     };
   }
 
@@ -230,6 +235,7 @@
 
     const sharedDomains = renderChipList(comparison.sharedDomains, 'No shared domains.');
     const sharedSources = renderChipList(comparison.sharedOriginalSources, 'No shared original sources.', getSourceUrl);
+    const sharedCategoryLabel = comparison.sharedCategory ? categoryLabel(comparison.sharedCategory) : 'Different categories';
 
     return `
       <div class="card compare-card shadow-sm mb-4">
@@ -243,6 +249,7 @@
                 <div class="small text-uppercase compare-muted fw-semibold mb-2">Similarity</div>
                 <div class="compare-score ${scoreClass}">${comparison.similarityScore.toFixed(1)}</div>
                 <div class="compare-muted mt-2">${comparison.sharedFeatureCount} shared feature${comparison.sharedFeatureCount === 1 ? '' : 's'}</div>
+                <div class="mt-2"><i class="bi bi-${categoryIcon(comparison.sharedCategory || leftResource.category)}"></i> ${escapeHtml(sharedCategoryLabel)}</div>
               </div>
             </div>
             <div class="col-lg-5">

--- a/compare.md
+++ b/compare.md
@@ -1,0 +1,116 @@
+---
+layout: default
+title: Compare Resources
+description: Compare KG-Registry resources by shared domains and shared original sources.
+permalink: /compare/
+---
+
+<style>
+  .compare-hero {
+    background: linear-gradient(135deg, rgba(13, 110, 253, 0.10), rgba(32, 201, 151, 0.10));
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 1.25rem;
+  }
+
+  .compare-hero-badge {
+    background: rgba(13, 110, 253, 0.08);
+    color: #0b5ed7;
+    border-radius: 999px;
+    padding: 0.5rem 0.9rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .compare-score {
+    font-size: 2.1rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .compare-chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .compare-chip {
+    border-radius: 999px;
+    padding: 0.35rem 0.7rem;
+    background: #f1f5f9;
+    border: 1px solid #dbe2ea;
+    font-size: 0.92rem;
+  }
+
+  .compare-card {
+    border-radius: 1rem;
+  }
+
+  .compare-muted {
+    color: #667085;
+  }
+
+  .compare-table thead th {
+    white-space: nowrap;
+  }
+
+  .compare-empty {
+    border: 1px dashed rgba(0, 0, 0, 0.2);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    background: rgba(255, 255, 255, 0.7);
+  }
+</style>
+
+<div class="compare-hero mb-4">
+  <div class="p-4 p-lg-5">
+    <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 align-items-start align-items-lg-center">
+      <div>
+        <div class="text-uppercase fw-semibold small compare-muted mb-2">Resource similarity</div>
+        <h1 class="mb-2">Compare KG-Registry Resources</h1>
+        <p class="lead mb-0" style="max-width: 54rem;">
+          Compare one resource against the registry or compare a specific pair by the features they share:
+          domains and original sources.
+        </p>
+      </div>
+      <div class="compare-hero-badge">
+        Live from <span class="font-monospace">registry/kgs.yml</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card compare-card shadow-sm mb-4">
+  <div class="card-body p-4">
+    <form id="compare-form" class="row g-3 align-items-end">
+      <div class="col-lg-5">
+        <label for="resource-id" class="form-label fw-semibold">Primary resource ID</label>
+        <input id="resource-id" name="resource" class="form-control form-control-lg" list="resource-id-list" placeholder="e.g. raras" autocomplete="off" spellcheck="false" />
+        <datalist id="resource-id-list"></datalist>
+        <div class="form-text">Enter a KG-Registry resource ID or resource name.</div>
+      </div>
+      <div class="col-lg-5">
+        <label for="compare-id" class="form-label fw-semibold">Second resource ID <span class="text-muted fw-normal">(optional)</span></label>
+        <input id="compare-id" name="compare" class="form-control form-control-lg" list="compare-id-list" placeholder="Leave blank to compare against the registry" autocomplete="off" spellcheck="false" />
+        <datalist id="compare-id-list"></datalist>
+        <div class="form-text">If you provide a second ID, the page compares only those two resources.</div>
+      </div>
+      <div class="col-lg-2 d-grid gap-2">
+        <button class="btn btn-primary btn-lg" type="submit">
+          <i class="bi bi-search me-1"></i>Compare
+        </button>
+        <button class="btn btn-outline-secondary" type="button" id="swap-inputs">
+          <i class="bi bi-arrow-left-right me-1"></i>Swap
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div id="comparison-message" class="mb-4"></div>
+<div id="comparison-output"></div>
+
+<script>
+  window.kgRegistryBaseUrl = {{ site.baseurl | jsonify }};
+</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+<script src="{{ '/assets/js/resource-compare.js' | relative_url }}"></script>

--- a/compare.md
+++ b/compare.md
@@ -59,6 +59,23 @@ permalink: /compare/
     padding: 1.5rem;
     background: rgba(255, 255, 255, 0.7);
   }
+
+  .compare-field-label {
+    min-height: 2rem;
+    display: flex;
+    align-items: end;
+  }
+
+  .compare-field-subtitle {
+    min-height: 2.5rem;
+  }
+
+  @media (max-width: 991.98px) {
+    .compare-field-label,
+    .compare-field-subtitle {
+      min-height: 0;
+    }
+  }
 </style>
 
 <div class="compare-hero mb-4">
@@ -69,7 +86,7 @@ permalink: /compare/
         <h1 class="mb-2">Compare KG-Registry Resources</h1>
         <p class="lead mb-0" style="max-width: 54rem;">
           Compare one resource against the registry or compare a specific pair by the features they share:
-          domains and original sources.
+          category, domains, and original sources.
         </p>
       </div>
     </div>
@@ -80,16 +97,16 @@ permalink: /compare/
   <div class="card-body p-4">
     <form id="compare-form" class="row g-3 align-items-end">
       <div class="col-lg-5">
-        <label for="resource-id" class="form-label fw-semibold">Primary resource ID</label>
+        <label for="resource-id" class="form-label fw-semibold compare-field-label">Primary resource ID</label>
         <input id="resource-id" name="resource" class="form-control form-control-lg" list="resource-id-list" placeholder="e.g. raras" autocomplete="off" spellcheck="false" />
         <datalist id="resource-id-list"></datalist>
-        <div class="form-text">Enter a KG-Registry resource ID or resource name.</div>
+        <div class="form-text compare-field-subtitle">Enter a KG-Registry resource ID or resource name.</div>
       </div>
       <div class="col-lg-5">
-        <label for="compare-id" class="form-label fw-semibold">Second resource ID <span class="text-muted fw-normal">(optional)</span></label>
+        <label for="compare-id" class="form-label fw-semibold compare-field-label">Second resource ID</label>
         <input id="compare-id" name="compare" class="form-control form-control-lg" list="compare-id-list" placeholder="Leave blank to compare against the registry" autocomplete="off" spellcheck="false" />
         <datalist id="compare-id-list"></datalist>
-        <div class="form-text">If you provide a second ID, the page compares only those two resources.</div>
+        <div class="form-text compare-field-subtitle">Optional. If provided, the page compares only those two resources.</div>
       </div>
       <div class="col-lg-2 d-grid gap-2">
         <button class="btn btn-primary btn-lg" type="submit">

--- a/compare.md
+++ b/compare.md
@@ -72,9 +72,6 @@ permalink: /compare/
           domains and original sources.
         </p>
       </div>
-      <div class="compare-hero-badge">
-        Live from <span class="font-monospace">registry/kgs.yml</span>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This pull request introduces a new resource comparison feature to the KG-Registry site, allowing users to compare resources by shared domains and original sources. It adds a dedicated "Compare" page, updates the navigation to link to this new page, and adds "Compare" buttons to individual resource detail pages for easy access.

**New Compare Feature:**

* Added a new `compare.md` page, which provides a user interface for comparing KG-Registry resources by category, domains, and original sources. This page includes form inputs, helpful descriptions, and styling for the comparison tool.
* Included a reference to a new JavaScript file (`resource-compare.js`) and the `js-yaml` library to support the comparison functionality on the compare page.

**Navigation and UI Enhancements:**

* Updated the site navigation in `_includes/header.html` to include a "Compare" link, making the comparison tool easily accessible from anywhere on the site.
* Added "Compare" buttons to the resource detail page (`_layouts/resource_detail.html`), allowing users to quickly compare the current resource with others directly from its detail view. The button is shown regardless of whether an evaluation is available.