### PR TITLE
Curate stale resource metadata and ontology pages

### DIFF
--- a/resource/5srrnadb/5srrnadb.md
+++ b/resource/5srrnadb/5srrnadb.md
@@ -6,9 +6,19 @@ description: 5SRNAdb (5S rRNA Database) is a curated repository of unique full-l
 domains:
   - genomics
   - biological systems
-homepage_url: http://www.combio.pl/5srnadb/
+homepage_url: http://www.combio.pl/rrna/
 id: 5srrnadb
-last_modified_date: '2025-09-10T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
+contacts:
+  - category: Organization
+    label: Adam Mickiewicz University, Department of Computational Biology
+    contact_details:
+      - contact_type: email
+        value: mszyman@amu.edu.pl
+      - contact_type: email
+        value: wmk@amu.edu.pl
+      - contact_type: url
+        value: http://www.combio.pl/rrna/contact/
 layout: resource_detail
 name: 5SRNAdb
 products:
@@ -17,7 +27,7 @@ products:
     format: fasta
     id: 5srrnadb.portal
     name: 5SRNAdb Portal
-    product_url: http://www.combio.pl/5srnadb/
+    product_url: http://www.combio.pl/rrna/
     original_source:
       - source: 5srrnadb
         relation_type: prov:hadPrimarySource

--- a/resource/adrecs/adrecs.md
+++ b/resource/adrecs/adrecs.md
@@ -10,7 +10,15 @@ domains:
 - health
 homepage_url: http://www.bio-add.org/ADReCS/
 id: adrecs
-last_modified_date: '2026-05-29T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
+contacts:
+- category: Organization
+  label: Bioinformatics-Aided Drug Discovery Group (BADD)
+  contact_details:
+  - contact_type: email
+    value: appo@xmu.edu.cn
+  - contact_type: url
+    value: http://www.bio-add.org/
 layout: resource_detail
 name: ADReCS
 products:

--- a/resource/aelous/aelous.md
+++ b/resource/aelous/aelous.md
@@ -8,9 +8,12 @@ domains:
 - biomedical
 - pharmacology
 - health
-homepage_url: https://datadryad.org/stash/dataset/doi:10.5061/dryad.8q0s4
+homepage_url: https://datadryad.org/dataset/doi:10.5061/dryad.8q0s4
 id: aelous
-last_modified_date: '2026-05-29T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
+license:
+  id: https://creativecommons.org/publicdomain/zero/1.0/
+  label: CC0 1.0
 layout: resource_detail
 name: AELOUS
 products:
@@ -18,11 +21,14 @@ products:
   description: AELOUS dataset landing page hosted by Dryad.
   format: http
   id: aelous.dataset
+  license:
+    id: https://creativecommons.org/publicdomain/zero/1.0/
+    label: CC0 1.0
   name: AELOUS Dataset
   original_source:
   - relation_type: prov:hadPrimarySource
     source: aelous
-  product_url: https://datadryad.org/stash/dataset/doi:10.5061/dryad.8q0s4
+  product_url: https://datadryad.org/dataset/doi:10.5061/dryad.8q0s4
 - category: GraphProduct
   compression: gzip
   description: PharMeBINet V2 JSON release published on February 6, 2024.

--- a/resource/aeolus/aeolus.md
+++ b/resource/aeolus/aeolus.md
@@ -20,23 +20,29 @@ domains:
   - drug discovery
   - health
   - biomedical
-homepage_url: https://datadryad.org/stash/dataset/doi:10.5061/dryad.8q0s4
+homepage_url: https://datadryad.org/dataset/doi:10.5061/dryad.8q0s4
 id: aeolus
 infores_id: aeolus
-last_modified_date: '2025-11-22T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
+license:
+  id: https://creativecommons.org/publicdomain/zero/1.0/
+  label: CC0 1.0
 layout: resource_detail
 name: Adverse Event Open Learning through Universal Standardization (AEOLUS)
 products:
   - category: Product
     description: Standardized and deduplicated version of FDA FAERS data with drug names mapped to RxNorm and adverse event outcomes mapped to SNOMED-CT, including pre-computed summary statistics for drug-outcome relationships.
     id: aeolus.standardized_data
+    license:
+      id: https://creativecommons.org/publicdomain/zero/1.0/
+      label: CC0 1.0
     name: AEOLUS Standardized FAERS Data
     original_source:
       - source: faers
         relation_type: prov:hadPrimarySource
       - source: aeolus
         relation_type: prov:hadPrimarySource
-    product_url: https://datadryad.org/stash/dataset/doi:10.5061/dryad.8q0s4
+    product_url: https://datadryad.org/dataset/doi:10.5061/dryad.8q0s4
 publications:
   - authors:
       - Banda JM

--- a/resource/brenda/brenda.md
+++ b/resource/brenda/brenda.md
@@ -17,7 +17,7 @@ domains:
 - biomedical
 homepage_url: https://www.brenda-enzymes.org/
 id: brenda
-last_modified_date: '2025-11-19T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -76,11 +76,22 @@ products:
   - relation_type: prov:hadPrimarySource
     source: brenda
   product_url: https://www.brenda-enzymes.org/download.php
+- category: DocumentationProduct
+  description: BRENDA help and tutorial resources covering support, usage guidance,
+    FAQs, and tutorial videos.
+  format: http
+  id: brenda.docs
+  name: BRENDA Help and Tutorials
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: brenda
+  product_url: https://www.brenda-enzymes.org/help.php
 - category: GraphProduct
   description: The integrative Biomedical Knowledge Hub (iBKH) knowledge graph, harmonizing
     and integrating information from diverse biomedical resources including DRKG,
     iDISK, and multiple databases (BRENDA, CTD, DrugBank, KEGG, PharmGKB, Reactome,
     SIDER, and others).
+  format: http
   id: ibkh.graph
   name: iBKH Knowledge Graph
   original_source:

--- a/resource/circbase/circbase.md
+++ b/resource/circbase/circbase.md
@@ -10,8 +10,9 @@ domains:
 - genomics
 - biological systems
 - organisms
+homepage_url: https://www.circbase.org/
 id: circbase
-last_modified_date: '2025-09-16T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 license:
   id: http://www.circbase.org/
@@ -65,6 +66,7 @@ products:
 - category: GraphicalInterface
   description: Web interface for searching and browsing circular RNA annotations across
     species.
+  format: http
   id: circbase.portal
   name: circBase Portal
   original_source:
@@ -74,6 +76,7 @@ products:
 - category: Product
   description: Bulk data downloads (BED/GFF and sequence files) for circular RNAs
     provided via the downloads CGI page.
+  format: http
   id: circbase.downloads
   name: circBase Bulk Downloads
   original_source:
@@ -83,6 +86,7 @@ products:
 - category: DocumentationProduct
   description: Help and documentation describing circBase data sources, identifiers,
     and usage notes.
+  format: http
   id: circbase.docs
   name: circBase Documentation
   original_source:
@@ -185,3 +189,16 @@ publications:
   year: '2014'
 ---
 # circBase
+
+circBase is a public aggregation and exploration resource for circular RNAs
+(circRNAs). It brings together published circRNA detection datasets across
+multiple species, tissues, and experimental settings, then exposes them through
+search, genomic-context views, table filtering, sequence-based search, and bulk
+downloads.
+
+The live circBase site supports identifier, gene, and genomic-position queries,
+dataset slicing through the table browser, and export of tables and FASTA
+sequences. It also distributes the custom `find_circ` scripts and historical
+dataset files used in early circRNA discovery workflows. In KG-Registry, the
+RNA-KG products remain attached as downstream derivatives that reuse circBase as
+one upstream source among several RNA resources.

--- a/resource/cmap/cmap.md
+++ b/resource/cmap/cmap.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://clue.io/
 id: cmap
 infores_id: cmap
-last_modified_date: '2025-01-10T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://clue.io/connectopedia/terms
@@ -29,28 +29,40 @@ name: Connectivity Map
 products:
   - category: GraphicalInterface
     description: Cloud-based user interface providing suite of apps for querying gene expression signatures, browsing perturbagen data, searching metadata, and visualizing connectivity results
+    format: http
     id: cmap.clue
     name: CLUE Platform
     original_source:
       - source: cmap
         relation_type: prov:hadPrimarySource
+    secondary_source:
+      - source: lincs
+        relation_type: prov:wasInfluencedBy
     product_url: https://clue.io/
   - category: ProgrammingInterface
     description: Python library cmapBQ for programmatic access to CMap data through Google BigQuery with query capabilities for signatures and metadata
+    format: http
     id: cmap.python_api
     is_public: true
     name: cmapBQ Python Library
     original_source:
       - source: cmap
         relation_type: prov:hadPrimarySource
+    secondary_source:
+      - source: lincs
+        relation_type: prov:wasInfluencedBy
     product_url: https://cmapbq.readthedocs.io/
   - category: GraphicalInterface
     description: Query app enabling users to search CMap database with custom gene expression signatures to find perturbagens with similar or opposing transcriptional effects
+    format: http
     id: cmap.query_app
     name: CLUE Query App
     original_source:
       - source: cmap
         relation_type: prov:hadPrimarySource
+    secondary_source:
+      - source: lincs
+        relation_type: prov:wasInfluencedBy
     product_url: https://clue.io/query
   - category: Product
     description: Data releases containing replicate-collapsed signatures and gene expression profiles in GCTx matrix format available for download
@@ -60,6 +72,9 @@ products:
     original_source:
       - source: cmap
         relation_type: prov:hadPrimarySource
+    secondary_source:
+      - source: lincs
+        relation_type: prov:wasInfluencedBy
     product_url: https://clue.io/releases/data-dashboard
   - category: DocumentationProduct
     description: Comprehensive knowledge base containing glossary, tutorials, analytical methods, experimental protocols, and detailed documentation
@@ -69,6 +84,9 @@ products:
     original_source:
       - source: cmap
         relation_type: prov:hadPrimarySource
+    secondary_source:
+      - source: lincs
+        relation_type: prov:wasInfluencedBy
     product_url: https://clue.io/connectopedia
 publications:
   - id: https://doi.org/10.1016/j.cell.2017.10.049

--- a/resource/darkkinasekb/darkkinasekb.md
+++ b/resource/darkkinasekb/darkkinasekb.md
@@ -15,7 +15,7 @@ domains:
 homepage_url: https://darkkinome.org
 id: darkkinasekb
 infores_id: darkkinasekb
-last_modified_date: '2025-11-13T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 name: Dark Kinase Knowledgebase
 products:

--- a/resource/docm/docm.md
+++ b/resource/docm/docm.md
@@ -13,10 +13,10 @@ domains:
   - precision medicine
   - genomics
   - health
-homepage_url: http://www.docm.info/
+homepage_url: https://github.com/griffithlab/docm
 id: docm
 infores_id: docm
-last_modified_date: '2025-01-20T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://opensource.org/licenses/MIT

--- a/resource/ehda/ehda.md
+++ b/resource/ehda/ehda.md
@@ -1,9 +1,9 @@
 ---
 id: ehda
 name: Human developmental anatomy, timed version
-description: Description unavailable.
+description: The Human Developmental Anatomy timed ontology is a stage-specific controlled vocabulary for human embryonic anatomy across Carnegie stages. The ontology is deprecated and has been superseded by EHDAA2.
 activity_status: inactive
-homepage_url: http://genex.hgu.mrc.ac.uk/
+homepage_url: https://obofoundry.org/ontology/ehda
 license:
   id: ''
   label: Not specified
@@ -12,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - anatomy and development
 taxon:
@@ -23,12 +23,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: J.Bard@ed.ac.uk
-products: []
+products:
+- category: OntologyProduct
+  description: Human developmental anatomy, timed version in OWL format
+  format: owl
+  id: ehda.owl
+  name: ehda.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ehda
+  product_url: http://purl.obolibrary.org/obo/ehda.owl
+- category: OntologyProduct
+  description: Human developmental anatomy, timed version in OBO format
+  format: obo
+  id: ehda.obo
+  name: ehda.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ehda
+  product_url: http://purl.obolibrary.org/obo/ehda.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+The Human Developmental Anatomy timed ontology is a deprecated stage-specific vocabulary for human embryonic anatomy across Carnegie stages 1-20. OBO Foundry identifies EHDAA2 as the successor resource.
 
 ## Contacts
 

--- a/resource/ehdaa/ehdaa.md
+++ b/resource/ehdaa/ehdaa.md
@@ -1,8 +1,9 @@
 ---
 id: ehdaa
 name: Human developmental anatomy, abstract version
-description: Description unavailable.
+description: The Human Developmental Anatomy abstract ontology is a controlled vocabulary that compresses human embryonic anatomical structures across Carnegie stages into a single hierarchy. The ontology is deprecated and has been superseded by EHDAA2.
 activity_status: inactive
+homepage_url: https://obofoundry.org/ontology/ehdaa
 license:
   id: ''
   label: Not specified
@@ -11,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - anatomy and development
 taxon:
@@ -22,12 +23,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: J.Bard@ed.ac.uk
-products: []
+products:
+- category: OntologyProduct
+  description: Human developmental anatomy, abstract version in OWL format
+  format: owl
+  id: ehdaa.owl
+  name: ehdaa.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ehdaa
+  product_url: http://purl.obolibrary.org/obo/ehdaa.owl
+- category: OntologyProduct
+  description: Human developmental anatomy, abstract version in OBO format
+  format: obo
+  id: ehdaa.obo
+  name: ehdaa.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ehdaa
+  product_url: http://purl.obolibrary.org/obo/ehdaa.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+The Human Developmental Anatomy abstract ontology is a deprecated vocabulary that collapses human embryonic anatomy across Carnegie stages into a single hierarchy. OBO Foundry identifies EHDAA2 as the successor resource.
 
 ## Contacts
 

--- a/resource/ev/ev.md
+++ b/resource/ev/ev.md
@@ -1,8 +1,9 @@
 ---
 id: ev
 name: eVOC (Expressed Sequence Annotation for Humans)
-description: Description unavailable.
+description: eVOC provides structured controlled vocabularies for annotating expressed sequences with respect to anatomy, cell type, developmental stage, experimental technique, pathology, and related attributes. The ontology is deprecated.
 activity_status: inactive
+homepage_url: https://obofoundry.org/ontology/ev
 license:
   id: ''
   label: Not specified
@@ -11,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - anatomy and development
 contacts:
@@ -20,12 +21,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: evoc@sanbi.ac.za
-products: []
+products:
+- category: OntologyProduct
+  description: eVOC in OWL format
+  format: owl
+  id: ev.owl
+  name: ev.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ev
+  product_url: http://purl.obolibrary.org/obo/ev.owl
+- category: OntologyProduct
+  description: eVOC in OBO format
+  format: obo
+  id: ev.obo
+  name: ev.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ev
+  product_url: http://purl.obolibrary.org/obo/ev.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+eVOC is a deprecated vocabulary suite for annotating expressed sequences by anatomy, cell type, developmental stage, experimental technique, pathology, and related attributes.
 
 ## Contacts
 

--- a/resource/glkb/glkb.md
+++ b/resource/glkb/glkb.md
@@ -10,7 +10,7 @@ contacts:
 description: The Genomic Literature Knowledge Base (GLKB) is a comprehensive and powerful resource that integrates over 263 million biomedical terms and more than 14.6 million biomedical relationships. This collection is curated from 33 million PubMed abstracts and nine well-established biomedical repositories, offering an unparalleled wealth of knowledge for researchers and practitioners in the field.
 domains:
   - biological systems
-homepage_url: https://glkb.dcmb.med.umich.edu/
+homepage_url: https://glkb.org/
 id: glkb
 layout: resource_detail
 name: GLKB
@@ -22,7 +22,10 @@ products:
     original_source:
       - source: glkb
         relation_type: prov:hadPrimarySource
-    product_url: https://glkb.dcmb.med.umich.edu/
+    secondary_source:
+      - source: pubmed
+        relation_type: prov:wasInfluencedBy
+    product_url: https://glkb.org/
     format: http
 publications:
   - authors:
@@ -57,7 +60,7 @@ publications:
     title: Building a literature knowledge base towards transparent biomedical AI
     year: '2025'
 creation_date: '2025-03-20T00:00:00Z'
-last_modified_date: '2025-04-11T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 ---
 
-GLKB
+GLKB is a literature-grounded biomedical knowledge interface that lets users ask natural-language questions over a large corpus of PubMed-derived relationships and supporting source papers. The current canonical public site is https://glkb.org/, which supersedes the earlier University of Michigan host.

--- a/resource/gro/gro.md
+++ b/resource/gro/gro.md
@@ -1,9 +1,9 @@
 ---
 id: gro
 name: Cereal Plant Gross Anatomy
-description: Description unavailable.
+description: Cereal Plant Gross Anatomy is a structured controlled vocabulary for the anatomy of Graminae. The ontology is deprecated and has been superseded by the Plant Ontology.
 activity_status: inactive
-homepage_url: http://www.gramene.org/plant_ontology/
+homepage_url: https://obofoundry.org/ontology/gro
 license:
   id: ''
   label: Not specified
@@ -12,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - anatomy and development
 contacts:
@@ -21,12 +21,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: po-discuss@plantontology.org
-products: []
+products:
+- category: OntologyProduct
+  description: Cereal Plant Gross Anatomy in OWL format
+  format: owl
+  id: gro.owl
+  name: gro.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: gro
+  product_url: http://purl.obolibrary.org/obo/gro.owl
+- category: OntologyProduct
+  description: Cereal Plant Gross Anatomy in OBO format
+  format: obo
+  id: gro.obo
+  name: gro.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: gro
+  product_url: http://purl.obolibrary.org/obo/gro.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+Cereal Plant Gross Anatomy is a deprecated ontology for the anatomy of grasses and cereal plants. OBO Foundry notes that it has been superseded by the Plant Ontology.
 
 ## Contacts
 

--- a/resource/habronattus/habronattus.md
+++ b/resource/habronattus/habronattus.md
@@ -1,9 +1,9 @@
 ---
 id: habronattus
 name: Habronattus courtship
-description: Description unavailable.
+description: Habronattus courtship is a demonstration ontology for encoding ethograms and courtship behavior of the spider Habronattus californicus in machine-readable form. The ontology is deprecated.
 activity_status: inactive
-homepage_url: http://www.mesquiteproject.org/ontology/Habronattus/index.html
+homepage_url: https://obofoundry.org/ontology/habronattus
 license:
   id: ''
   label: Not specified
@@ -12,9 +12,9 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
-- biological systems
+- organisms
 contacts:
 - category: Individual
   label: Peter Midford
@@ -22,12 +22,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: peteremidford@yahoo.com
-products: []
+products:
+- category: OntologyProduct
+  description: Habronattus courtship ontology in OWL format
+  format: owl
+  id: habronattus.owl
+  name: habronattus.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: habronattus
+  product_url: http://purl.obolibrary.org/obo/habronattus.owl
+- category: OntologyProduct
+  description: Habronattus courtship ontology in OBO format
+  format: obo
+  id: habronattus.obo
+  name: habronattus.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: habronattus
+  product_url: http://purl.obolibrary.org/obo/habronattus.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+Habronattus courtship is a deprecated demonstration ontology for representing ethograms and the courtship behavior of the spider Habronattus californicus in machine-readable form.
 
 ## Contacts
 

--- a/resource/iev/iev.md
+++ b/resource/iev/iev.md
@@ -1,9 +1,9 @@
 ---
 id: iev
 name: Event (INOH pathway ontology)
-description: Description unavailable.
+description: IEV is the event ontology from the INOH pathway ontology suite, used to annotate biological processes, pathways, and sub-pathways in pathway data integration workflows. The ontology is deprecated.
 activity_status: inactive
-homepage_url: http://www.inoh.org
+homepage_url: https://obofoundry.org/ontology/iev
 license:
   id: ''
   label: Not specified
@@ -12,16 +12,34 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - chemistry and biochemistry
 contacts: []
-products: []
+products:
+- category: OntologyProduct
+  description: Event (INOH pathway ontology) in OWL format
+  format: owl
+  id: iev.owl
+  name: iev.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: iev
+  product_url: http://purl.obolibrary.org/obo/iev.owl
+- category: OntologyProduct
+  description: Event (INOH pathway ontology) in OBO format
+  format: obo
+  id: iev.obo
+  name: iev.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: iev
+  product_url: http://purl.obolibrary.org/obo/iev.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+IEV is a deprecated pathway-event ontology from the INOH pathway ontology suite, intended to annotate biological processes, pathways, and sub-pathways for pathway data integration.
 
 **Domains**: chemistry and biochemistry
 

--- a/resource/irefindex/irefindex.md
+++ b/resource/irefindex/irefindex.md
@@ -12,7 +12,7 @@ domains:
 homepage_url: https://irefindex.vib.be/wiki/index.php/iRefIndex
 id: irefindex
 infores_id: irefindex
-last_modified_date: '2025-10-30T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 name: iRefIndex
 products:
@@ -49,6 +49,7 @@ products:
 - category: Product
   description: Cytoscape plugin for visualization and data mining of iRefIndex protein
     interaction data
+  format: http
   id: irefindex.irefscape
   name: iRefScape
   original_source:
@@ -57,6 +58,7 @@ products:
 - category: GraphicalInterface
   description: Web interface for navigating the global protein-protein interaction
     landscape
+  format: http
   id: irefindex.irefweb
   name: iRefWeb
   original_source:

--- a/resource/mgd/mgd.md
+++ b/resource/mgd/mgd.md
@@ -45,13 +45,14 @@ domains:
 homepage_url: https://www.informatics.jax.org/
 id: mgd
 infores_id: mgi
-last_modified_date: '2025-01-10T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 name: Mouse Genome Database
 products:
 - category: GraphicalInterface
   description: Primary web interface providing integrated access to mouse genes, phenotypes,
     expression data, disease models, and genome features
+  format: http
   id: mgd.portal
   name: MGI Web Portal
   original_source:
@@ -71,16 +72,18 @@ products:
 - category: ProgrammingInterface
   description: MouseMine data mining platform providing programmatic access to MGD
     data through InterMine query interface
+  format: http
   id: mgd.mousemine
   is_public: true
   name: MouseMine
   original_source:
   - relation_type: prov:hadPrimarySource
     source: mgd
-  product_url: http://www.mousemine.org/
+  product_url: https://www.mousemine.org/
 - category: GraphicalInterface
   description: Gene Expression Database documenting spatiotemporal gene expression
     patterns during mouse development and adulthood
+  format: http
   id: mgd.gxd
   name: Gene Expression Database (GXD)
   original_source:

--- a/resource/oma/oma.md
+++ b/resource/oma/oma.md
@@ -25,7 +25,7 @@ domains:
 - organisms
 homepage_url: https://omabrowser.org/
 id: oma
-last_modified_date: '2026-05-26T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -376,6 +376,7 @@ publications:
 - id: https://doi.org/10.1093/nar/gkaa1007
   title: 'OMA orthology in 2021: website overhaul, conserved isoforms, ancestral gene
     order and more'
+repository: https://github.com/DessimozLab/pyomabrowser
 ---
 OMA (Orthologous MAtrix) is a comprehensive database of orthologous gene relationships across multiple species. It provides a systematic and efficient approach to identifying orthologs among complete genomes, which are genes in different species that evolved from a common ancestor through speciation.
 

--- a/resource/pao/pao.md
+++ b/resource/pao/pao.md
@@ -1,9 +1,9 @@
 ---
 id: pao
 name: Plant Anatomy Ontology
-description: Description unavailable.
+description: The Plant Anatomy Ontology is a controlled vocabulary for plant anatomical and morphological structures. The ontology is deprecated and has been subsumed into the Plant Ontology (PO).
 activity_status: inactive
-homepage_url: http://www.plantontology.org
+homepage_url: https://obofoundry.org/ontology/pao
 license:
   id: ''
   label: Not specified
@@ -12,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - anatomy and development
 taxon:
@@ -26,12 +26,30 @@ contacts:
     value: jaiswalp@science.oregonstate.edu
   - contact_type: github
     value: jaiswalp
-products: []
+products:
+- category: OntologyProduct
+  description: Plant Anatomy Ontology in OWL format
+  format: owl
+  id: pao.owl
+  name: pao.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: pao
+  product_url: http://purl.obolibrary.org/obo/pao.owl
+- category: OntologyProduct
+  description: Plant Anatomy Ontology in OBO format
+  format: obo
+  id: pao.obo
+  name: pao.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: pao
+  product_url: http://purl.obolibrary.org/obo/pao.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+The Plant Anatomy Ontology is a deprecated controlled vocabulary for plant anatomical and morphological structures. OBO Foundry notes that this ontology has been replaced by the Plant Ontology.
 
 ## Contacts
 

--- a/resource/pd_st/pd_st.md
+++ b/resource/pd_st/pd_st.md
@@ -1,9 +1,9 @@
 ---
 id: pd_st
 name: Platynereis stage ontology
-description: Description unavailable.
+description: The Platynereis stage ontology is a developmental stage ontology for Platynereis. The ontology is deprecated and OBO Foundry recommends using PDUMDV instead.
 activity_status: inactive
-homepage_url: http://4dx.embl.de/platy
+homepage_url: https://obofoundry.org/ontology/pd_st
 license:
   id: ''
   label: Not specified
@@ -12,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - anatomy and development
 taxon:
@@ -26,12 +26,30 @@ contacts:
     value: henrich@embl.de
   - contact_type: github
     value: ThorstenHen
-products: []
+products:
+- category: OntologyProduct
+  description: Platynereis stage ontology in OWL format
+  format: owl
+  id: pd_st.owl
+  name: pd_st.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: pd_st
+  product_url: http://purl.obolibrary.org/obo/pd_st.owl
+- category: OntologyProduct
+  description: Platynereis stage ontology in OBO format
+  format: obo
+  id: pd_st.obo
+  name: pd_st.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: pd_st
+  product_url: http://purl.obolibrary.org/obo/pd_st.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+The Platynereis stage ontology is a deprecated developmental stage ontology for Platynereis. OBO Foundry recommends the Platynereis dumerilii development and anatomy ontology (`pdumdv`) as the successor resource.
 
 ## Contacts
 

--- a/resource/pharmacodb/pharmacodb.md
+++ b/resource/pharmacodb/pharmacodb.md
@@ -42,7 +42,7 @@ domains:
 - pharmacology
 homepage_url: https://pharmacodb.ca/
 id: pharmacodb
-last_modified_date: '2025-01-10T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.gnu.org/licenses/gpl-3.0.en.html
@@ -53,21 +53,37 @@ products:
   description: Primary web portal for searching and browsing cancer pharmacogenomics
     data across multiple integrated datasets with interactive dose-response curve
     visualization
+  format: http
   id: pharmacodb.portal
   name: PharmacoDB Web Application
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pharmacodb
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: ccle
+  - relation_type: prov:wasInfluencedBy
+    source: gdsc
+  - relation_type: prov:wasInfluencedBy
+    source: ctrp
   product_url: https://pharmacodb.ca/
 - category: ProgrammingInterface
   description: RESTful JSON API providing programmatic access to cell lines, compounds,
     tissues, datasets, experiments, and intersections data
+  format: http
   id: pharmacodb.api
   is_public: true
   name: PharmacoDB API
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pharmacodb
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: ccle
+  - relation_type: prov:wasInfluencedBy
+    source: gdsc
+  - relation_type: prov:wasInfluencedBy
+    source: ctrp
   product_url: http://api.pharmacodb.ca/v1/
 - category: DocumentationProduct
   description: Comprehensive user documentation covering search functionality, datasets,
@@ -78,6 +94,13 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pharmacodb
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: ccle
+  - relation_type: prov:wasInfluencedBy
+    source: gdsc
+  - relation_type: prov:wasInfluencedBy
+    source: ctrp
   product_url: https://pharmacodb.ca/documentation
 - category: Product
   description: Network embeddings of the Bioteque graph that represent biological

--- a/resource/snodb/snodb.md
+++ b/resource/snodb/snodb.md
@@ -12,7 +12,7 @@ domains:
 - biological systems
 homepage_url: https://bioinfo-scottgroup.med.usherbrooke.ca/snoDB/
 id: snodb
-last_modified_date: '2026-05-26T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 name: snoDB
 products:

--- a/resource/sopharm/sopharm.md
+++ b/resource/sopharm/sopharm.md
@@ -1,9 +1,9 @@
 ---
 id: sopharm
 name: Suggested Ontology for Pharmacogenomics
-description: Description unavailable.
+description: SO-Pharm is a formal ontology for pharmacogenomics that models genotype, phenotype, drug, and trial knowledge for pharmacogenomic investigations. The ontology is deprecated in OBO Foundry.
 activity_status: inactive
-homepage_url: http://www.loria.fr/~coulet/sopharm2.0_description.php
+homepage_url: https://obofoundry.org/ontology/sopharm
 license:
   id: ''
   label: Not specified
@@ -12,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - chemistry and biochemistry
 taxon:
@@ -23,12 +23,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: Adrien.Coulet@loria.fr
-products: []
+products:
+- category: OntologyProduct
+  description: Suggested Ontology for Pharmacogenomics in OWL format
+  format: owl
+  id: sopharm.owl
+  name: sopharm.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: sopharm
+  product_url: http://purl.obolibrary.org/obo/sopharm.owl
+- category: OntologyProduct
+  description: Suggested Ontology for Pharmacogenomics in OBO format
+  format: obo
+  id: sopharm.obo
+  name: sopharm.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: sopharm
+  product_url: http://purl.obolibrary.org/obo/sopharm.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+SO-Pharm is a deprecated ontology for pharmacogenomics that models knowledge about genotypes, phenotypes, drugs, trials, and pharmacogenomic investigations.
 
 ## Contacts
 

--- a/resource/startgeo/startgeo.md
+++ b/resource/startgeo/startgeo.md
@@ -8,10 +8,22 @@ domains:
   - biomedical
 id: "startgeo"
 infores_id: "startgeo"
-last_modified_date: '2025-11-25T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 name: STAR GEO Search Application
-homepage_url: http://stargeo.org/
+homepage_url: https://stargeo.org/
+products:
+  - category: GraphicalInterface
+    description: Historical STARGEO web application for searching GEO datasets by differential expression signatures
+    format: http
+    id: startgeo.portal
+    name: STARGEO Web Application
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: startgeo
+    product_url: https://stargeo.org/
+    warnings:
+      - 'File was not able to be retrieved when checked on 2026-06-01: HTTP 404 at the historical STARGEO site'
 synonyms:
   - STARGEO
 ---
@@ -22,7 +34,7 @@ synonyms:
 
 STARGEO (Search Tool for Analysis of GEO) is a web-based application designed to search and analyze gene expression data from NCBI's Gene Expression Omnibus (GEO), one of the largest public repositories of genomics data. STARGEO enables researchers to identify datasets containing significant differential expression for genes of interest, facilitating discovery of relevant experimental data and biological insights.
 
-**Note:** Website availability appears intermittent (http://stargeo.org/). Users may experience connectivity issues.
+**Note:** The historical STARGEO site currently returns HTTP 404, so the application should be treated as inactive unless a maintained replacement is identified.
 
 ## Key Features
 

--- a/resource/tahe/tahe.md
+++ b/resource/tahe/tahe.md
@@ -1,8 +1,9 @@
 ---
 id: tahe
 name: Terminology of Anatomy of Human Embryology
-description: Description unavailable.
+description: Terminology of Anatomy of Human Embryology is a deprecated ontology covering human embryological anatomy.
 activity_status: inactive
+homepage_url: https://obofoundry.org/ontology/tahe
 license:
   id: ''
   label: Not specified
@@ -11,7 +12,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
 - anatomy and development
 taxon:
@@ -22,12 +23,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: pierre.sprumont@unifr.ch
-products: []
+products:
+- category: OntologyProduct
+  description: Terminology of Anatomy of Human Embryology in OWL format
+  format: owl
+  id: tahe.owl
+  name: tahe.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: tahe
+  product_url: http://purl.obolibrary.org/obo/tahe.owl
+- category: OntologyProduct
+  description: Terminology of Anatomy of Human Embryology in OBO format
+  format: obo
+  id: tahe.obo
+  name: tahe.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: tahe
+  product_url: http://purl.obolibrary.org/obo/tahe.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+Terminology of Anatomy of Human Embryology is a deprecated OBO Foundry ontology for human embryological anatomy.
 
 ## Contacts
 

--- a/resource/tahh/tahh.md
+++ b/resource/tahh/tahh.md
@@ -1,8 +1,9 @@
 ---
 id: tahh
 name: Terminology of Anatomy of Human Histology
-description: Description unavailable.
+description: Terminology of Anatomy of Human Histology is a deprecated ontology covering human histological anatomy.
 activity_status: inactive
+homepage_url: https://obofoundry.org/ontology/tahh
 license:
   id: ''
   label: Not specified
@@ -11,9 +12,9 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
-- biomedical
+- health
 taxon:
 - NCBITaxon:9606
 contacts:
@@ -22,12 +23,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: pierre.sprumont@unifr.ch
-products: []
+products:
+- category: OntologyProduct
+  description: Terminology of Anatomy of Human Histology in OWL format
+  format: owl
+  id: tahh.owl
+  name: tahh.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: tahh
+  product_url: http://purl.obolibrary.org/obo/tahh.owl
+- category: OntologyProduct
+  description: Terminology of Anatomy of Human Histology in OBO format
+  format: obo
+  id: tahh.obo
+  name: tahh.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: tahh
+  product_url: http://purl.obolibrary.org/obo/tahh.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+Terminology of Anatomy of Human Histology is a deprecated OBO Foundry ontology for human histological anatomy.
 
 ## Contacts
 

--- a/resource/tcrd/tcrd.md
+++ b/resource/tcrd/tcrd.md
@@ -49,7 +49,7 @@ domains:
 homepage_url: http://juniper.health.unm.edu/tcrd/
 id: tcrd
 infores_id: tcrd
-last_modified_date: '2025-01-10T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by-sa/4.0/
@@ -65,6 +65,19 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: tcrd
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: uniprot
+  - relation_type: prov:wasInfluencedBy
+    source: chembl
+  - relation_type: prov:wasInfluencedBy
+    source: drugcentral
+  - relation_type: prov:wasInfluencedBy
+    source: string
+  - relation_type: prov:wasInfluencedBy
+    source: gtex
+  - relation_type: prov:wasInfluencedBy
+    source: omim
   product_url: http://juniper.health.unm.edu/tcrd/download/
   warnings:
   - File was not able to be retrieved when checked on 2026-03-30_ Timeout connecting
@@ -76,12 +89,26 @@ products:
 - category: ProgrammingInterface
   description: RESTful API providing programmatic access to TCRD data through Pharos
     for computational workflows and custom applications
+  format: http
   id: tcrd.api
   is_public: true
   name: Pharos API
   original_source:
   - relation_type: prov:hadPrimarySource
     source: tcrd
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: uniprot
+  - relation_type: prov:wasInfluencedBy
+    source: chembl
+  - relation_type: prov:wasInfluencedBy
+    source: drugcentral
+  - relation_type: prov:wasInfluencedBy
+    source: string
+  - relation_type: prov:wasInfluencedBy
+    source: gtex
+  - relation_type: prov:wasInfluencedBy
+    source: omim
   product_url: https://pharos.nih.gov/api
 - category: DocumentationProduct
   description: Comprehensive documentation describing TCRD data sources, schema structure,
@@ -92,6 +119,19 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: tcrd
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: uniprot
+  - relation_type: prov:wasInfluencedBy
+    source: chembl
+  - relation_type: prov:wasInfluencedBy
+    source: drugcentral
+  - relation_type: prov:wasInfluencedBy
+    source: string
+  - relation_type: prov:wasInfluencedBy
+    source: gtex
+  - relation_type: prov:wasInfluencedBy
+    source: omim
   product_url: http://juniper.health.unm.edu/tcrd/
   warnings:
   - File was not able to be retrieved when checked on 2026-03-30_ Timeout connecting

--- a/resource/ypo/ypo.md
+++ b/resource/ypo/ypo.md
@@ -1,9 +1,9 @@
 ---
 id: ypo
 name: Yeast phenotypes
-description: Description unavailable.
+description: Yeast Phenotypes Ontology is a structured controlled vocabulary for the phenotypes of budding yeast. The ontology is deprecated and OBO Foundry recommends APO as a replacement.
 activity_status: inactive
-homepage_url: http://www.yeastgenome.org/
+homepage_url: https://obofoundry.org/ontology/ypo
 license:
   id: ''
   label: Not specified
@@ -12,9 +12,9 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-16T00:00:00Z'
+last_modified_date: '2026-06-01T00:00:00Z'
 domains:
-- biological systems
+- phenotype
 taxon:
 - NCBITaxon:4932
 contacts:
@@ -24,12 +24,30 @@ contacts:
   contact_details:
   - contact_type: email
     value: cherry@genome.stanford.edu
-products: []
+products:
+- category: OntologyProduct
+  description: Yeast phenotypes ontology in OWL format
+  format: owl
+  id: ypo.owl
+  name: ypo.owl
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ypo
+  product_url: http://purl.obolibrary.org/obo/ypo.owl
+- category: OntologyProduct
+  description: Yeast phenotypes ontology in OBO format
+  format: obo
+  id: ypo.obo
+  name: ypo.obo
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ypo
+  product_url: http://purl.obolibrary.org/obo/ypo.obo
 publications: []
 ---
 ## Description
 
-Description unavailable.
+Yeast Phenotypes Ontology is a deprecated controlled vocabulary for the phenotypes of budding yeast. OBO Foundry recommends APO as a successor resource.
 
 ## Contacts
 


### PR DESCRIPTION
This PR curates a set of stale KG-Registry resource pages and expands several thin ontology entries.

Summary:
- update the OMA page metadata without adding an unverified INFORES identifier
- refresh stale resource pages including cmap, docm, glkb, mgd, pharmacodb, and tcrd
- improve provenance annotations where the upstream sources are explicitly supported by the resource page text
- expand multiple deprecated OBO-style ontology stubs with grounded descriptions, canonical OBO Foundry homepages, and standard OWL/OBO products
- add explicit CC0 licensing for the Dryad-backed AEOLUS/AELOUS dataset pages and add published contact metadata for 5SRNAdb and ADReCS

Validation:
- ran `uv run make validate-file FILE=...` for each touched resource page during curation

Notes:
- license fields were only added where the authoritative source published an explicit license
- resources with only copyright notices or no published license text were left unchanged rather than guessed