### PR TITLE
Curate: update KG resources for provenance and URL fixes

### DIFF
--- a/resource/atom/atom.md
+++ b/resource/atom/atom.md
@@ -22,7 +22,7 @@ domains:
   - health
 homepage_url: https://doi.org/10.1109/BIBM47256.2019.8983062
 id: atom
-last_modified_date: '2025-11-22T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: ATOM
 products:
@@ -44,6 +44,8 @@ products:
     name: ATOM Construction Pipeline
     original_source:
       - source: atom
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_url: https://doi.org/10.1109/BIBM47256.2019.8983062
     warnings:

--- a/resource/biobricks-mesh/biobricks-mesh.md
+++ b/resource/biobricks-mesh/biobricks-mesh.md
@@ -33,6 +33,8 @@ products:
   original_source:
   - source: biobricks-mesh
     relation_type: prov:hadPrimarySource
+  - source: mesh
+    relation_type: prov:hadPrimarySource
   product_url: https://apps.okn.us/biobricks-mesh/sparql
 - id: biobricks-mesh.tpf
   name: BioBricks MeSH TPF
@@ -42,9 +44,11 @@ products:
   original_source:
   - source: biobricks-mesh
     relation_type: prov:hadPrimarySource
+  - source: mesh
+    relation_type: prov:hadPrimarySource
 repository: https://github.com/biobricks-ai/mesh-kg
 creation_date: '2025-12-08T00:00:00Z'
-last_modified_date: '2026-05-19T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 ---
 BioBricks MeSH
 

--- a/resource/biobricks-pubchem-annotations/biobricks-pubchem-annotations.md
+++ b/resource/biobricks-pubchem-annotations/biobricks-pubchem-annotations.md
@@ -32,6 +32,8 @@ products:
   original_source:
   - source: biobricks-pubchem-annotations
     relation_type: prov:hadPrimarySource
+  - source: pubchem
+    relation_type: prov:hadPrimarySource
   product_url: https://apps.okn.us/biobricks-pubchem-annotations/sparql
 - id: biobricks-pubchem-annotations.tpf
   name: BioBricks PubChem Annotations TPF
@@ -41,9 +43,11 @@ products:
   original_source:
   - source: biobricks-pubchem-annotations
     relation_type: prov:hadPrimarySource
+  - source: pubchem
+    relation_type: prov:hadPrimarySource
 repository: https://github.com/biobricks-ai/pubchem-annotations-kg
 creation_date: '2025-12-08T00:00:00Z'
-last_modified_date: '2026-05-19T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 ---
 BioBricks PubChem Annotations
 

--- a/resource/biobricks-toxcast/biobricks-toxcast.md
+++ b/resource/biobricks-toxcast/biobricks-toxcast.md
@@ -32,6 +32,8 @@ products:
   original_source:
   - source: biobricks-toxcast
     relation_type: prov:hadPrimarySource
+  - source: toxcast
+    relation_type: prov:hadPrimarySource
   product_url: https://apps.okn.us/biobricks-toxcast/sparql
 - id: biobricks-toxcast.tpf
   name: BioBricks ToxCast TPF
@@ -41,9 +43,11 @@ products:
   original_source:
   - source: biobricks-toxcast
     relation_type: prov:hadPrimarySource
+  - source: toxcast
+    relation_type: prov:hadPrimarySource
 repository: https://github.com/biobricks-ai/biobricks-okg
 creation_date: '2025-12-08T00:00:00Z'
-last_modified_date: '2026-05-19T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 ---
 BioBricks ToxCast
 

--- a/resource/cam-kp/cam-kp.md
+++ b/resource/cam-kp/cam-kp.md
@@ -38,13 +38,15 @@ products:
     original_source:
       - source: cam-kp
         relation_type: prov:hadPrimarySource
+    warnings:
+      - 'Endpoint was unreachable by automated checks on 2026-05-28; may be retired or intermittently unavailable.'
   - category: ProgrammingInterface
     description: TRAPI-compliant REST API for programmatic access to causal knowledge graphs supporting Translator ecosystem integration and federated querying
     format: http
     id: cam-kp.api
     is_public: true
     name: CAM-KP REST API
-    product_url: https://cam-kp-api-dev.renci.org/1.2.0/query
+    product_url: https://automat.renci.org/cam-kp
     original_source:
       - source: cam-kp
         relation_type: prov:hadPrimarySource
@@ -85,6 +87,8 @@ products:
         relation_type: prov:hadPrimarySource
       - source: ctd
         relation_type: prov:hadPrimarySource
+      - source: doid
+        relation_type: prov:hadPrimarySource
   - category: DocumentationProduct
     description: Comprehensive API documentation, SPARQL endpoint documentation, and developer guides for querying and integrating CAM-KP
     format: http
@@ -95,6 +99,8 @@ products:
     original_source:
       - source: cam-kp
         relation_type: prov:hadPrimarySource
+    warnings:
+      - Repository was archived by the owner in 2024; documentation may be historical.
 publications:
   - authors:
       - Balhoff JP
@@ -157,7 +163,7 @@ publications:
 repository: https://github.com/ExposuresProvider/cam-kp-api
 taxon:
   - NCBITaxon:1
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 ---
 
 # CAM-KP (Causal Activity Models Knowledge Provider)

--- a/resource/catalogue-of-life/catalogue-of-life.md
+++ b/resource/catalogue-of-life/catalogue-of-life.md
@@ -60,6 +60,10 @@ products:
     original_source:
       - source: catalogue-of-life
         relation_type: prov:hadPrimarySource
+      - source: itis
+        relation_type: prov:hadPrimarySource
+      - source: gbif
+        relation_type: prov:hadPrimarySource
   - category: Product
     description: Downloadable Catalogue of Life datasets in multiple standardized formats including Catalogue of Life Data Package (ColDP), Darwin Core Archive, ACEF, TextTree, and MySQL dumps
     id: catalogue-of-life.downloads
@@ -68,11 +72,17 @@ products:
     original_source:
       - source: catalogue-of-life
         relation_type: prov:hadPrimarySource
+      - source: itis
+        relation_type: prov:hadPrimarySource
+      - source: gbif
+        relation_type: prov:hadPrimarySource
+    warnings:
+      - 'Automated checks may return HTTP 418 due to anti-bot challenge on catalogueoflife.org download pages; URL is retained as the canonical human-access endpoint.'
   - category: Product
     description: ChecklistBank repository infrastructure for publishing, discovery, and management of taxonomic datasets with data standardization to ColDP format and quality control workflows
     id: catalogue-of-life.checklistbank
     name: ChecklistBank Repository
-    product_url: https://checklistbank.org/
+    product_url: https://www.checklistbank.org/
     original_source:
       - source: catalogue-of-life
         relation_type: prov:hadPrimarySource
@@ -114,7 +124,7 @@ synonyms:
   - Catalogue of Life Checklist
 taxon:
   - NCBITaxon:1
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 ---
 
 # Catalogue of Life

--- a/resource/cfde-ddkg/cfde-ddkg.md
+++ b/resource/cfde-ddkg/cfde-ddkg.md
@@ -12,7 +12,7 @@ domains:
   - health
 homepage_url: https://dd-kg-ui.cfde.cloud/about
 id: cfde-ddkg
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 layout: resource_detail
 name: Data Distillery Knowledge Graph (DDKG)
 products:
@@ -24,6 +24,10 @@ products:
     original_source:
       - source: cfde-ddkg
         relation_type: prov:hadPrimarySource
+      - source: ubkg
+        relation_type: prov:hadPrimarySource
+      - source: umls
+        relation_type: prov:hadPrimarySource
     product_url: https://dd-kg-ui.cfde.cloud/
   - category: Product
     description: JSON manifest listing downloadable DDKG resources and files.
@@ -32,6 +36,10 @@ products:
     name: DDKG Downloads Manifest
     original_source:
       - source: cfde-ddkg
+        relation_type: prov:hadPrimarySource
+      - source: ubkg
+        relation_type: prov:hadPrimarySource
+      - source: umls
         relation_type: prov:hadPrimarySource
     product_file_size: 5216
     product_url: https://s3.amazonaws.com/maayan-kg/dd-kg/minio/downloads.json

--- a/resource/cfde-gse/cfde-gse.md
+++ b/resource/cfde-gse/cfde-gse.md
@@ -28,7 +28,7 @@ domains:
 - biological systems
 homepage_url: https://cfde.cloud/gse/
 id: cfde-gse
-last_modified_date: '2025-09-23T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -65,6 +65,14 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cfde-gse
+  - relation_type: prov:hadPrimarySource
+    source: kegg
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: msigdb
+  - relation_type: prov:hadPrimarySource
+    source: disgenet
 - category: Product
   description: Standardized gene set collections from Common Fund programs in GMT
     format
@@ -73,6 +81,14 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cfde-gse
+  - relation_type: prov:hadPrimarySource
+    source: kegg
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: msigdb
+  - relation_type: prov:hadPrimarySource
+    source: disgenet
   product_url: https://cfde.cloud/gse/downloads/
   warnings:
   - 'File was not able to be retrieved when checked on 2026-05-26: HTTP 404 error

--- a/resource/cfde-gse/cfde-gse.md
+++ b/resource/cfde-gse/cfde-gse.md
@@ -55,6 +55,16 @@ products:
   - relation_type: prov:hadPrimarySource
     source: cfde-gse
   product_url: https://gse.cfde.cloud/api/
+- category: GraphicalInterface
+  description: Interactive graph traversal interface for exploring connections between
+    genes and CFDE program-specific signatures
+  format: http
+  id: cfde-gse.connection-explorer
+  name: CFDE-GSE Connection Explorer
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: cfde-gse
+  product_url: https://gse.cfde.cloud/ConnectionExplorer
 - category: GraphProduct
   description: Neo4j knowledge graph containing integrated gene sets from multiple
     Common Fund programs with cross-references
@@ -73,6 +83,16 @@ products:
     source: msigdb
   - relation_type: prov:hadPrimarySource
     source: disgenet
+  - relation_type: prov:hadPrimarySource
+    source: gtex
+  - relation_type: prov:hadPrimarySource
+    source: hubmap
+  - relation_type: prov:hadPrimarySource
+    source: lincs
+  - relation_type: prov:hadPrimarySource
+    source: glygen
+  - relation_type: prov:hadPrimarySource
+    source: motrpac
 - category: Product
   description: Standardized gene set collections from Common Fund programs in GMT
     format
@@ -89,7 +109,37 @@ products:
     source: msigdb
   - relation_type: prov:hadPrimarySource
     source: disgenet
+  - relation_type: prov:hadPrimarySource
+    source: gtex
+  - relation_type: prov:hadPrimarySource
+    source: hubmap
+  - relation_type: prov:hadPrimarySource
+    source: lincs
+  - relation_type: prov:hadPrimarySource
+    source: glygen
+  - relation_type: prov:hadPrimarySource
+    source: motrpac
   product_url: https://gse.cfde.cloud/downloads/
+- category: Product
+  description: Downloadable node metadata CSV snapshots from the CFDE-GSE downloads
+    page (for example, Gene.nodes.csv and program-specific node tables)
+  format: csv
+  id: cfde-gse.nodes-csv
+  name: CFDE-GSE Node CSV Snapshot
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: cfde-gse
+  product_url: https://s3.amazonaws.com/maayan-kg/cfde-kg/042123/Gene.nodes.csv
+- category: Product
+  description: Downloadable edge/triple CSV snapshots from the CFDE-GSE downloads
+    page using source.relation.target edge files
+  format: csv
+  id: cfde-gse.edges-csv
+  name: CFDE-GSE Edge CSV Snapshot
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: cfde-gse
+  product_url: https://s3.amazonaws.com/maayan-kg/cfde-kg/042123/KOMP2_Mouse_Phenotypes_2022.KOMP2_Mouse_Phenotype.Gene.edges.csv
 publications:
 - authors:
   - Clarke DJB
@@ -105,6 +155,7 @@ publications:
   preferred: true
   title: Cross-program analysis of the CFDE gene sets reveals common biological themes
   year: '2022'
+repository: https://github.com/MaayanLab/CFDE-KG
 ---
 # Common Fund Data Ecosystem Gene Set Enrichment (CFDE-GSE)
 

--- a/resource/cfde-gse/cfde-gse.md
+++ b/resource/cfde-gse/cfde-gse.md
@@ -26,7 +26,7 @@ domains:
 - genomics
 - systems biology
 - biological systems
-homepage_url: https://cfde.cloud/gse/
+homepage_url: https://gse.cfde.cloud/
 id: cfde-gse
 last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
@@ -44,7 +44,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cfde-gse
-  product_url: https://cfde.cloud/gse/
+  product_url: https://gse.cfde.cloud/
 - category: ProgrammingInterface
   description: RESTful API for programmatic access to Common Fund gene set collections
     and enrichment analysis
@@ -54,7 +54,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cfde-gse
-  product_url: https://cfde.cloud/gse/api/
+  product_url: https://gse.cfde.cloud/api/
 - category: GraphProduct
   description: Neo4j knowledge graph containing integrated gene sets from multiple
     Common Fund programs with cross-references
@@ -89,12 +89,7 @@ products:
     source: msigdb
   - relation_type: prov:hadPrimarySource
     source: disgenet
-  product_url: https://cfde.cloud/gse/downloads/
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-05-26: HTTP 404 error
-    when accessing file'
-  - File was not able to be retrieved when checked on 2026-03-30_ HTTP 404 error when
-    accessing file
+  product_url: https://gse.cfde.cloud/downloads/
 publications:
 - authors:
   - Clarke DJB
@@ -110,7 +105,6 @@ publications:
   preferred: true
   title: Cross-program analysis of the CFDE gene sets reveals common biological themes
   year: '2022'
-repository: https://github.com/nih-cfde/cfde-gse
 ---
 # Common Fund Data Ecosystem Gene Set Enrichment (CFDE-GSE)
 

--- a/resource/cl-kg/cl-kg.md
+++ b/resource/cl-kg/cl-kg.md
@@ -29,10 +29,14 @@ products:
     original_source:
       - source: cl-kg
         relation_type: prov:hadPrimarySource
+      - source: cl
+        relation_type: prov:hadPrimarySource
+      - source: cellxgene
+        relation_type: prov:hadPrimarySource
     product_url: https://cellular-semantics.sanger.ac.uk/browser/
 repository: https://github.com/Cellular-Semantics/CL_KG
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 ---
 
 CL-KG is a knowledge graph integrating the cell ontology and linked ontologies with hierarchical annotations of single cell transcriptomics data from CellXGene.

--- a/resource/clinicaltrialsgov/clinicaltrialsgov.md
+++ b/resource/clinicaltrialsgov/clinicaltrialsgov.md
@@ -36,7 +36,7 @@ fairsharing_id: FAIRsharing.mewhad
 homepage_url: https://clinicaltrials.gov/
 id: clinicaltrialsgov
 infores_id: clinicaltrials
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 layout: resource_detail
 license:
   id: https://clinicaltrials.gov/about-site/terms-conditions
@@ -83,6 +83,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: clinicaltrialsgov
+  - relation_type: prov:hadPrimarySource
+    source: aact
   product_url: https://aact.ctti-clinicaltrials.org/
 - category: DocumentationProduct
   description: Comprehensive documentation covering data structure, data element definitions,

--- a/resource/ctkp/ctkp.md
+++ b/resource/ctkp/ctkp.md
@@ -14,7 +14,7 @@ domains:
 - translational
 homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/Clinical-Trials-KP
 id: ctkp
-last_modified_date: '2026-02-18T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: Clinical Trials KP
 products:
@@ -52,6 +52,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ctkp
+  - relation_type: prov:hadPrimarySource
+    source: translator
   product_url: https://github.com/NCATSTranslator/Translator-All/wiki/Clinical-Trials-KP
 - category: GraphProduct
   compatibility:

--- a/resource/drkg/drkg.md
+++ b/resource/drkg/drkg.md
@@ -16,7 +16,7 @@ domains:
 - health
 homepage_url: https://github.com/gnn4dr/DRKG
 id: drkg
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: Drug Repurposing Knowledge Graph
 products:
@@ -29,6 +29,18 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: drkg
+  - relation_type: prov:hadPrimarySource
+    source: dgidb
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: gnbr
+  - relation_type: prov:hadPrimarySource
+    source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: intact
+  - relation_type: prov:hadPrimarySource
+    source: string
   product_file_size: 216650245
   product_url: https://dgl-data.s3-us-west-2.amazonaws.com/dataset/DRKG/drkg.tar.gz
 - category: GraphProduct

--- a/resource/drug-approvals-kp/drug-approvals-kp.md
+++ b/resource/drug-approvals-kp/drug-approvals-kp.md
@@ -20,7 +20,7 @@ domains:
 - drug discovery
 - biomedical
 id: drug-approvals-kp
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: Drug Approvals KP
 products:
@@ -67,6 +67,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: drug-approvals-kp
+  - relation_type: prov:hadPrimarySource
+    source: translator
   product_url: https://github.com/multiomicsKP/drug_approvals_kp
 - category: GraphProduct
   compatibility:

--- a/resource/enrichr-kg/enrichr-kg.md
+++ b/resource/enrichr-kg/enrichr-kg.md
@@ -19,7 +19,7 @@ domains:
   - biological systems
 homepage_url: https://maayanlab.cloud/enrichr-kg/
 id: enrichr-kg
-last_modified_date: '2026-05-21T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -61,6 +61,14 @@ products:
       - source: enrichr-kg
         relation_type: prov:hadPrimarySource
       - source: enrichr
+        relation_type: prov:hadPrimarySource
+      - source: kegg
+        relation_type: prov:hadPrimarySource
+      - source: reactome
+        relation_type: prov:hadPrimarySource
+      - source: wikipathways
+        relation_type: prov:hadPrimarySource
+      - source: disgenet
         relation_type: prov:hadPrimarySource
 publications:
   - authors:

--- a/resource/enrichr-kg/enrichr-kg.md
+++ b/resource/enrichr-kg/enrichr-kg.md
@@ -51,6 +51,15 @@ products:
     secondary_source:
       - source: enrichr
         relation_type: prov:wasInfluencedBy
+  - category: GraphicalInterface
+    description: Download assets page exposing node and edge CSV snapshots for the current Enrichr-KG release
+    format: http
+    id: enrichr-kg.downloads
+    name: Enrichr-KG Downloads
+    product_url: https://maayanlab.cloud/enrichr-kg/downloads
+    original_source:
+      - source: enrichr-kg
+        relation_type: prov:hadPrimarySource
   - category: GraphProduct
     description: Neo4j graph database integrating Enrichr gene set libraries with genes, terms, pathways, diseases, drugs, cell types, and other functional annotations
     dump_format: neo4j
@@ -69,6 +78,54 @@ products:
       - source: wikipathways
         relation_type: prov:hadPrimarySource
       - source: disgenet
+        relation_type: prov:hadPrimarySource
+      - source: go
+        relation_type: prov:hadPrimarySource
+      - source: pfam
+        relation_type: prov:hadPrimarySource
+      - source: depmap
+        relation_type: prov:hadPrimarySource
+      - source: achilles
+        relation_type: prov:hadPrimarySource
+      - source: gtex
+        relation_type: prov:hadPrimarySource
+      - source: hubmap
+        relation_type: prov:hadPrimarySource
+      - source: lincs
+        relation_type: prov:hadPrimarySource
+      - source: archs4
+        relation_type: prov:hadPrimarySource
+      - source: hp
+        relation_type: prov:hadPrimarySource
+      - source: mgi
+        relation_type: prov:hadPrimarySource
+      - source: gwascatalog
+        relation_type: prov:hadPrimarySource
+      - source: kg-jensenlab-diseases
+        relation_type: prov:hadPrimarySource
+  - category: Product
+    description: Node-table CSV snapshot from the Enrichr-KG downloads page containing node metadata for a current release
+    format: csv
+    id: enrichr-kg.nodes-csv
+    name: Enrichr-KG Node CSV Snapshot
+    product_url: https://s3.amazonaws.com/maayan-kg/enrichr-kg/current/Gene.nodes.csv
+    original_source:
+      - source: enrichr-kg
+        relation_type: prov:hadPrimarySource
+      - source: enrichr
+        relation_type: prov:hadPrimarySource
+  - category: Product
+    description: Edge-table CSV snapshot from the Enrichr-KG downloads page using source.relation.target edge triples
+    format: csv
+    id: enrichr-kg.edges-csv
+    name: Enrichr-KG Edge CSV Snapshot
+    product_url: https://s3.amazonaws.com/maayan-kg/enrichr-kg/current/GO_Biological_Process_2021.GO_BP.Gene.edges.csv
+    original_source:
+      - source: enrichr-kg
+        relation_type: prov:hadPrimarySource
+      - source: enrichr
+        relation_type: prov:hadPrimarySource
+      - source: go
         relation_type: prov:hadPrimarySource
 publications:
   - authors:

--- a/resource/evoweb/evoweb.md
+++ b/resource/evoweb/evoweb.md
@@ -4,6 +4,14 @@ name: EvoWeb
 description: EvoWeb - An Open Knowledge Graph of Co-evolving Genes (NIAID)
 activity_status: active
 homepage_url: https://data.niaid.nih.gov/
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: Erik.Wright@bcm.edu
+  - contact_type: github
+    value: WrightLabScience
+  label: Erik Wright
 products:
 - id: evoweb.sparql
   name: EvoWeb SPARQL
@@ -13,6 +21,18 @@ products:
   original_source:
   - source: evoweb
     relation_type: prov:hadPrimarySource
+  - source: corum
+    relation_type: prov:hadPrimarySource
+  - source: string
+    relation_type: prov:hadPrimarySource
+  - source: kegg
+    relation_type: prov:hadPrimarySource
+  - source: refseq
+    relation_type: prov:hadPrimarySource
+  - source: uniprot
+    relation_type: prov:hadPrimarySource
+  - source: ncbigene
+    relation_type: prov:hadPrimarySource
 - id: evoweb.tpf
   name: EvoWeb TPF
   description: Triple Pattern Fragments endpoint for EvoWeb
@@ -21,20 +41,37 @@ products:
   original_source:
   - source: evoweb
     relation_type: prov:hadPrimarySource
+  - source: corum
+    relation_type: prov:hadPrimarySource
+  - source: string
+    relation_type: prov:hadPrimarySource
+  - source: kegg
+    relation_type: prov:hadPrimarySource
+  - source: refseq
+    relation_type: prov:hadPrimarySource
+  - source: uniprot
+    relation_type: prov:hadPrimarySource
+  - source: ncbigene
+    relation_type: prov:hadPrimarySource
 collection:
 - okn
 layout: resource_detail
 category: KnowledgeGraph
 creation_date: '2026-03-30T00:00:00Z'
-last_modified_date: '2026-05-19T00:00:00Z'
-contacts: []
+last_modified_date: '2026-05-27T00:00:00Z'
 domains:
-- general
+- biomedical
+- genomics
+- proteomics
 ---
 EvoWeb
 
 ## Description
 
 EvoWeb - An Open Knowledge Graph of Co-evolving Genes (NIAID)
+
+EvoWeb is a weighted network of protein-protein functional relations reconstructed
+from prior knowledge available from genomic sequences. It continues the EvoWeaver
+project and supports discovery of proteins involved in complexes or biochemical pathways.
 
 *This resource was automatically synchronized from the FRINK OKN registry.*

--- a/resource/forum/forum.md
+++ b/resource/forum/forum.md
@@ -12,7 +12,7 @@ domains:
 - biomedical
 homepage_url: https://forum-webapp.semantic-metabolomics.fr/
 id: forum
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: FORUM
 products:
@@ -23,6 +23,14 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: forum
+  - relation_type: prov:hadPrimarySource
+    source: chebi
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: pubchem
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://forum-webapp.semantic-metabolomics.fr/
 - category: ProgrammingInterface
   description: FORUM REST API for programmatic access to chemical-disease associations
@@ -31,6 +39,14 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: forum
+  - relation_type: prov:hadPrimarySource
+    source: chebi
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: pubchem
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://forum-webapp.semantic-metabolomics.fr/#/openapi-documentation
 - category: DocumentationProduct
   description: FORUM VoID (Vocabulary of Interlinked Datasets) metadata describing
@@ -40,6 +56,14 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: forum
+  - relation_type: prov:hadPrimarySource
+    source: chebi
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: pubchem
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_file_size: 96461
   product_url: https://forum.semantic-metabolomics.fr/.well-known/void
 - category: GraphProduct

--- a/resource/geneticskp/geneticskp.md
+++ b/resource/geneticskp/geneticskp.md
@@ -13,7 +13,7 @@ domains:
 - translational
 homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/Genetics-Knowledge-Provider
 id: geneticskp
-last_modified_date: '2026-02-18T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: Genetics KP
 products:
@@ -50,6 +50,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: geneticskp
+  - relation_type: prov:hadPrimarySource
+    source: translator
   product_url: https://genetics-kp.transltr.io/genetics_provider/trapi/v1.4/
 - category: GraphProduct
   compatibility:

--- a/resource/genophenoenvo-kg/genophenoenvo-kg.md
+++ b/resource/genophenoenvo-kg/genophenoenvo-kg.md
@@ -12,7 +12,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/genophenoenvo/knowledge-graph
 id: genophenoenvo-kg
-last_modified_date: '2025-11-22T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://opensource.org/licenses/BSD-3-Clause
@@ -25,6 +25,18 @@ products:
     name: GenoPhenoEnvo KG Data
     original_source:
       - source: genophenoenvo-kg
+        relation_type: prov:hadPrimarySource
+      - source: go
+        relation_type: prov:hadPrimarySource
+      - source: po
+        relation_type: prov:hadPrimarySource
+      - source: to
+        relation_type: prov:hadPrimarySource
+      - source: peco
+        relation_type: prov:hadPrimarySource
+      - source: tair
+        relation_type: prov:hadPrimarySource
+      - source: interpro
         relation_type: prov:hadPrimarySource
     product_url: https://datacommons.cyverse.org/browse/iplant/home/shared/genophenoenvo
   - category: GraphicalInterface

--- a/resource/gnbr/gnbr.md
+++ b/resource/gnbr/gnbr.md
@@ -23,7 +23,7 @@ domains:
 homepage_url: https://github.com/jakelever/GNBR
 id: gnbr
 infores_id: gnbr
-last_modified_date: '2026-04-16T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -40,6 +40,8 @@ products:
     source: gnbr
   - relation_type: prov:hadPrimarySource
     source: pubtator
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://zenodo.org/records/3459420
 - category: GraphProduct
   description: Cleaned benchmark graph (PharmKG-8k) with typed relations between genes,

--- a/resource/hald/hald.md
+++ b/resource/hald/hald.md
@@ -10,7 +10,7 @@ domains:
   - precision medicine
 homepage_url: https://bis.zju.edu.cn/hald
 id: hald
-last_modified_date: '2026-04-06T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -26,6 +26,8 @@ products:
     original_source:
       - source: hald
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
     product_file_size: 854292307
     product_url: https://ndownloader.figshare.com/files/43612512
   - category: Product
@@ -36,6 +38,8 @@ products:
     name: HALD Entity Info
     original_source:
       - source: hald
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_file_size: 296732271
     product_url: https://ndownloader.figshare.com/files/43612509
@@ -48,6 +52,8 @@ products:
     original_source:
       - source: hald
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
     product_file_size: 98203237
     product_url: https://ndownloader.figshare.com/files/43612506
   - category: Product
@@ -58,6 +64,8 @@ products:
     name: HALD Aging Biomarkers
     original_source:
       - source: hald
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_file_size: 1199321
     product_url: https://ndownloader.figshare.com/files/43612503
@@ -70,6 +78,8 @@ products:
     original_source:
       - source: hald
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
     product_file_size: 339386
     product_url: https://ndownloader.figshare.com/files/43612497
   - category: Product
@@ -80,6 +90,8 @@ products:
     name: HALD Neo4j Entities
     original_source:
       - source: hald
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_file_size: 239792
     product_url: https://ndownloader.figshare.com/files/43612494
@@ -92,6 +104,8 @@ products:
     original_source:
       - source: hald
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
     product_file_size: 5077672
     product_url: https://ndownloader.figshare.com/files/43612500
   - category: GraphicalInterface
@@ -101,6 +115,8 @@ products:
     name: HALD Web Interface
     original_source:
       - source: hald
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_url: https://bis.zju.edu.cn/hald
 publications:

--- a/resource/hetionet/hetionet.md
+++ b/resource/hetionet/hetionet.md
@@ -37,6 +37,30 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: ncbigene
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: doid
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: sider
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: go
+  - relation_type: prov:hadPrimarySource
+    source: wikipathways
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: pid
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
   product_url: https://neo4j.het.io/browser/
 - category: GraphProduct
   description: Hetionet v1.0 in JSON format
@@ -46,6 +70,30 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: ncbigene
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: doid
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: sider
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: go
+  - relation_type: prov:hadPrimarySource
+    source: wikipathways
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: pid
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
   product_file_size: 131
   product_url: https://github.com/hetio/hetionet/blob/master/hetnet/json/hetionet-v1.0.json.bz2
 - category: GraphProduct
@@ -55,6 +103,30 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: ncbigene
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: doid
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: sider
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: go
+  - relation_type: prov:hadPrimarySource
+    source: wikipathways
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: pid
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
   product_file_size: 132
   product_url: https://github.com/hetio/hetionet/blob/master/hetnet/neo4j/hetionet-v1.0.db.tar.bz2
 - category: GraphProduct
@@ -65,6 +137,30 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: ncbigene
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: doid
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: sider
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: go
+  - relation_type: prov:hadPrimarySource
+    source: wikipathways
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: pid
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
   product_file_size: 131
   product_url: https://github.com/hetio/hetionet/blob/main/hetnet/tsv/hetionet-v1.0-edges.sif.gz
 - category: GraphProduct
@@ -75,6 +171,30 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: ncbigene
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: doid
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: sider
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: go
+  - relation_type: prov:hadPrimarySource
+    source: wikipathways
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: pid
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
   product_file_size: 427128
   product_url: https://github.com/hetio/hetionet/blob/main/hetnet/tsv/hetionet-v1.0-nodes.tsv
 - category: ProcessProduct
@@ -85,6 +205,30 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: ncbigene
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: doid
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: sider
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: go
+  - relation_type: prov:hadPrimarySource
+    source: wikipathways
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: pid
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
   product_url: https://github.com/hetio/hetnetpy
 - category: GraphicalInterface
   description: Web application to search and explore connectivity between nodes in
@@ -95,6 +239,30 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: hetionet
+  - relation_type: prov:hadPrimarySource
+    source: ncbigene
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: doid
+  - relation_type: prov:hadPrimarySource
+    source: mesh
+  - relation_type: prov:hadPrimarySource
+    source: sider
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: go
+  - relation_type: prov:hadPrimarySource
+    source: wikipathways
+  - relation_type: prov:hadPrimarySource
+    source: reactome
+  - relation_type: prov:hadPrimarySource
+    source: pid
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
   product_url: https://het.io/search
 - category: GraphicalInterface
   description: A browser interface for a knowledge graph for Alzheimer's Disease.

--- a/resource/hetionet/hetionet.md
+++ b/resource/hetionet/hetionet.md
@@ -22,7 +22,7 @@ domains:
 homepage_url: https://het.io/
 id: hetionet
 infores_id: hetionet
-last_modified_date: '2025-12-13T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -82,6 +82,9 @@ products:
     networks)
   id: hetnetpy
   name: hetnetpy
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: hetionet
   product_url: https://github.com/hetio/hetnetpy
 - category: GraphicalInterface
   description: Web application to search and explore connectivity between nodes in

--- a/resource/icees-kg/icees-kg.md
+++ b/resource/icees-kg/icees-kg.md
@@ -26,7 +26,7 @@ domains:
 homepage_url: https://robokop.renci.org/api-docs/docs/automat/icees-kg
 id: icees-kg
 infores_id: icees-kg
-last_modified_date: '2025-11-05T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: Exposures KP (icees-kg)
 products:
@@ -82,6 +82,8 @@ products:
     source: hmdb
   - relation_type: prov:hadPrimarySource
     source: icees-kg
+  - relation_type: prov:hadPrimarySource
+    source: translator
   product_url: https://robokop.renci.org/api-docs/docs/automat/icees-kg-trapi
 - category: Product
   description: Meta knowledge graph and metadata describing the data sources, node
@@ -108,6 +110,8 @@ products:
     source: hmdb
   - relation_type: prov:hadPrimarySource
     source: icees-kg
+  - relation_type: prov:hadPrimarySource
+    source: translator
   product_url: https://robokop.renci.org/api-docs/docs/automat/metadata-metadata-get-icees-kg
 - category: GraphProduct
   compatibility:

--- a/resource/idisk/idisk.md
+++ b/resource/idisk/idisk.md
@@ -21,7 +21,7 @@ domains:
 homepage_url: https://doi.org/10.13020/d6bm3v
 id: idisk
 infores_id: idisk
-last_modified_date: '2026-04-16T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://conservancy.umn.edu/handle/11299/204783
@@ -72,6 +72,8 @@ products:
     source: tissues
   - relation_type: prov:hadPrimarySource
     source: uberon
+  - relation_type: prov:hadPrimarySource
+    source: umls
 publications:
 - id: doi:10.1093/jamia/ocz216
   preferred: true

--- a/resource/ikraph/ikraph.md
+++ b/resource/ikraph/ikraph.md
@@ -23,7 +23,7 @@ domains:
   - genomics
 homepage_url: https://biokde.insilicom.com/
 id: ikraph
-last_modified_date: '2025-07-22T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -38,6 +38,8 @@ products:
     original_source:
       - source: ikraph
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
     product_url: https://biokde.insilicom.com/
   - category: ProcessProduct
     description: Code for named entity recognition, relation extraction, and drug repurposing in assembly and analysis of iKraph
@@ -48,6 +50,8 @@ products:
     name: iKraph Code
     original_source:
       - source: ikraph
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_url: https://github.com/myinsilicom/iKraph
     repository: https://github.com/myinsilicom/iKraph
@@ -60,6 +64,8 @@ products:
     original_source:
       - source: ikraph
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
     product_file_size: 61183533
     product_url: https://zenodo.org/records/14851275/files/data.tar.gz?download=1
   - category: GraphProduct
@@ -69,6 +75,8 @@ products:
     name: iKraph graph data
     original_source:
       - source: ikraph
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_file_size: 1440676039
     product_url: https://zenodo.org/records/14851275/files/iKraph_full.tar.gz?download=1

--- a/resource/lncrnalyzr/lncrnalyzr.md
+++ b/resource/lncrnalyzr/lncrnalyzr.md
@@ -17,7 +17,7 @@ domains:
   - systems biology
 homepage_url: https://lncrnalyzr.maayanlab.cloud/
 id: lncrnalyzr
-last_modified_date: '2025-09-23T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -50,6 +50,20 @@ products:
     name: lncRNAlyzr Knowledge Graph
     original_source:
       - source: lncrnalyzr
+        relation_type: prov:hadPrimarySource
+      - source: gencode
+        relation_type: prov:hadPrimarySource
+      - source: noncode
+        relation_type: prov:hadPrimarySource
+      - source: gtex
+        relation_type: prov:hadPrimarySource
+      - source: encode
+        relation_type: prov:hadPrimarySource
+      - source: go
+        relation_type: prov:hadPrimarySource
+      - source: kegg
+        relation_type: prov:hadPrimarySource
+      - source: doid
         relation_type: prov:hadPrimarySource
 publications:
   - id: doi:10.1016/j.jmb.2025.168938

--- a/resource/mangal/mangal.md
+++ b/resource/mangal/mangal.md
@@ -11,7 +11,9 @@ contacts:
     label: Mangal
 creation_date: '2025-12-15T00:00:00Z'
 description: mangal.io is a collaborative database and analysis platform for ecological networks, providing a comprehensive collection of species interaction networks (food webs, pollination networks, plant-herbivore networks) with tools for visualization, analysis, and reuse of published ecological data.
-domains: []
+domains:
+  - environment
+  - biological systems
 homepage_url: https://mangal.io/
 id: mangal
 last_modified_date: '2025-12-15T00:00:00Z'
@@ -30,6 +32,12 @@ products:
     original_source:
       - source: mangal
         relation_type: prov:hadPrimarySource
+      - source: catalogue-of-life
+        relation_type: prov:hadPrimarySource
+      - source: gbif
+        relation_type: prov:hadPrimarySource
+      - source: itis
+        relation_type: prov:hadPrimarySource
   - category: ProgrammingInterface
     description: RESTful API for programmatic access to network data and metadata
     format: http
@@ -40,6 +48,12 @@ products:
     original_source:
       - source: mangal
         relation_type: prov:hadPrimarySource
+      - source: catalogue-of-life
+        relation_type: prov:hadPrimarySource
+      - source: gbif
+        relation_type: prov:hadPrimarySource
+      - source: itis
+        relation_type: prov:hadPrimarySource
   - category: DocumentationProduct
     description: API documentation, user guides, and data model specification
     format: http
@@ -48,6 +62,12 @@ products:
     product_url: https://mangal.io/documentation
     original_source:
       - source: mangal
+        relation_type: prov:hadPrimarySource
+      - source: catalogue-of-life
+        relation_type: prov:hadPrimarySource
+      - source: gbif
+        relation_type: prov:hadPrimarySource
+      - source: itis
         relation_type: prov:hadPrimarySource
 taxon:
   - NCBITaxon:33208

--- a/resource/maudekg/maudekg.md
+++ b/resource/maudekg/maudekg.md
@@ -5,6 +5,14 @@ description: Knowledge graph constructed from FDA MAUDE adverse event reports us
   standardized FDA product codes.
 activity_status: active
 homepage_url: https://github.com/Prabhadeus/Proto-OKN
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: psingh37@pride.hofstra.edu
+  - contact_type: github
+    value: Prabhadeus
+  label: Prabhjot Singh
 products:
 - id: maudekg.sparql
   name: FDA MAUDE Adverse Event Knowledge Graph SPARQL
@@ -28,15 +36,16 @@ collection:
 layout: resource_detail
 category: KnowledgeGraph
 creation_date: '2026-03-30T00:00:00Z'
-last_modified_date: '2026-05-19T00:00:00Z'
-contacts: []
+last_modified_date: '2026-05-27T00:00:00Z'
 domains:
-- general
+- biomedical
+- clinical
+- pharmacology
 ---
 FDA MAUDE Adverse Event Knowledge Graph
 
 ## Description
 
-Knowledge graph constructed from FDA MAUDE adverse event reports using standardized FDA product codes.
+Knowledge graph constructed from FDA MAUDE adverse event reports retrieved via the openFDA MAUDE API using standardized FDA product codes.
 
 *This resource was automatically synchronized from the FRINK OKN registry.*

--- a/resource/medkg/medkg.md
+++ b/resource/medkg/medkg.md
@@ -9,7 +9,9 @@ contacts:
     label: Prabha Garg
 description: MedKG is a comprehensive and continuously updated knowledge graph designed to address challenges in precision medicine and drug discovery. MedKG integrates data from 35 authoritative sources, encompassing 34 node types and 79 relationships. A Continuous Integration/Continuous Update pipeline ensures MedKG remains current, addressing a critical limitation of static knowledge bases. The integration of molecular embeddings enhances semantic analysis capabilities, bridging the gap between chemical structures and biological entities.
 domains:
-  - biological systems
+  - biomedical
+  - pharmacology
+  - chemistry and biochemistry
 homepage_url: http://pitools.niper.ac.in/medkg/
 id: medkg
 layout: resource_detail
@@ -21,6 +23,38 @@ products:
     name: MedKG Site
     original_source:
       - source: medkg
+        relation_type: prov:hadPrimarySource
+      - source: mondo
+        relation_type: prov:hadPrimarySource
+      - source: go
+        relation_type: prov:hadPrimarySource
+      - source: uberon
+        relation_type: prov:hadPrimarySource
+      - source: chebi
+        relation_type: prov:hadPrimarySource
+      - source: omim
+        relation_type: prov:hadPrimarySource
+      - source: reactome
+        relation_type: prov:hadPrimarySource
+      - source: drugbank
+        relation_type: prov:hadPrimarySource
+      - source: hmdb
+        relation_type: prov:hadPrimarySource
+      - source: ttd
+        relation_type: prov:hadPrimarySource
+      - source: uniprot
+        relation_type: prov:hadPrimarySource
+      - source: hgnc
+        relation_type: prov:hadPrimarySource
+      - source: doid
+        relation_type: prov:hadPrimarySource
+      - source: mesh
+        relation_type: prov:hadPrimarySource
+      - source: gwascatalog
+        relation_type: prov:hadPrimarySource
+      - source: snomedct
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
         relation_type: prov:hadPrimarySource
     product_url: http://pitools.niper.ac.in/medkg/
     secondary_source:
@@ -36,7 +70,7 @@ publications:
     title: '''MedKG: enabling drug discovery through a unified biomedical knowledge graph'''
     year: '2025'
 creation_date: '2025-03-24T00:00:00Z'
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 ---
 
 MedKG

--- a/resource/mind/mind.md
+++ b/resource/mind/mind.md
@@ -24,7 +24,7 @@ domains:
 - biomedical
 homepage_url: https://zenodo.org/records/8117748
 id: mind
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -46,6 +46,10 @@ products:
     source: mechreponet
   - relation_type: prov:hadPrimarySource
     source: mind
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: mesh
   product_url: https://zenodo.org/records/8117748/files/train.txt
   warnings:
   - 'File was not able to be retrieved when checked on 2026-05-26: No Content-Length
@@ -71,6 +75,10 @@ products:
     source: mechreponet
   - relation_type: prov:hadPrimarySource
     source: mind
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: mesh
   product_url: https://zenodo.org/records/8117748/files/test.txt
   warnings:
   - 'File was not able to be retrieved when checked on 2026-05-26: No Content-Length
@@ -95,6 +103,10 @@ products:
     source: mechreponet
   - relation_type: prov:hadPrimarySource
     source: mind
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: mesh
   product_url: https://zenodo.org/records/8117748/files/valid.txt
   warnings:
   - 'File was not able to be retrieved when checked on 2026-05-26: No Content-Length
@@ -120,6 +132,10 @@ products:
     source: mechreponet
   - relation_type: prov:hadPrimarySource
     source: mind
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: mesh
   product_file_size: 5629618
   product_url: https://zenodo.org/records/8117748/files/entities.dict
 - category: Product
@@ -137,6 +153,10 @@ products:
     source: mechreponet
   - relation_type: prov:hadPrimarySource
     source: mind
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  - relation_type: prov:hadPrimarySource
+    source: mesh
   product_file_size: 1648
   product_url: https://zenodo.org/records/8117748/files/relations.dict
 publications:

--- a/resource/openbiodiv/openbiodiv.md
+++ b/resource/openbiodiv/openbiodiv.md
@@ -31,6 +31,8 @@ products:
     original_source:
       - source: openbiodiv
         relation_type: prov:hadPrimarySource
+      - source: gbif
+        relation_type: prov:hadPrimarySource
   - category: ProgrammingInterface
     description: SPARQL endpoint for complex semantic queries across the biodiversity knowledge graph, enabling advanced queries combining taxonomic, literature, specimen, and ecological data
     format: http
@@ -41,6 +43,8 @@ products:
     original_source:
       - source: openbiodiv
         relation_type: prov:hadPrimarySource
+      - source: gbif
+        relation_type: prov:hadPrimarySource
   - category: ProgrammingInterface
     description: RESTful API for programmatic access to OpenBiodiv biodiversity data with Swagger API documentation for easy integration
     format: http
@@ -50,6 +54,8 @@ products:
     product_url: https://graph.openbiodiv.net/webapi
     original_source:
       - source: openbiodiv
+        relation_type: prov:hadPrimarySource
+      - source: gbif
         relation_type: prov:hadPrimarySource
   - category: OntologyProduct
     description: OpenBioDiv-O, the OpenBiodiv Ontology
@@ -109,7 +115,7 @@ publications:
 repository: https://github.com/pensoft/OpenBiodiv
 taxon:
   - NCBITaxon:1
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 ---
 
 # OpenBiodiv

--- a/resource/petagraph/petagraph.md
+++ b/resource/petagraph/petagraph.md
@@ -45,6 +45,14 @@ products:
         relation_type: prov:hadPrimarySource
       - source: string
         relation_type: prov:hadPrimarySource
+      - source: gtex
+        relation_type: prov:hadPrimarySource
+      - source: clinvar
+        relation_type: prov:hadPrimarySource
+      - source: glygen
+        relation_type: prov:hadPrimarySource
+      - source: lincs
+        relation_type: prov:hadPrimarySource
     product_url: https://ubkg-downloads.xconsortia.org/
 publications:
   - authors:
@@ -70,7 +78,7 @@ repository: https://github.com/TaylorResearchLab/Petagraph
 taxon:
   - NCBITaxon:9606
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2026-05-27T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 ---
 
 ## Petagraph: A Large-Scale Biomedical Knowledge Graph

--- a/resource/petagraph/petagraph.md
+++ b/resource/petagraph/petagraph.md
@@ -41,6 +41,10 @@ products:
         relation_type: prov:hadPrimarySource
       - source: ubkg
         relation_type: prov:hadPrimarySource
+      - source: umls
+        relation_type: prov:hadPrimarySource
+      - source: string
+        relation_type: prov:hadPrimarySource
     product_url: https://ubkg-downloads.xconsortia.org/
 publications:
   - authors:
@@ -66,7 +70,7 @@ repository: https://github.com/TaylorResearchLab/Petagraph
 taxon:
   - NCBITaxon:9606
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2025-12-13T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 ---
 
 ## Petagraph: A Large-Scale Biomedical Knowledge Graph

--- a/resource/rdkg/rdkg.md
+++ b/resource/rdkg/rdkg.md
@@ -10,11 +10,36 @@ collection:
 layout: resource_detail
 category: KnowledgeGraph
 creation_date: '2026-03-30T00:00:00Z'
-last_modified_date: '2026-03-30T00:00:00Z'
-contacts: []
-products: []
+last_modified_date: '2026-05-27T00:00:00Z'
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: jinlian.wang@uth.tmc.edu
+  - contact_type: github
+    value: wnagjl99
+  label: Jinlian Wang
+products:
+- category: ProgrammingInterface
+  description: Triple Pattern Fragments endpoint for RDKG
+  format: http
+  id: rdkg.tpf
+  name: RDKG TPF
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: rdkg
+  - relation_type: prov:hadPrimarySource
+    source: mondo
+  - relation_type: prov:hadPrimarySource
+    source: ordo
+  - relation_type: prov:hadPrimarySource
+    source: omim
+  - relation_type: prov:hadPrimarySource
+    source: umls
+  product_url: https://apps.okn.us/ldf/rdkg
 domains:
-- general
+- biomedical
+- clinical
 ---
 Rare Disease Knowledge Graph
 

--- a/resource/redrugs/redrugs.md
+++ b/resource/redrugs/redrugs.md
@@ -11,7 +11,7 @@ domains:
   - translational
 homepage_url: http://redrugs.tw.rpi.edu/
 id: redrugs
-last_modified_date: '2025-11-22T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -25,6 +25,14 @@ products:
     original_source:
       - source: redrugs
         relation_type: prov:hadPrimarySource
+      - source: drugbank
+        relation_type: prov:hadPrimarySource
+      - source: irefindex
+        relation_type: prov:hadPrimarySource
+      - source: omim
+        relation_type: prov:hadPrimarySource
+      - source: cosmic
+        relation_type: prov:hadPrimarySource
     product_url: http://redrugs.tw.rpi.edu/
   - category: ProgrammingInterface
     description: SADI web services API for querying the knowledge graph including resource search, interaction lookup, and network expansion
@@ -32,6 +40,14 @@ products:
     name: ReDrugs API
     original_source:
       - source: redrugs
+        relation_type: prov:hadPrimarySource
+      - source: drugbank
+        relation_type: prov:hadPrimarySource
+      - source: irefindex
+        relation_type: prov:hadPrimarySource
+      - source: omim
+        relation_type: prov:hadPrimarySource
+      - source: cosmic
         relation_type: prov:hadPrimarySource
     product_url: http://redrugs.tw.rpi.edu/api/
 publications:

--- a/resource/reprotox-kg/reprotox-kg.md
+++ b/resource/reprotox-kg/reprotox-kg.md
@@ -4,21 +4,18 @@ category: KnowledgeGraph
 contacts:
 - category: Organization
   contact_details:
-  - contact_type: email
-    value: contact@reprotox-kg.net
+  - contact_type: github
+    value: MaayanLab
   - contact_type: url
-    value: https://reprotox-kg.net/about
-  label: ReproTox-KG Consortium
+    value: https://maayanlab.cloud/
+  label: Ma'ayan Lab
 creation_date: '2025-09-23T00:00:00Z'
-description: ReproTox-KG is a specialized knowledge graph focused on reproductive
-  toxicology, integrating chemical exposure data with reproductive health outcomes,
-  developmental toxicity information, and mechanistic pathways to support risk assessment
-  and regulatory decision-making for reproductive and developmental health.
+description: ReproTox-KG is a knowledge graph for structural birth defects and reproductive toxicology that integrates literature-derived and chemical evidence to support exploration of drug-birth defect relationships.
 domains:
 - biomedical
 - toxicology
 - drug discovery
-homepage_url: https://reprotox-kg.net/
+homepage_url: https://maayanlab.cloud/reprotox-kg
 id: reprotox-kg
 last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
@@ -28,44 +25,41 @@ license:
 name: ReproTox-KG
 products:
 - category: GraphicalInterface
-  description: Web portal for exploring reproductive toxicology knowledge with chemical-outcome
-    relationship visualization
+  description: Public web interface for querying and exploring ReproTox-KG relationships.
   format: http
   id: reprotox-kg.portal
   name: ReproTox-KG Explorer
   original_source:
   - relation_type: prov:hadPrimarySource
     source: reprotox-kg
-  product_url: https://reprotox-kg.net/
-- category: ProgrammingInterface
-  description: API for programmatic access to reproductive toxicology data and relationships
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
+  - relation_type: prov:hadPrimarySource
+    source: pubchem
+  product_url: https://maayanlab.cloud/reprotox-kg
+- category: ProcessProduct
+  description: Source repository for the ReproTox-KG website assets, schema, and ingestion notebooks.
   format: http
-  id: reprotox-kg.api
-  name: ReproTox-KG API
+  id: reprotox-kg.code
+  name: ReproTox-KG Source Repository
   original_source:
   - relation_type: prov:hadPrimarySource
     source: reprotox-kg
-  product_url: https://reprotox-kg.net/api/
-- category: GraphProduct
-  description: Neo4j database containing integrated reproductive toxicology data with
-    chemicals, endpoints, and mechanistic pathways
-  dump_format: neo4j
-  format: neo4j
-  id: reprotox-kg.graph
-  name: ReproTox-KG Database
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: reprotox-kg
-  - relation_type: prov:hadPrimarySource
-    source: pubmed
-  - relation_type: prov:hadPrimarySource
-    source: pubchem
+  product_url: https://github.com/MaayanLab/Reprotox-KG
 - category: Product
-  description: Curated dataset of reproductive toxicity studies with standardized
-    endpoints and exposure conditions
+  description: Knowledge graph schema definition used by ReproTox-KG.
   format: json
-  id: reprotox-kg.dataset
-  name: ReproTox Dataset
+  id: reprotox-kg.schema
+  name: ReproTox-KG Schema
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: reprotox-kg
+  product_url: https://github.com/MaayanLab/Reprotox-KG/blob/main/schema.json
+- category: Product
+  description: Data and content assets published with ReproTox-KG (markdown and supporting materials).
+  format: http
+  id: reprotox-kg.data
+  name: ReproTox-KG Data Assets
   original_source:
   - relation_type: prov:hadPrimarySource
     source: reprotox-kg
@@ -73,460 +67,47 @@ products:
     source: pubmed
   - relation_type: prov:hadPrimarySource
     source: pubchem
-  product_url: https://reprotox-kg.net/downloads/
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-05-26: Error connecting
-    to URL: HTTPSConnectionPool(host=''reprotox-kg.net'', port=443): Max retries exceeded
-    with url: /downloads/ (Caused by NameResolutionError("HTTPSConnection(host=''reprotox-kg.net'',
-    port=443): Failed to resolve ''reprotox-kg.net'' ([Errno -2] Name or service not
-    known)"))'
-  - File was not able to be retrieved when checked on 2026-03-30_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("HTTPSConnection(host='reprotox-kg.net',
-    port=443)_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name or service not
-    known)"))
-  - File was not able to be retrieved when checked on 2025-12-13_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fb70a90bca0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-11_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f1820e5c740>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-11_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f20850aef50>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-11_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f8e7e70b470>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-11_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f643ec7d4e0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-09_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f27e2f7aaa0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-08_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fa0ec1388c0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-08_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f1b7d8cefb0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-08_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fa6d3930160>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-05_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f3aceb0b1c0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-04_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f3d84ca3340>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-04_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fd6e7cc9c70>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-12-04_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fe0f7ab6b30>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-26_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f43593ee620>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-25_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f7a1b98f7d0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-25_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fecb12297e0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-22_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fa9b78da470>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-21_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f182c0516c0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-19_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f215b1435e0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-19_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fb977ee1960>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-17_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fd6850c4d60>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-13_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f2f77360550>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-11_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f2b10012dd0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-10_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f9f98706710>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-09_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f313ecd7eb0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-06_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f72c9f8ad10>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-05_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7ff27e44b8b0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-11-04_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f27e0865480>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-31_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f5000a936e0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-31_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f9e1fc012a0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-30_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f225f01ea20>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-30_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f7e93b11c10>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-30_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f9752c8ea70>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-30_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7ff657ea2660>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-29_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fd84ef59ac0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-29_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f6f5c7205e0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-28_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f4dcd6998a0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-27_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f1fbf99e060>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-27_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f6604e0db10>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-21_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f3808239be0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-21_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f2c243ef160>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-15_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f9fb9e00140>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-15_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f07feb7e8c0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-10_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fa66366cdd0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-10_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fab00807b60>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-10_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7efee9258670>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-09_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f4048109dc0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-09_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f9db802a3e0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-08_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f08401c3e30>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-08_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f52197a2c80>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-08_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fca2e2161d0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-07_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f601743e620>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-06_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f7314e5a000>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-10-06_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f8990304e00>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-29_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f8951c5a960>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-29_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f4ba4154320>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-29_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f1e66685c90>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-28_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7ff961640c20>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-28_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7ff8041e85f0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-28_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fea6cfd1610>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-28_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7ffa1e776360>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-27_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fd098164590>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-27_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f53b1208fb0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-27_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f1c17438040>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-25_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f1ecab83470>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-24_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f3cc32ff7d0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-24_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f14ff3fb940>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-23_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7fcd1fc6dd30>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-23_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f852bc83ce0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
-  - File was not able to be retrieved when checked on 2025-09-23_ Error connecting
-    to URL_ HTTPSConnectionPool(host='reprotox-kg.net', port=443)_ Max retries exceeded
-    with url_ /downloads/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection
-    object at 0x7f01f5009cc0>_ Failed to resolve 'reprotox-kg.net' ([Errno -2] Name
-    or service not known)"))
+  product_url: https://github.com/MaayanLab/Reprotox-KG/tree/main/markdown
 publications:
 - authors:
-  - Smith AB
-  - Johnson CD
-  - Williams EF
-  - Brown GH
-  - Davis IJ
-  id: doi:10.1016/j.reprotox.2023.108380
-  journal: Reproductive Toxicology
+  - Evangelista JE
+  - Clarke DJB
+  - Xie Z
+  - Marino GB
+  - Utti V
+  - Jenkins SL
+  - Ahooyi TM
+  - Bologa CG
+  - Yang JJ
+  - Binder JL
+  - Kumar P
+  - Lambert CG
+  - Grethe JS
+  - Wenger E
+  - Taylor D
+  - Oprea TI
+  - de Bono B
+  - Ma'ayan A
+  doi: 10.1038/s43856-023-00329-2
+  id: PMID:37460679
+  journal: Communications Medicine
   preferred: true
-  title: 'ReproTox-KG: A knowledge graph for reproductive and developmental toxicology'
+  title: Toxicology knowledge graph for structural birth defects
   year: '2023'
-repository: https://github.com/reprotox-kg/reprotox-kg
+repository: https://github.com/MaayanLab/Reprotox-KG
 ---
 # ReproTox-KG
 
-ReproTox-KG is a comprehensive knowledge graph specifically designed for reproductive and developmental toxicology research and risk assessment. It integrates diverse data sources including chemical properties, toxicity studies, mechanistic information, and regulatory assessments to provide a unified resource for understanding reproductive health risks.
+ReproTox-KG is a knowledge graph focused on reproductive toxicology and structural birth defects.
 
-## Key Features
+## Current Access Points
 
-### Comprehensive Toxicology Integration
-- Integration of reproductive and developmental toxicity studies from multiple databases
-- Chemical structure and property data linked to toxicological outcomes
-- Mechanistic pathway information connecting molecular targets to adverse outcomes
-- Regulatory assessment data from international agencies (EPA, ECHA, FDA)
+- Public interface: https://maayanlab.cloud/reprotox-kg
+- Source repository: https://github.com/MaayanLab/Reprotox-KG
 
-### Standardized Endpoints
-- Harmonized reproductive toxicity endpoints across studies
-- Developmental toxicity classifications with standardized terminology
-- Dose-response relationship modeling and visualization
-- Species-specific and route-specific exposure data
+## Notes
 
-### Mechanistic Understanding
-- Adverse Outcome Pathway (AOP) integration for mechanistic insights
-- Molecular initiating events linked to reproductive outcomes
-- Key events and biomarkers for reproductive toxicity
-- Cross-species extrapolation frameworks
-
-## Data Sources
-
-### Regulatory Databases
-- EPA ToxRefDB reproductive toxicity studies
-- ECHA REACH registration dossiers
-- FDA reproductive toxicity guidelines and assessments
-- OECD test guideline study results
-
-### Literature Sources
-- PubMed abstracts focused on reproductive toxicology
-- Systematic reviews and meta-analyses
-- Case studies and epidemiological data
-- In vitro mechanistic studies
-
-### Chemical Information
-- Chemical structure data from ChEMBL and PubChem
-- Physicochemical properties affecting bioavailability
-- Metabolic pathway information and biotransformation
-- Environmental fate and exposure modeling data
-
-### Biological Pathways
-- Reproductive hormone signaling pathways
-- Developmental gene regulatory networks
-- Endocrine disruption mechanisms
-- Gamete development and fertility pathways
-
-## Applications
-
-### Risk Assessment
-- Chemical hazard identification for reproductive effects
-- Dose-response modeling for regulatory decision-making
-- Species extrapolation and human relevance assessment
-- Uncertainty quantification in risk characterization
-
-### Drug Development
-- Early screening for reproductive toxicity potential
-- Mechanism-based safety assessment strategies
-- Biomarker identification for reproductive toxicity
-- Alternative testing method development and validation
-
-### Regulatory Science
-- Support for regulatory guidelines development
-- Evidence synthesis for chemical assessments
-- Cross-agency data harmonization initiatives
-- Transparency in regulatory decision-making processes
-
-### Research Applications
-- Hypothesis generation for mechanistic studies
-- Study design optimization for reproductive toxicity testing
-- Data mining for novel toxicity patterns
-- Comparative toxicology across chemical classes
-
-## Technical Implementation
-ReproTox-KG is built using Neo4j graph database technology with standardized ontologies for chemical entities, biological processes, and toxicological endpoints. The knowledge graph incorporates confidence scoring for relationships based on study quality and evidence weight, enabling users to assess the reliability of toxicological associations.
+The legacy reprotox-kg.net endpoints appear to have been retired. This entry now points to the currently maintained Ma'ayan Lab resources and removes stale URL-check warnings tied to the abandoned domain.
 
 ## Automated Evaluation
 

--- a/resource/reprotox-kg/reprotox-kg.md
+++ b/resource/reprotox-kg/reprotox-kg.md
@@ -20,7 +20,7 @@ domains:
 - drug discovery
 homepage_url: https://reprotox-kg.net/
 id: reprotox-kg
-last_modified_date: '2025-09-23T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by-nc/4.0/
@@ -56,6 +56,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: reprotox-kg
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
+  - relation_type: prov:hadPrimarySource
+    source: pubchem
 - category: Product
   description: Curated dataset of reproductive toxicity studies with standardized
     endpoints and exposure conditions
@@ -65,6 +69,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: reprotox-kg
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
+  - relation_type: prov:hadPrimarySource
+    source: pubchem
   product_url: https://reprotox-kg.net/downloads/
   warnings:
   - 'File was not able to be retrieved when checked on 2026-05-26: Error connecting

--- a/resource/rtx-kg2/rtx-kg2.md
+++ b/resource/rtx-kg2/rtx-kg2.md
@@ -70,6 +70,18 @@ products:
         relation_type: prov:hadPrimarySource
       - source: semmeddb
         relation_type: prov:hadPrimarySource
+      - source: doid
+        relation_type: prov:hadPrimarySource
+      - source: umls
+        relation_type: prov:hadPrimarySource
+      - source: hmdb
+        relation_type: prov:hadPrimarySource
+      - source: intact
+        relation_type: prov:hadPrimarySource
+      - source: ncbigene
+        relation_type: prov:hadPrimarySource
+      - source: smpdb
+        relation_type: prov:hadPrimarySource
     product_file_size: 376501785
     product_url: https://rtx-kg2-public.s3.us-west-2.amazonaws.com/kg2c-2.10.1-v1.0-nodes.jsonl.gz
   - category: GraphProduct
@@ -113,6 +125,18 @@ products:
       - source: rtx-kg2
         relation_type: prov:hadPrimarySource
       - source: semmeddb
+        relation_type: prov:hadPrimarySource
+      - source: doid
+        relation_type: prov:hadPrimarySource
+      - source: umls
+        relation_type: prov:hadPrimarySource
+      - source: hmdb
+        relation_type: prov:hadPrimarySource
+      - source: intact
+        relation_type: prov:hadPrimarySource
+      - source: ncbigene
+        relation_type: prov:hadPrimarySource
+      - source: smpdb
         relation_type: prov:hadPrimarySource
     product_file_size: 1807360397
     product_url: https://rtx-kg2-public.s3.us-west-2.amazonaws.com/kg2c-2.10.1-v1.0-edges.jsonl.gz
@@ -168,6 +192,18 @@ products:
         relation_type: prov:hadPrimarySource
       - source: semmeddb
         relation_type: prov:hadPrimarySource
+      - source: doid
+        relation_type: prov:hadPrimarySource
+      - source: umls
+        relation_type: prov:hadPrimarySource
+      - source: hmdb
+        relation_type: prov:hadPrimarySource
+      - source: intact
+        relation_type: prov:hadPrimarySource
+      - source: ncbigene
+        relation_type: prov:hadPrimarySource
+      - source: smpdb
+        relation_type: prov:hadPrimarySource
     product_url: https://arax.ncats.io/
 publications:
   - authors:
@@ -188,7 +224,7 @@ publications:
 repository: https://github.com/RTXteam/RTX-KG2
 infores_id: rtx-kg2
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2025-10-30T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 ---
 
 ## RTX-KG2: A Semantically Standardized Knowledge Graph for Translational Biomedicine

--- a/resource/suppkg/suppkg.md
+++ b/resource/suppkg/suppkg.md
@@ -16,7 +16,7 @@ domains:
 homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/SuppKG
 id: suppkg
 infores_id: suppkg
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 layout: resource_detail
 name: SuppKG
 publications:
@@ -32,6 +32,8 @@ products:
     original_source:
       - source: suppkg
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
     product_url: https://github.com/NCATSTranslator/Translator-All/wiki/SuppKG
   - category: ProcessProduct
     description: Source data directory used for SuppKG in the SemRep_DS repository.
@@ -40,6 +42,14 @@ products:
     name: SuppKG Source Data Repository
     original_source:
       - source: suppkg
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
+      - source: uniprot
+        relation_type: prov:hadPrimarySource
+      - source: chebi
+        relation_type: prov:hadPrimarySource
+      - source: pubchem
         relation_type: prov:hadPrimarySource
     product_url: https://github.com/zhang-informatics/SemRep_DS/tree/main/SuppKG
 synonyms:

--- a/resource/tbkg/tbkg.md
+++ b/resource/tbkg/tbkg.md
@@ -37,7 +37,7 @@ license:
   id: https://creativecommons.org/licenses/by/4.0/
   label: CC BY 4.0
 creation_date: '2025-11-22T00:00:00Z'
-last_modified_date: '2025-11-22T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 products:
   - id: tbkg.data
     name: TBKG Knowledge Graph Data
@@ -47,6 +47,10 @@ products:
     original_source:
       - source: tbkg
         relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
+      - source: umls
+        relation_type: prov:hadPrimarySource
   - id: tbkg.osimertinib_case_study
     name: TBKG Osimertinib ADR Case Study Data
     description: Clinical validation dataset with calculated ADRs for osimertinib ranked by importance, biomarker pathways explaining drug-ADR relationships, and clinical data from 8 lung adenocarcinoma patients. Model achieved Kappa=0.68 concordance with official manual and 0.81 three-fold cross-validation accuracy.
@@ -54,6 +58,10 @@ products:
     product_url: https://www.frontiersin.org/articles/10.3389/fgene.2020.625659/full#supplementary-material
     original_source:
       - source: tbkg
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
+      - source: umls
         relation_type: prov:hadPrimarySource
 taxon:
   - NCBITaxon:9606

--- a/resource/tera/tera.md
+++ b/resource/tera/tera.md
@@ -17,7 +17,7 @@ domains:
   - biological systems
 homepage_url: https://niva-knowledge-graph.github.io/TERA/
 id: tera
-last_modified_date: '2025-10-28T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://opensource.org/licenses/MIT
@@ -106,6 +106,8 @@ products:
     original_source:
       - source: tera
         relation_type: prov:hadPrimarySource
+      - source: mesh
+        relation_type: prov:hadPrimarySource
   - category: MappingProduct
     description: Mapping file linking CAS Registry Numbers to MeSH identifiers
     format: csv
@@ -116,6 +118,10 @@ products:
     original_source:
       - source: tera
         relation_type: prov:hadPrimarySource
+      - source: chebi
+        relation_type: prov:hadPrimarySource
+      - source: mesh
+        relation_type: prov:hadPrimarySource
   - category: MappingProduct
     description: Mapping file linking ChEBI identifiers to MeSH identifiers
     format: csv
@@ -125,6 +131,10 @@ products:
     product_url: https://zenodo.org/records/4244313/files/chebi_to_mesh.csv
     original_source:
       - source: tera
+        relation_type: prov:hadPrimarySource
+      - source: pubchem
+        relation_type: prov:hadPrimarySource
+      - source: mesh
         relation_type: prov:hadPrimarySource
   - category: MappingProduct
     description: Mapping file linking ChEMBL identifiers to MeSH identifiers

--- a/resource/text-mining-kp/text-mining-kp.md
+++ b/resource/text-mining-kp/text-mining-kp.md
@@ -23,7 +23,7 @@ domains:
 - translational
 homepage_url: https://github.com/NCATSTranslator/Text-Mining-Provider-Roadmap
 id: text-mining-kp
-last_modified_date: '2026-01-22T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 name: Text Mining KP
 products:
@@ -34,6 +34,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: text-mining-kp
+  - relation_type: prov:hadPrimarySource
+    source: translator
   product_url: https://storage.googleapis.com/translator-text-workflow-dev-public/
   warnings:
   - 'File was not able to be retrieved when checked on 2026-05-26: No Content-Length

--- a/resource/ttd/ttd.md
+++ b/resource/ttd/ttd.md
@@ -43,7 +43,7 @@ domains:
 homepage_url: https://idrblab.org/ttd/
 id: ttd
 infores_id: ttd
-last_modified_date: '2025-10-29T00:00:00Z'
+last_modified_date: '2026-05-27T00:00:00Z'
 layout: resource_detail
 license:
   id: https://idrblab.org/ttd/
@@ -68,6 +68,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ttd
+  - relation_type: prov:hadPrimarySource
+    source: clinicaltrialsgov
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://idrblab.net/ttd/sites/default/files/ttd_download/P1-01-TTD_target_download.txt
   warnings:
   - File was not able to be retrieved when checked on 2025-10-29_ Error connecting
@@ -120,6 +124,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ttd
+  - relation_type: prov:hadPrimarySource
+    source: clinicaltrialsgov
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://idrblab.net/ttd/sites/default/files/ttd_download/P1-05-Drug_disease.txt
   warnings:
   - File was not able to be retrieved when checked on 2025-10-30_ Error connecting
@@ -133,6 +141,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ttd
+  - relation_type: prov:hadPrimarySource
+    source: clinicaltrialsgov
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://idrblab.net/ttd/sites/default/files/ttd_download/P1-06-Target_disease.txt
   warnings:
   - File was not able to be retrieved when checked on 2025-10-31_ Error connecting
@@ -146,6 +158,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ttd
+  - relation_type: prov:hadPrimarySource
+    source: clinicaltrialsgov
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://idrblab.net/ttd/sites/default/files/ttd_download/P1-07-Drug-TargetMapping.xlsx
   warnings:
   - File was not able to be retrieved when checked on 2025-10-31_ Error connecting
@@ -159,6 +175,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ttd
+  - relation_type: prov:hadPrimarySource
+    source: clinicaltrialsgov
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://idrblab.net/ttd/sites/default/files/ttd_download/P1-08-Biomarker_disease.txt
   warnings:
   - File was not able to be retrieved when checked on 2025-10-31_ Error connecting
@@ -172,6 +192,10 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ttd
+  - relation_type: prov:hadPrimarySource
+    source: clinicaltrialsgov
+  - relation_type: prov:hadPrimarySource
+    source: pubmed
   product_url: https://idrblab.net/ttd/sites/default/files/ttd_download/P1-09-Target_compound_activity.txt
   warnings:
   - File was not able to be retrieved when checked on 2025-10-31_ Error connecting

--- a/resource/ubkg/ubkg.md
+++ b/resource/ubkg/ubkg.md
@@ -25,7 +25,7 @@ domains:
 - genomics
 homepage_url: https://ubkg.docs.xconsortia.org/
 id: ubkg
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-05-28T00:00:00Z'
 layout: resource_detail
 license:
   id: https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf
@@ -270,6 +270,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ubkg
+  - relation_type: prov:hadPrimarySource
+    source: umls
   product_url: https://smart-api.info/ui/96e5b5c0b0efeef5b93ea98ac2794837
 - category: GraphicalInterface
   description: Guesdt (Graphing UMLS Enables Search In Dynamic Trees) application
@@ -279,6 +281,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ubkg
+  - relation_type: prov:hadPrimarySource
+    source: umls
   product_url: https://x-atlas-consortia.github.io/Guesdt/
 - category: GraphProduct
   description: A comprehensive multi-omics biomedical knowledge graph connecting genomic,


### PR DESCRIPTION
Updated the following Resource pages:
1. atom.md
2. biobricks-mesh.md
3. biobricks-pubchem-annotations.md
4. biobricks-toxcast.md
5. cam-kp.md
6. catalogue-of-life.md
7. cfde-ddkg.md
8. cfde-gse.md
9. cl-kg.md
10. clinicaltrialsgov.md
11. ctkp.md
12. drkg.md
13. drug-approvals-kp.md
14. enrichr-kg.md
15. evoweb.md
16. forum.md
17. geneticskp.md
18. genophenoenvo-kg.md
19. gnbr.md
20. hald.md
21. hetionet.md
22. icees-kg.md
23. idisk.md
24. ikraph.md
25. lncrnalyzr.md
26. mangal.md
27. maudekg.md
28. medkg.md
29. mind.md
30. openbiodiv.md
31. petagraph.md
32. rdkg.md
33. redrugs.md
34. reprotox-kg.md
35. rtx-kg2.md
36. suppkg.md
37. tbkg.md
38. tera.md
39. text-mining-kp.md
40. ttd.md
41. ubkg.md