### PR TITLE
Align remaining citation labels with cached titles

### DIFF
--- a/resource/emapa/emapa.md
+++ b/resource/emapa/emapa.md
@@ -97,7 +97,7 @@ Mouse Developmental Anatomy Ontology in OBO format
 - [An internet-accessible database of mouse developmental anatomy based on a systematic nomenclature](https://www.ncbi.nlm.nih.gov/pubmed/9651497)
 - [EMAP/EMAPA ontology of mouse developmental anatomy: 2013 update](https://www.ncbi.nlm.nih.gov/pubmed/23972281)
 - [Mouse Anatomy Ontologies: Enhancements and Tools for Exploring and Integrating Biomedical Data](https://www.ncbi.nlm.nih.gov/pubmed/26208972)
-- [Textual Anatomics: the Mouse Developmental Anatomy Ontology and the Gene Expression Database for Mouse Development (GXD)](https://doi.org/10.1016/B978-0-12-800043-4.00023-3)
+- [Textual Anatomics](https://doi.org/10.1016/B978-0-12-800043-4.00023-3)
 
 **Domains**: anatomy and development
 

--- a/resource/ontoneo/ontoneo.md
+++ b/resource/ontoneo/ontoneo.md
@@ -70,7 +70,7 @@ The full version of ONTONEO in OWL format
 ## Publications
 
 - [OntONeo: The Obstetric and Neonatal Ontology](https://doi.org/10.5281/zenodo.17429771)
-- [Formal Ontologies in Knowledge Organization within the Obstetric and Neonatal Domain](https://doi.org/10.5281/zenodo.17508651)
+- [Ontologias Formais na Organização do Conhecimento no Domínio Obstétrico e Neonatal](https://doi.org/10.5281/zenodo.17508651)
 
 **Domains**: biomedical
 


### PR DESCRIPTION
## Summary
- align EMAPA and OntONeo Markdown citation labels with their cached reference titles
- remove stale body text that matched old citation-validation error messages

## Validation
- uv run ./util/extract-metadata.py validate --no-reference-validation-cache resource/emapa/emapa.md resource/ontoneo/ontoneo.md
- uv run ./util/extract-metadata.py validate resource/emapa/emapa.md resource/ontoneo/ontoneo.md
- git diff --check

Notes: The front matter already matched the cached citation metadata on current main; this PR cleans up the remaining Markdown body labels that still showed the old titles.