### PR TITLE
Add KG-FM resource

### DIFF
--- a/resource/kg-fm/kg-fm.md
+++ b/resource/kg-fm/kg-fm.md
@@ -1,0 +1,127 @@
+---
+activity_status: active
+category: KnowledgeGraph
+contacts:
+  - category: Individual
+    contact_details:
+      - contact_type: github
+        value: MontageBai
+    label: Xuefeng Bai
+creation_date: '2026-06-02T00:00:00Z'
+description: KG-FM is a Neo4j knowledge graph for framework materials, including metal-organic frameworks, covalent-organic frameworks, and hydrogen-bonded organic frameworks. It was constructed with large language model extraction over more than 100,000 Web of Science articles and covers synthesis, properties, applications, publications, and other framework-material relationships.
+domains:
+  - chemistry and biochemistry
+  - information technology
+  - other
+homepage_url: https://github.com/MontageBai/KGFM
+id: kg-fm
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+name: KG-FM
+products:
+  - category: GraphProduct
+    description: Neo4j framework-materials knowledge graph constructed from Web of Science abstracts and publication metadata with LLM-assisted information extraction. The paper reports 2.53 million nodes and 4.01 million relationships covering materials, properties, structures, applications, and related literature.
+    edge_count: 4010000
+    id: kg-fm.graph
+    name: KG-FM Neo4j Knowledge Graph
+    node_count: 2530000
+    original_source:
+      - source: kg-fm
+        relation_type: prov:hadPrimarySource
+      - source: web-of-science
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/MontageBai/KGFM
+    warnings:
+      - No standalone Neo4j database dump, public graph endpoint, or versioned graph release was identified in the GitHub repository when curated on 2026-06-02; the repository provides source text, JSON extraction files, and Python scripts for constructing and using the graph.
+  - category: ProcessProduct
+    description: Python scripts for splitting abstract text, converting LLM-extracted JSON records into Neo4j Cypher imports, loading title metadata, and integrating KG-FM with LLM-based question answering.
+    format: http
+    id: kg-fm.workflow
+    name: KG-FM Construction and QA Code
+    original_source:
+      - source: kg-fm
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/MontageBai/KGFM
+    repository: https://github.com/MontageBai/KGFM
+    warnings:
+      - The GitHub repository did not expose a machine-readable license record and no explicit license file was identified when curated on 2026-06-02.
+  - category: Product
+    compression: zip
+    description: Zipped abstract-text corpora for COF, HOF, and MOF literature used as input to KG-FM extraction and graph construction.
+    id: kg-fm.abstract_text
+    name: KG-FM Abstract Text Files
+    original_source:
+      - source: kg-fm
+        relation_type: prov:hadPrimarySource
+      - source: web-of-science
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/MontageBai/KGFM/tree/main/Abstract%20Text
+  - category: Product
+    compression: zip
+    description: Zipped JSON extraction files for COF, HOF, and MOF literature, produced from framework-material abstracts and used to import KG-FM nodes and relationships.
+    id: kg-fm.json_extractions
+    name: KG-FM JSON Extraction Files
+    original_source:
+      - source: kg-fm
+        relation_type: prov:hadPrimarySource
+      - source: web-of-science
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/MontageBai/KGFM/tree/main/Json%20File
+  - category: Product
+    description: CSV file containing framework-material questions and reference answers used to evaluate KG-enhanced LLM question answering.
+    format: csv
+    id: kg-fm.question_answer
+    name: KG-FM Question and Answer Benchmark
+    original_source:
+      - source: kg-fm
+        relation_type: prov:hadPrimarySource
+    product_file_size: 22859
+    product_url: https://raw.githubusercontent.com/MontageBai/KGFM/main/Question%20and%20Answer.csv
+  - category: Product
+    compression: zip
+    description: Zipped answer-reference material for the KG-FM question-answering benchmark.
+    id: kg-fm.answer_references
+    name: KG-FM Answer References
+    original_source:
+      - source: kg-fm
+        relation_type: prov:hadPrimarySource
+    product_file_size: 118366
+    product_url: https://raw.githubusercontent.com/MontageBai/KGFM/main/Answer%20Reference.zip
+  - category: DocumentationProduct
+    description: Demonstration video for the KG-FM project.
+    id: kg-fm.demonstration_video
+    name: KG-FM Demonstration Video
+    original_source:
+      - source: kg-fm
+        relation_type: prov:hadPrimarySource
+    product_file_size: 4578745
+    product_url: https://raw.githubusercontent.com/MontageBai/KGFM/main/demonstration%20video.mp4
+publications:
+  - authors:
+      - Xuefeng Bai
+      - Song He
+      - Yi Li
+      - Yabo Xie
+      - Xin Zhang
+      - Wenli Du
+      - Jian-Rong Li
+    doi: 10.1038/s41524-025-01540-6
+    id: doi:10.1038/s41524-025-01540-6
+    journal: npj Computational Materials
+    preferred: true
+    title: Construction of a knowledge graph for framework material enabled by large language models and its application
+    year: '2025'
+repository: https://github.com/MontageBai/KGFM
+synonyms:
+  - KGFM
+  - KG-FM
+  - Framework Materials Knowledge Graph
+warnings:
+  - The GitHub repository did not expose a machine-readable license record and no explicit license file was identified when curated on 2026-06-02.
+---
+
+# KG-FM
+
+KG-FM is a knowledge graph for framework materials, including MOFs, COFs, and HOFs. The graph was built from Web of Science literature records using large language model extraction and loaded into Neo4j for Cypher querying, visualization, data mining, and KG-enhanced question answering.
+
+The public repository provides the construction scripts, abstract text archives, JSON extraction outputs, benchmark question-answer files, answer references, and a demonstration video. A standalone graph dump or hosted graph endpoint was not identified at curation time.

--- a/resource/web-of-science/web-of-science.md
+++ b/resource/web-of-science/web-of-science.md
@@ -1,0 +1,52 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://clarivate.com/
+    label: Clarivate
+creation_date: '2026-06-02T00:00:00Z'
+description: Web of Science Core Collection is a multidisciplinary citation database from Clarivate that indexes peer-reviewed journals, conference proceedings, books, and cited references across sciences, social sciences, arts, and humanities.
+domains:
+  - literature
+  - information technology
+  - general
+homepage_url: https://clarivate.com/academia-government/scientific-and-academic-research/research-discovery-and-referencing/web-of-science/
+id: web-of-science
+last_modified_date: '2026-06-02T00:00:00Z'
+layout: resource_detail
+name: Web of Science
+products:
+  - category: GraphicalInterface
+    description: Web of Science research discovery and citation-index platform.
+    format: http
+    id: web-of-science.platform
+    name: Web of Science Platform
+    original_source:
+      - source: web-of-science
+        relation_type: prov:hadPrimarySource
+    product_url: https://www.webofscience.com/
+    warnings:
+      - Web of Science access is subscription-dependent.
+  - category: DocumentationProduct
+    description: Clarivate documentation for Web of Science Core Collection content, indexes, records, and search features.
+    format: http
+    id: web-of-science.core_collection_docs
+    name: Web of Science Core Collection Documentation
+    original_source:
+      - source: web-of-science
+        relation_type: prov:hadPrimarySource
+    product_url: https://webofscience.help.clarivate.com/Content/wos-core-collection/wos-core-collection.htm
+synonyms:
+  - WoS
+  - Web of Science Core Collection
+  - WOSCC
+warnings:
+  - Web of Science is a proprietary Clarivate resource and institutional subscription depth can affect available coverage.
+---
+
+# Web of Science
+
+Web of Science is a Clarivate research discovery and citation-index platform. KG-FM used Web of Science records for framework-material literature retrieval, abstracts, DOI metadata, author information, publication dates, and journal information.


### PR DESCRIPTION
## Summary
- Add a curated KG-FM KnowledgeGraph resource for issue #594
- Add Web of Science as a new upstream source resource used by KG-FM
- Include products, publication metadata, provenance, and access warnings for unavailable graph dump/license details

## Validation
- `uv run make prettify-file FILE=resource/kg-fm/kg-fm.md`
- `uv run make validate-file FILE=resource/kg-fm/kg-fm.md`
- `uv run make prettify-file FILE=resource/web-of-science/web-of-science.md`
- `uv run make validate-file FILE=resource/web-of-science/web-of-science.md`

Closes #594