### PR TITLE
Fix invalid archive URL halting TTL build (#624)

### DIFF
--- a/resource/afcs/afcs.md
+++ b/resource/afcs/afcs.md
@@ -37,7 +37,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: afcs
   product_url: https://web.archive.org/web/20220315092731/http://www.signaling-gateway.org/molecule/
-    on 2026-06-01.
 - category: Product
   compression: zip
   description: IntAct-hosted AFCS protein interaction dataset in PSI-MI MITAB format.

--- a/resource/afcs/afcs.molecule-pages.md
+++ b/resource/afcs/afcs.molecule-pages.md
@@ -9,6 +9,5 @@ original_source:
 - relation_type: prov:hadPrimarySource
   source: afcs
 product_url: https://web.archive.org/web/20220315092731/http://www.signaling-gateway.org/molecule/
-  on 2026-06-01.
 layout: product_detail
 ---

--- a/util/yaml2ttl.py
+++ b/util/yaml2ttl.py
@@ -46,6 +46,12 @@ from urllib.parse import quote
 from rdflib import Graph, URIRef, Literal, Namespace
 from rdflib.namespace import RDF, RDFS, DCTERMS, OWL, XSD
 
+try:
+    # rdflib's own check for whether a string can be serialized as a URI.
+    from rdflib.term import _is_valid_uri
+except ImportError:  # pragma: no cover - guard against rdflib internals moving
+    _is_valid_uri = None
+
 # Define namespace URIs
 KGREGISTRY_BASE = "https://w3id.org/kg-registry/"
 SCHEMA = Namespace("http://schema.org/")
@@ -74,9 +80,25 @@ def add_string_property(graph, subject, predicate, value):
 
 
 def add_uri_property(graph, subject, predicate, value):
-    """Add a URI property to the graph if value is not None."""
-    if value:
-        graph.add((subject, predicate, URIRef(str(value))))
+    """Add a URI property to the graph if value is not None.
+
+    Some values (e.g. Wayback Machine archive links, or URLs that picked up
+    stray trailing text during curation) are not serializable as RDF URIs.
+    Rather than letting a single bad value abort the whole Turtle build, we
+    validate first and fall back to a plain string literal, emitting a warning
+    so the offending value still surfaces in the build log.
+    """
+    if not value:
+        return
+    value = str(value)
+    if _is_valid_uri is None or _is_valid_uri(value):
+        graph.add((subject, predicate, URIRef(value)))
+    else:
+        print(
+            f"Warning: {value!r} is not a valid URI; serializing as a string literal.",
+            file=sys.stderr,
+        )
+        graph.add((subject, predicate, Literal(value)))
 
 
 def add_resource_to_graph(graph, resource):


### PR DESCRIPTION
## What was wrong

Issue #624 reads like Wayback Machine URLs trip the URL validator, but that turned out to be a red herring. A clean wayback link like `https://web.archive.org/web/20220315092731/http://www.signaling-gateway.org/molecule/` validates fine in both paths (the JSON-schema path treats these fields as plain strings, and rdflib serializes it as a proper URI).

The real culprit: the afcs `product_url` picked up stray trailing text during curation — `... /molecule/ on 2026-06-01.` — which has spaces and a period, making it a genuinely invalid URI. The Turtle serializer choked on it and halted the entire build (`Makefile:217`). Only `afcs.md` and `afcs.molecule-pages.md` were affected.

## Changes

1. **Fixed the data** — stripped the ` on 2026-06-01.` from the URL in both afcs resource files. This alone unblocks the build.
2. **Hardened `util/yaml2ttl.py`** so a single bad URL can never halt the whole build again. Previously it did a raw `URIRef(str(value))` that only fails at final serialization, so one rotten value aborts everything. Now each URL is validated with rdflib's own check first; anything unserializable is logged as a warning and written as a string literal instead of crashing.

## Verification

- Fixed afcs data serializes as a proper `foaf:homepage` / `schema:url`.
- Re-injecting the old corruption now warns and exits 0 instead of crashing.
- Scanned every resource file's parsed URL values — zero invalid URIs remain, so the regenerated build will pass.

No schema change was needed: clean wayback URLs were always valid.

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)