### PR TITLE
Make citation warnings nonfatal in metadata build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ endif
 # But don't show the whole command because it is very long
 # These commands need the combined schema to be built first
 extract-metadata: tmp/resource-files.txt $(SOURCE_SCHEMA_ALL)
-	@$(RUN) ./util/extract-metadata.py validate @$<
+	@$(RUN) ./util/extract-metadata.py validate --warn-publication-reference-validation @$<
 
 prettify: tmp/resource-files.txt $(SOURCE_SCHEMA_ALL)
 	@$(RUN) ./util/extract-metadata.py prettify @$<

--- a/docs/reference-validation.md
+++ b/docs/reference-validation.md
@@ -14,6 +14,11 @@ uv run make validate-file FILE=resource/<resource>/<resource>.md
 uv run make extract-metadata
 ```
 
+The full `extract-metadata` build target reports publication reference findings
+as warnings so citation metadata issues do not block unrelated registry builds.
+Single-file validation and explicit citation validation commands remain stricter
+and can fail on hard citation metadata errors.
+
 By default, missing cache files are warnings. Cached references are compared to
 the Resource page publication fields, and mismatches in title, year, DOI, or
 first author are validation errors. Journal mismatches are warnings because

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -242,6 +242,56 @@ Content
         mod.validate_markdown(SimpleNamespace(files=[str(md_path)]))
 
 
+def test_validate_markdown_can_warn_on_publication_reference_errors(
+    extract_metadata_module,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    mod = extract_metadata_module
+    resource_dir = tmp_path / "tmpres"
+    resource_dir.mkdir()
+    md_path = resource_dir / "tmpres.md"
+    md_path.write_text(
+        """---
+id: tmpres
+layout: resource_detail
+category: DataSource
+name: Temp Resource
+domains:
+  - biomedical
+publications:
+  - id: PMID:12345
+products:
+  - id: tmpres.product
+    category: Product
+    name: Minimal Product
+---
+
+Content
+"""
+    )
+
+    monkeypatch.setattr(mod, "validate", lambda **_: SimpleNamespace(results=[]))
+
+    def fake_validate_publication_references(*args, **kwargs):
+        return SimpleNamespace(errors=["publication mismatch"], warnings=["publication warning"])
+
+    monkeypatch.setattr(
+        mod,
+        "validate_publication_references",
+        fake_validate_publication_references,
+    )
+
+    mod.validate_markdown(
+        SimpleNamespace(
+            files=[str(md_path)],
+            warn_publication_reference_validation=True,
+            skip_publication_reference_validation=False,
+            no_reference_validation_cache=True,
+        )
+    )
+
+
 def test_validate_markdown_can_remove_invalid_publications(
     extract_metadata_module,
     monkeypatch: pytest.MonkeyPatch,

--- a/util/extract-metadata.py
+++ b/util/extract-metadata.py
@@ -118,6 +118,11 @@ def main():
         action="store_true",
         help="Remove publication entries with hard metadata mismatches from Resource pages.",
     )
+    parser_n.add_argument(
+        "--warn-publication-reference-validation",
+        action="store_true",
+        help="Report publication reference validation errors as warnings instead of failing.",
+    )
     parser_n = subparsers.add_parser(
         "prettify", help="prettify YAML block in registry Markdown files"
     )
@@ -247,6 +252,9 @@ def validate_markdown(args):
                 use_validation_cache=use_reference_validation_cache,
                 validation_cache_data=validation_cache_data,
             )
+            warn_publication_reference_validation = getattr(
+                args, "warn_publication_reference_validation", False
+            )
             if (
                 getattr(args, "remove_invalid_publications", False)
                 and getattr(publication_report, "invalid_publication_indexes", [])
@@ -272,18 +280,31 @@ def validate_markdown(args):
                     f"{fn}: removed {len(removed_indexes)} invalid publication reference(s): "
                     + ", ".join(removed_ids)
                 )
-                errs.extend(
-                    error
-                    for error in publication_report.errors
-                    if not any(f"publication[{index}]" in error for index in removed_indexes)
-                )
                 warn.extend(
                     warning
                     for warning in publication_report.warnings
                     if not any(f"publication[{index}]" in warning for index in removed_indexes)
                 )
+                remaining_errors = [
+                    error
+                    for error in publication_report.errors
+                    if not any(f"publication[{index}]" in error for index in removed_indexes)
+                ]
+                if warn_publication_reference_validation:
+                    warn.extend(
+                        f"publication reference validation error: {error}"
+                        for error in remaining_errors
+                    )
+                else:
+                    errs.extend(remaining_errors)
             else:
-                errs.extend(publication_report.errors)
+                if warn_publication_reference_validation:
+                    warn.extend(
+                        f"publication reference validation error: {error}"
+                        for error in publication_report.errors
+                    )
+                else:
+                    errs.extend(publication_report.errors)
                 warn.extend(publication_report.warnings)
 
         # Now run yaml linter to check for basic syntax errors and formatting


### PR DESCRIPTION
## Summary
- add a validation mode that reports publication reference validation errors as warnings
- use that warning-only mode for the general extract-metadata build target
- keep stricter citation validation available through explicit validation commands
- document the build behavior and add a regression test

## Validation
- uv run pytest tests/test_reference_validation.py
- python3 -m py_compile util/extract-metadata.py util/reference_validation.py
- git diff --check
- uv run ./util/extract-metadata.py validate --warn-publication-reference-validation resource/emapa/emapa.md resource/ontoneo/ontoneo.md

Follows #615