### PR TITLE
Add MetaboKG resource

### DIFF
--- a/resource/afo/afo.md
+++ b/resource/afo/afo.md
@@ -1,0 +1,51 @@
+---
+activity_status: active
+category: Ontology
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://www.allotrope.org/
+    label: Allotrope Foundation
+creation_date: '2026-06-02T00:00:00Z'
+description: The Allotrope Foundation Ontology (AFO) is a suite of ontologies and controlled vocabularies from the Allotrope Foundation for representing laboratory analytical instruments, processes, materials, results, and related scientific data.
+domains:
+  - chemistry and biochemistry
+  - information technology
+homepage_url: https://www.allotrope.org/product-releases
+id: afo
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
+name: Allotrope Foundation Ontology
+products:
+  - category: OntologyProduct
+    description: Allotrope Foundation Ontology release information and access page for current AFO product releases.
+    format: http
+    id: afo.release
+    latest_version: 2026/03
+    name: AFO Release Page
+    original_source:
+      - source: afo
+        relation_type: prov:hadPrimarySource
+    product_url: https://www.allotrope.org/product-releases
+  - category: GraphicalInterface
+    description: Ontobee browser page for the Allotrope Foundation Ontology.
+    format: http
+    id: afo.ontobee
+    name: AFO Ontobee Browser
+    original_source:
+      - source: afo
+        relation_type: prov:hadPrimarySource
+    product_url: https://ontobee.org/ontology/AFO
+synonyms:
+  - AFO
+warnings:
+  - Allotrope release packages may require access through Allotrope Foundation release pages rather than stable direct public ontology-file URLs.
+---
+
+# Allotrope Foundation Ontology
+
+AFO provides controlled vocabulary and ontology terms for Allotrope laboratory data models, including analytical instruments, processes, materials, and measurement results.

--- a/resource/dcat/dcat.md
+++ b/resource/dcat/dcat.md
@@ -1,0 +1,59 @@
+---
+activity_status: active
+category: DataModel
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://www.w3.org/
+    label: World Wide Web Consortium
+creation_date: '2026-06-02T00:00:00Z'
+description: The Data Catalog Vocabulary (DCAT) is a W3C RDF vocabulary designed to support interoperability between data catalogs published on the Web.
+domains:
+  - information technology
+  - general
+homepage_url: https://www.w3.org/TR/vocab-dcat-3/
+id: dcat
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+name: Data Catalog Vocabulary
+products:
+  - category: DataModelProduct
+    description: Turtle serialization of the W3C Data Catalog Vocabulary namespace.
+    id: dcat.ttl
+    latest_version: '3'
+    name: DCAT Turtle Vocabulary
+    original_source:
+      - source: dcat
+        relation_type: prov:hadPrimarySource
+    product_url: https://www.w3.org/ns/dcat.ttl
+  - category: DocumentationProduct
+    description: W3C Recommendation for Data Catalog Vocabulary version 3.
+    format: http
+    id: dcat.spec
+    latest_version: '3'
+    name: DCAT Version 3 Specification
+    original_source:
+      - source: dcat
+        relation_type: prov:hadPrimarySource
+    product_url: https://www.w3.org/TR/vocab-dcat-3/
+publications:
+  - authors:
+      - Riccardo Albertoni
+      - David Browning
+      - Simon Cox
+      - Alejandra Gonzalez Beltran
+      - Andrea Perego
+      - Peter Winstanley
+    id: https://www.w3.org/TR/vocab-dcat-3/
+    journal: W3C Recommendation
+    preferred: true
+    title: Data Catalog Vocabulary (DCAT) - Version 3
+    year: '2024'
+synonyms:
+  - DCAT
+---
+
+# Data Catalog Vocabulary
+
+DCAT is a W3C RDF vocabulary for describing datasets, data services, and catalogs so that data catalogs can interoperate on the Web.

--- a/resource/gnps/gnps.md
+++ b/resource/gnps/gnps.md
@@ -1,0 +1,72 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://ccms.ucsd.edu/
+    label: UC San Diego Center for Computational Mass Spectrometry
+creation_date: '2026-06-02T00:00:00Z'
+description: Global Natural Products Social Molecular Networking (GNPS) is a web-based mass spectrometry ecosystem and open-access knowledge base for organizing, sharing, analyzing, and annotating raw, processed, or identified tandem mass spectrometry data.
+domains:
+  - chemistry and biochemistry
+  - biomedical
+  - microbiome
+homepage_url: https://gnps.ucsd.edu/ProteoSAFe/static/gnps-splash.jsp
+id: gnps
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+name: Global Natural Products Social Molecular Networking
+products:
+  - category: GraphicalInterface
+    description: GNPS web interface for molecular networking, library search, MASST search, public dataset browsing, spectral library curation, and related mass spectrometry analysis workflows.
+    format: http
+    id: gnps.portal
+    name: GNPS Web Portal
+    original_source:
+      - source: gnps
+        relation_type: prov:hadPrimarySource
+    product_url: https://gnps.ucsd.edu/ProteoSAFe/static/gnps-splash.jsp
+  - category: DocumentationProduct
+    description: GNPS documentation covering the platform, analysis tools, data preparation, molecular networking, spectral library search, dataset sharing, and community features.
+    format: http
+    id: gnps.docs
+    name: GNPS Documentation
+    original_source:
+      - source: gnps
+        relation_type: prov:hadPrimarySource
+    product_url: https://gnpsdocs.readthedocs.io/
+  - category: Product
+    description: GNPS public MS/MS reference spectral library browser and curation interface.
+    format: http
+    id: gnps.spectral_libraries
+    name: GNPS Reference Spectral Libraries
+    original_source:
+      - source: gnps
+        relation_type: prov:hadPrimarySource
+    product_url: https://gnps-external.ucsd.edu/gnpslibrary
+publications:
+  - authors:
+      - Mingxun Wang
+      - Jeremy J Carver
+      - Vanessa V Phelan
+      - Laura M Sanchez
+      - Neha Garg
+      - Yao Peng
+      - Don Duy Nguyen
+    doi: 10.1038/nbt.3597
+    id: doi:10.1038/nbt.3597
+    journal: Nature Biotechnology
+    preferred: true
+    title: Sharing and community curation of mass spectrometry data with Global Natural Products Social Molecular Networking
+    year: '2016'
+repository: https://github.com/CCMS-UCSD/GNPSDocumentation
+synonyms:
+  - GNPS
+  - Global Natural Products Social Molecular Networking
+---
+
+# GNPS
+
+GNPS is an open web ecosystem for tandem mass spectrometry analysis, molecular networking, spectral library search, dataset publication, and community curation of MS/MS reference spectra.

--- a/resource/massive/massive.md
+++ b/resource/massive/massive.md
@@ -1,0 +1,47 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://ccms.ucsd.edu/
+    label: UC San Diego Center for Computational Mass Spectrometry
+creation_date: '2026-06-02T00:00:00Z'
+description: MassIVE is a community mass spectrometry data repository developed by the NIH-funded UC San Diego Center for Computational Mass Spectrometry to support global, free exchange, browsing, redistribution, reanalysis, and publication-linked sharing of mass spectrometry datasets.
+domains:
+  - chemistry and biochemistry
+  - biomedical
+  - proteomics
+homepage_url: https://massive.ucsd.edu/ProteoSAFe/static/massive.jsp
+id: massive
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+name: MassIVE
+products:
+  - category: GraphicalInterface
+    description: MassIVE web portal for submitting, browsing, downloading, and reanalyzing public mass spectrometry datasets.
+    format: http
+    id: massive.portal
+    name: MassIVE Web Portal
+    original_source:
+      - source: massive
+        relation_type: prov:hadPrimarySource
+    product_url: https://massive.ucsd.edu/ProteoSAFe/static/massive.jsp
+  - category: DocumentationProduct
+    description: MassIVE documentation covering dataset sharing, public dataset access, reanalysis workflows, APIs, and related MassIVE services.
+    format: http
+    id: massive.docs
+    name: MassIVE Documentation
+    original_source:
+      - source: massive
+        relation_type: prov:hadPrimarySource
+    product_url: https://ccms-ucsd.github.io/MassIVEDocumentation/
+synonyms:
+  - Mass Spectrometry Interactive Virtual Environment
+  - MassIVE
+---
+
+# MassIVE
+
+MassIVE is a public repository and analysis environment for mass spectrometry datasets. It supports dataset submission, access to public datasets, online reanalysis workflows, and publication-oriented dataset sharing.

--- a/resource/metabokg/metabokg.md
+++ b/resource/metabokg/metabokg.md
@@ -1,0 +1,159 @@
+---
+activity_status: active
+category: KnowledgeGraph
+contacts:
+  - category: Individual
+    contact_details:
+      - contact_type: email
+        value: matthieu.feraud@univ-cotedazur.fr
+    label: Matthieu Feraud
+creation_date: '2026-06-02T00:00:00Z'
+description: MetaboKG is an analysis-centric knowledge graph framework for untargeted metabolomics. It transforms public mass-spectrometry repository outputs, GNPS molecular-networking jobs, library annotations, confidence evidence, sample metadata, and environmental and taxonomic context into RDF knowledge graphs that preserve links between annotations and their analytical artifacts, samples, and studies.
+domains:
+  - chemistry and biochemistry
+  - biomedical
+  - microbiome
+  - environment
+homepage_url: https://github.com/HolobiomicsLab/MetaBoKG
+id: metabokg
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://www.apache.org/licenses/LICENSE-2.0
+  label: Apache License 2.0
+name: MetaboKG
+products:
+  - category: GraphProduct
+    description: RDF knowledge graph materialized by the MetaBoKG workflow from public metabolomics repository outputs, GNPS molecular-networking jobs, annotation evidence, sample metadata, and environmental and taxonomic context. The repository documents generated per-job Turtle files under mapping/kg and loading into Virtuoso named graphs.
+    id: metabokg.graph
+    latest_version: arXiv v1 demonstration
+    name: MetaboKG RDF Graph
+    original_source:
+      - source: metabokg
+        relation_type: prov:hadPrimarySource
+      - source: pubmed
+        relation_type: prov:hadPrimarySource
+      - source: pubmedcentral
+        relation_type: prov:hadPrimarySource
+      - source: gnps
+        relation_type: prov:hadPrimarySource
+      - source: massive
+        relation_type: prov:hadPrimarySource
+      - source: redu
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/HolobiomicsLab/MetaBoKG
+    secondary_source:
+      - source: ms
+        relation_type: prov:used
+      - source: chebi
+        relation_type: prov:used
+      - source: ncbitaxon
+        relation_type: prov:used
+      - source: envo
+        relation_type: prov:used
+      - source: ncit
+        relation_type: prov:used
+      - source: uberon
+        relation_type: prov:used
+      - source: chmo
+        relation_type: prov:used
+      - source: sio
+        relation_type: prov:used
+      - source: prov-o
+        relation_type: prov:used
+      - source: dcat
+        relation_type: prov:used
+      - source: afo
+        relation_type: prov:used
+    warnings:
+      - No static public graph release or hosted endpoint was available in the GitHub repository when curated on 2026-06-02; the repository documents local Turtle materialization and Virtuoso loading.
+  - category: ProcessProduct
+    description: Source-code workflow that fetches PubMed and PMC context, extracts GNPS and MassIVE identifiers, downloads GNPS job archives, materializes RDF with RML mappings, loads Virtuoso, and runs competency-question SPARQL queries.
+    format: http
+    id: metabokg.workflow
+    license:
+      id: https://www.apache.org/licenses/LICENSE-2.0
+      label: Apache License 2.0
+    name: MetaBoKG Transformation Workflow
+    original_source:
+      - source: metabokg
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/HolobiomicsLab/MetaBoKG/blob/main/main.py
+    repository: https://github.com/HolobiomicsLab/MetaBoKG
+  - category: DataModelProduct
+    description: Turtle schema files defining MetaBoKG classes, properties, and ReDU class hierarchies used by the generated knowledge graph.
+    id: metabokg.schema
+    license:
+      id: https://www.apache.org/licenses/LICENSE-2.0
+      label: Apache License 2.0
+    name: MetaBoKG RDF Schema
+    original_source:
+      - source: metabokg
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/HolobiomicsLab/MetaBoKG/tree/main/Schema
+    secondary_source:
+      - source: ms
+        relation_type: prov:wasInformedBy
+      - source: chebi
+        relation_type: prov:wasInformedBy
+      - source: ncbitaxon
+        relation_type: prov:wasInformedBy
+      - source: envo
+        relation_type: prov:wasInformedBy
+      - source: ncit
+        relation_type: prov:wasInformedBy
+      - source: uberon
+        relation_type: prov:wasInformedBy
+      - source: chmo
+        relation_type: prov:wasInformedBy
+      - source: sio
+        relation_type: prov:wasInformedBy
+      - source: prov-o
+        relation_type: prov:wasInformedBy
+      - source: dcat
+        relation_type: prov:wasInformedBy
+      - source: afo
+        relation_type: prov:wasInformedBy
+  - category: MappingProduct
+    description: RML mappings and configuration templates used to transform GNPS, molecular networking, feature-based molecular networking, and ReDU data into RDF.
+    format: http
+    id: metabokg.rml_mappings
+    license:
+      id: https://www.apache.org/licenses/LICENSE-2.0
+      label: Apache License 2.0
+    name: MetaBoKG RML Mappings
+    original_source:
+      - source: metabokg
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/HolobiomicsLab/MetaBoKG/tree/main/mapping/rml
+    secondary_source:
+      - source: gnps
+        relation_type: prov:wasInformedBy
+      - source: massive
+        relation_type: prov:wasInformedBy
+      - source: redu
+        relation_type: prov:wasInformedBy
+publications:
+  - authors:
+      - Matthieu Feraud
+      - Dina Boukhajou
+      - Fabien Gandon
+      - Louis-Felix Nothias
+    doi: 10.48550/arXiv.2605.24706
+    id: arXiv:2605.24706
+    journal: arXiv
+    preferred: true
+    title: 'MetaboKG: An Analysis-centric Knowledge Graph Framework for Untargeted Metabolomics'
+    year: '2026'
+repository: https://github.com/HolobiomicsLab/MetaBoKG
+synonyms:
+  - MetaBoKG
+warnings:
+  - The GitHub repository README states Apache License 2.0, but the repository did not expose a machine-readable GitHub license record when checked on 2026-06-02.
+---
+
+# MetaboKG
+
+MetaboKG is an analysis-centric knowledge graph framework for untargeted metabolomics. It connects public repository metadata, GNPS molecular-networking results, spectral annotations, confidence evidence, sample context, and controlled vocabulary terms so that metabolomics annotations can be explored across analyses with SPARQL.
+
+The public repository provides the transformation workflow, RDF schema files, RML mappings, Virtuoso loading scripts, and competency-question queries. The demonstrated graph materializes per-job Turtle files locally and loads them into named Virtuoso graphs; no static public graph archive or hosted endpoint was available at curation time.

--- a/resource/prov-o/prov-o.md
+++ b/resource/prov-o/prov-o.md
@@ -1,0 +1,57 @@
+---
+activity_status: active
+category: Ontology
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://www.w3.org/
+    label: World Wide Web Consortium
+creation_date: '2026-06-02T00:00:00Z'
+description: PROV-O is the W3C PROV Ontology, an OWL2 ontology for representing provenance information and mapping the PROV data model into RDF/OWL.
+domains:
+  - information technology
+  - general
+homepage_url: https://www.w3.org/TR/prov-o/
+id: prov-o
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+name: PROV-O
+products:
+  - category: OntologyProduct
+    description: OWL serialization of the W3C PROV Ontology.
+    format: owl
+    id: prov-o.owl
+    name: PROV-O OWL
+    original_source:
+      - source: prov-o
+        relation_type: prov:hadPrimarySource
+    product_url: https://www.w3.org/ns/prov-o.owl
+  - category: DocumentationProduct
+    description: W3C Recommendation for PROV-O, the PROV Ontology.
+    format: http
+    id: prov-o.spec
+    latest_version: W3C Recommendation 2013-04-30
+    name: PROV-O Specification
+    original_source:
+      - source: prov-o
+        relation_type: prov:hadPrimarySource
+    product_url: https://www.w3.org/TR/prov-o/
+publications:
+  - authors:
+      - Timothy Lebo
+      - Satya Sahoo
+      - Deborah McGuinness
+    id: https://www.w3.org/TR/prov-o/
+    journal: W3C Recommendation
+    preferred: true
+    title: 'PROV-O: The PROV Ontology'
+    year: '2013'
+synonyms:
+  - PROV Ontology
+  - W3C PROV Ontology
+---
+
+# PROV-O
+
+PROV-O is the W3C ontology for expressing provenance in RDF and OWL.

--- a/resource/redu/redu.md
+++ b/resource/redu/redu.md
@@ -1,0 +1,71 @@
+---
+activity_status: active
+category: Aggregator
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://ccms.ucsd.edu/
+    label: UC San Diego Center for Computational Mass Spectrometry
+creation_date: '2026-06-02T00:00:00Z'
+description: ReDU (Reanalysis of Data User Interface) is a metadata-driven resource for finding, selecting, and reanalyzing public tandem mass spectrometry data at repository scale. It bridges GNPS analysis workflows with MassIVE public mass spectrometry datasets and harmonized sample metadata.
+domains:
+  - chemistry and biochemistry
+  - biomedical
+  - microbiome
+homepage_url: https://redu.gnps2.org/selection/
+id: redu
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+name: ReDU
+products:
+  - category: GraphicalInterface
+    description: Pan-ReDU dashboard and file-selection interface for exploring daily updated public metabolomics metadata and selecting public data for GNPS reanalysis.
+    format: http
+    id: redu.dashboard
+    name: Pan-ReDU Dashboard
+    original_source:
+      - source: redu
+        relation_type: prov:hadPrimarySource
+    product_url: https://redu.gnps2.org/selection/
+    secondary_source:
+      - source: gnps
+        relation_type: prov:wasInformedBy
+      - source: massive
+        relation_type: prov:wasInformedBy
+  - category: DocumentationProduct
+    description: ReDU documentation describing the ReDU file selector, sample information metadata, GNPS repository-scale molecular networking, chemical explorer, contribution process, and data/code availability.
+    format: http
+    id: redu.docs
+    name: ReDU Documentation
+    original_source:
+      - source: redu
+        relation_type: prov:hadPrimarySource
+    product_url: https://mwang87.github.io/ReDU-MS2-Documentation/
+    repository: https://github.com/mwang87/ReDU-MS2-Documentation
+publications:
+  - authors:
+      - Alan K Jarmusch
+      - Louis-Felix Nothias
+      - Michael Petras
+      - Wang Mingxun
+      - Jennifer Koester
+      - Melody Vargas
+      - Nina van der Hooft
+      - Pieter C Dorrestein
+    doi: 10.1038/s41592-020-0916-7
+    id: doi:10.1038/s41592-020-0916-7
+    journal: Nature Methods
+    preferred: true
+    title: 'ReDU: a framework to find and reanalyze public mass spectrometry data'
+    year: '2020'
+repository: https://github.com/mwang87/ReDU-MS2-Documentation
+synonyms:
+  - ReDU
+  - Reanalysis of Data User Interface
+  - Pan-ReDU
+---
+
+# ReDU
+
+ReDU organizes public tandem mass spectrometry data through harmonized sample metadata, enabling repository-scale file selection, GNPS reanalysis, and contextual exploration of public metabolomics data.

--- a/resource/sio/sio.md
+++ b/resource/sio/sio.md
@@ -1,0 +1,70 @@
+---
+activity_status: active
+category: Ontology
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: email
+        value: sio-ontology@googlegroups.com
+      - contact_type: url
+        value: https://semanticscience.org/
+    label: Semanticscience
+creation_date: '2026-06-02T00:00:00Z'
+description: The Semanticscience Integrated Ontology (SIO) is an ontology of basic types and relations for representing physical, processual, and informational entities and supporting biomedical knowledge representation and discovery.
+domains:
+  - biomedical
+  - biological systems
+  - information technology
+homepage_url: https://semanticscience.org/
+id: sio
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
+name: Semanticscience Integrated Ontology
+products:
+  - category: OntologyProduct
+    description: OWL release of the Semanticscience Integrated Ontology.
+    format: owl
+    id: sio.owl
+    name: SIO OWL
+    original_source:
+      - source: sio
+        relation_type: prov:hadPrimarySource
+    product_url: https://semanticscience.org/ontology/sio.owl
+  - category: GraphicalInterface
+    description: BioPortal browser page for the Semanticscience Integrated Ontology.
+    format: http
+    id: sio.bioportal
+    name: SIO BioPortal Browser
+    original_source:
+      - source: sio
+        relation_type: prov:hadPrimarySource
+    product_url: https://bioportal.bioontology.org/ontologies/SIO
+publications:
+  - authors:
+      - Michel Dumontier
+      - Christopher J Baker
+      - Joachim Baran
+      - Alison Callahan
+      - Lap Chang
+      - Leyla Chepelev
+      - Jose Cruz-Toledo
+      - Nicholas R Del Rio
+      - Geraint Duck
+      - Luke I Furlong
+    doi: 10.1186/2041-1480-5-14
+    id: doi:10.1186/2041-1480-5-14
+    journal: Journal of Biomedical Semantics
+    preferred: true
+    title: The Semanticscience Integrated Ontology (SIO) for biomedical research and knowledge discovery
+    year: '2014'
+repository: https://github.com/micheldumontier/semanticscience
+synonyms:
+  - SIO
+---
+
+# Semanticscience Integrated Ontology
+
+SIO provides upper-level classes and relations for consistent knowledge representation across biomedical and semantic-web resources.


### PR DESCRIPTION
## Summary
- Add a curated MetaboKG KnowledgeGraph resource for issue #591
- Add newly referenced source resources: AFO, DCAT, GNPS, MassIVE, PROV-O, ReDU, and SIO
- Include products and provenance details for MetaboKG and source resources

## Validation
- `uv run make prettify-file FILE=resource/metabokg/metabokg.md`
- `uv run make validate-file FILE=resource/metabokg/metabokg.md`
- `uv run make prettify-file FILE=resource/afo/afo.md resource/dcat/dcat.md resource/gnps/gnps.md resource/massive/massive.md resource/prov-o/prov-o.md resource/redu/redu.md resource/sio/sio.md` was run as per-file iterations
- `uv run make validate-file FILE=resource/afo/afo.md resource/dcat/dcat.md resource/gnps/gnps.md resource/massive/massive.md resource/prov-o/prov-o.md resource/redu/redu.md resource/sio/sio.md` was run as per-file iterations

Closes #591