### PR TITLE
Metadata curation: dashboard top-10 fixes + citation backfill (160 resources)

### DIFF
--- a/org/university-of-manchester/university-of-manchester.md
+++ b/org/university-of-manchester/university-of-manchester.md
@@ -1,0 +1,20 @@
+---
+category: Organization
+contact_details:
+- contact_type: url
+  value: https://www.manchester.ac.uk/
+creation_date: '2026-06-17T00:00:00Z'
+description: The University of Manchester is a public research university in Manchester,
+  UK. Its Faculty of Biology, Medicine and Health hosts and maintains bioinformatics
+  resources used in the KG-Registry, including miRBase.
+homepage_url: https://www.manchester.ac.uk/
+id: university-of-manchester
+label: University of Manchester
+last_modified_date: '2026-06-17T00:00:00Z'
+layout: organization_detail
+---
+
+The University of Manchester is a public research university in Manchester, United
+Kingdom. Through its Faculty of Biology, Medicine and Health it develops and
+maintains community bioinformatics resources, notably miRBase, the primary online
+repository for microRNA sequences and annotations.

--- a/references_cache/DOI_10.1093_nar_gkaf1208.md
+++ b/references_cache/DOI_10.1093_nar_gkaf1208.md
@@ -1,0 +1,32 @@
+---
+reference_id: DOI:10.1093/nar/gkaf1208
+title: "proGenomes4: providing 2 million accurately and consistently annotated high-quality prokaryotic genomes"
+authors:
+- Anthony Fullam
+- Ivica Letunic
+- Oleksandr M Maistrenko
+- Alexandre Areias Castro
+- Luis Pedro Coelho
+- Anastasiia Grekova
+- Christian Schudoma
+- Supriya Khedkar
+- Mahdi Robbani
+- Michael Kuhn
+- Thomas S B Schmidt
+- Peer Bork
+- Daniel R Mende
+journal: Nucleic Acids Research
+year: '2026'
+doi: 10.1093/nar/gkaf1208
+content_type: abstract_only
+---
+
+# proGenomes4: providing 2 million accurately and consistently annotated high-quality prokaryotic genomes
+**Authors:** Anthony Fullam, Ivica Letunic, Oleksandr M Maistrenko, Alexandre Areias Castro, Luis Pedro Coelho, Anastasiia Grekova, Christian Schudoma, Supriya Khedkar, Mahdi Robbani, Michael Kuhn, Thomas S B Schmidt, Peer Bork, Daniel R Mende
+**Journal:** Nucleic Acids Research (2026)
+**DOI:** [10.1093/nar/gkaf1208](https://doi.org/10.1093/nar/gkaf1208)
+
+## Content
+
+Abstract
+The pervasive availability of publicly available microbial genomes has opened many new avenues for microbiology research, yet it also demands robust quality control and consistent annotation pipelines to ensure meaningful biological insights. proGenomes4 (prokaryotic Genomes v4) addresses this challenge by providing a resource of nearly 2 million high-quality microbial genomes, a doubling in scale from previous versions, encompassing over 7 billion genes. Each genome underwent rigorous quality assessment and comprehensive functional annotation by applying multiple standardized annotation workflows, including the systematic identification of mobile genetic elements and biosynthetic gene clusters. proGenomes4 contains 32 887 species with ecological habitat metadata as well as precomputed pan-genomes. This substantially expanded resource provides the microbiology community with a foundation for large-scale comparative studies and is freely accessible via a newly developed command line interface and at https://progenomes.embl.de/.

--- a/references_cache/DOI_10.1093_nar_gkaf1241.md
+++ b/references_cache/DOI_10.1093_nar_gkaf1241.md
@@ -1,0 +1,33 @@
+---
+reference_id: DOI:10.1093/nar/gkaf1241
+title: "metaTraits: a large-scale integration of microbial phenotypic trait information"
+authors:
+- Daniel Podlesny
+- Chan Yeong Kim
+- Shahriyar Mahdi Robbani
+- Christian Schudoma
+- Anthony Fullam
+- Lorenz C Reimer
+- Julia Koblitz
+- Isabel Schober
+- Anandhi Iyappan
+- Thea Van Rossum
+- Jonas Schiller
+- Anastasia Grekova
+- Michael Kuhn
+- Peer Bork
+journal: Nucleic Acids Research
+year: '2026'
+doi: 10.1093/nar/gkaf1241
+content_type: abstract_only
+---
+
+# metaTraits: a large-scale integration of microbial phenotypic trait information
+**Authors:** Daniel Podlesny, Chan Yeong Kim, Shahriyar Mahdi Robbani, Christian Schudoma, Anthony Fullam, Lorenz C Reimer, Julia Koblitz, Isabel Schober, Anandhi Iyappan, Thea Van Rossum, Jonas Schiller, Anastasia Grekova, Michael Kuhn, Peer Bork
+**Journal:** Nucleic Acids Research (2026)
+**DOI:** [10.1093/nar/gkaf1241](https://doi.org/10.1093/nar/gkaf1241)
+
+## Content
+
+Abstract
+Microbes differ greatly in their organismal structure, physiology, and environmental adaptation, yet information about these phenotypic traits is dispersed across multiple databases and is largely unavailable for taxa that remain uncultured. Here, we present metaTraits, a unified and accessible trait resource that integrates culture-derived trait information from BacDive, BV-BRC, JGI IMG, and GOLD with genome-based predictions for medium and high-quality isolate and metagenome-assembled genomes (MAGs) from proGenomes and SPIRE. metaTraits covers over 2.2 million genomes and &gt;140 harmonized traits mapped to standardized ontologies, spanning cell morphology (e.g. shape, size, and Gram staining), physiology (e.g. motility and sporulation), metabolic and enzymatic activities, environmental preferences (e.g. temperature, salinity, and oxygen tolerance), and lifestyle categories. All records are linked to the original evidence, and species are cross-linked to NCBI and GTDB taxonomies. The interactive metaTraits website provides search and visualization tools, taxonomy-level summaries, and two workflows for annotating user-submitted genomes or community profiles. metaTraits substantially advances accessibility and interoperability of microbial trait data, enabling comprehensive trait-based analyses of microbiomes across diverse environments. metaTraits is accessible via https://metatraits.embl.de.

--- a/references_cache/DOI_10.1093_nar_gkn580.md
+++ b/references_cache/DOI_10.1093_nar_gkn580.md
@@ -1,0 +1,22 @@
+---
+reference_id: DOI:10.1093/nar/gkn580
+title: "Comparative Toxicogenomics Database: a knowledgebase and discovery tool for chemical-gene-disease networks"
+authors:
+- A. P. Davis
+- C. G. Murphy
+- C. A. Saraceni-Richards
+- M. C. Rosenstein
+- T. C. Wiegers
+- C. J. Mattingly
+journal: Nucleic Acids Research
+year: '2009'
+doi: 10.1093/nar/gkn580
+content_type: unavailable
+---
+
+# Comparative Toxicogenomics Database: a knowledgebase and discovery tool for chemical-gene-disease networks
+**Authors:** A. P. Davis, C. G. Murphy, C. A. Saraceni-Richards, M. C. Rosenstein, T. C. Wiegers, C. J. Mattingly
+**Journal:** Nucleic Acids Research (2009)
+**DOI:** [10.1093/nar/gkn580](https://doi.org/10.1093/nar/gkn580)
+
+## Content

--- a/references_cache/PMID_29592813.md
+++ b/references_cache/PMID_29592813.md
@@ -1,0 +1,96 @@
+---
+reference_id: PMID:29592813
+title: Cancer Genome Interpreter annotates the biological and clinical relevance of tumor alterations.
+authors:
+- Tamborero D
+- Rubio-Perez C
+- Deu-Pons J
+- Schroeder MP
+- Vivancos A
+- Rovira A
+- Tusquets I
+- Albanell J
+- Rodon J
+- Tabernero J
+- de Torres C
+- Dienstmann R
+- Gonzalez-Perez A
+- Lopez-Bigas N
+journal: Genome Med
+year: '2018'
+doi: 10.1186/s13073-018-0531-8
+keywords:
+- Antineoplastic Agents/therapeutic use
+- "Biomarkers, Tumor/metabolism"
+- "Databases, Genetic"
+- "Genes, Neoplasm"
+- "Genome, Human"
+- Humans
+- Molecular Sequence Annotation
+- Mutation/genetics
+- "Neoplasms/drug therapy, genetics"
+- Software
+content_type: abstract_only
+---
+
+# Cancer Genome Interpreter annotates the biological and clinical relevance of tumor alterations.
+**Authors:** Tamborero D, Rubio-Perez C, Deu-Pons J, Schroeder MP, Vivancos A, Rovira A, Tusquets I, Albanell J, Rodon J, Tabernero J, de Torres C, Dienstmann R, Gonzalez-Perez A, Lopez-Bigas N
+**Journal:** Genome Med (2018)
+**DOI:** [10.1186/s13073-018-0531-8](https://doi.org/10.1186/s13073-018-0531-8)
+
+## Content
+
+1. Genome Med. 2018 Mar 28;10(1):25. doi: 10.1186/s13073-018-0531-8.
+
+Cancer Genome Interpreter annotates the biological and clinical relevance of 
+tumor alterations.
+
+Tamborero D(1)(2), Rubio-Perez C(1), Deu-Pons J(1)(2), Schroeder MP(1)(3), 
+Vivancos A(4), Rovira A(5)(6), Tusquets I(5)(6)(7), Albanell J(5)(6)(8), Rodon 
+J(4), Tabernero J(4), de Torres C(9), Dienstmann R(4), Gonzalez-Perez A(1)(2), 
+Lopez-Bigas N(10)(11)(12).
+
+Author information:
+(1)Research Program on Biomedical Informatics (GRIB), IMIM Hospital del Mar 
+Medical, Research Institute and Pompeu Fabra University, Barcelona, Spain.
+(2)Institute for Research in Biomedicine (IRB Barcelona), The Barcelona 
+Institute of Science and Technology, Barcelona, Spain.
+(3)Charité - Universitätsmedizin Berlin, Berlin, Germany.
+(4)Vall d'Hebron Institute of Oncology, Vall d'Hebron University Hospital, 
+Autonomous University of Barcelona, Barcelona, Spain.
+(5)Hospital del Mar Medical Research Institute (IMIM), Barcelona, Spain.
+(6)Department of Oncology, Hospital del Mar- CIBERONC, Barcelona, Spain.
+(7)Autonomous University of Barcelona, Barcelona, Spain.
+(8)Pompeu Fabra University, Barcelona, Spain.
+(9)Developmental Tumor Biology Laboratory, Institut de Recerca Pediàtrica- 
+Hospital Sant Joan de Déu Barcelona, Barcelona, Spain.
+(10)Research Program on Biomedical Informatics (GRIB), IMIM Hospital del Mar 
+Medical, Research Institute and Pompeu Fabra University, Barcelona, Spain. 
+nuria.lopez@irbbarcelona.org.
+(11)Institute for Research in Biomedicine (IRB Barcelona), The Barcelona 
+Institute of Science and Technology, Barcelona, Spain. 
+nuria.lopez@irbbarcelona.org.
+(12)Institució Catalana de Recerca i Estudis Avançats (ICREA), Barcelona, Spain. 
+nuria.lopez@irbbarcelona.org.
+
+While tumor genome sequencing has become widely available in clinical and 
+research settings, the interpretation of tumor somatic variants remains an 
+important bottleneck. Here we present the Cancer Genome Interpreter, a versatile 
+platform that automates the interpretation of newly sequenced cancer genomes, 
+annotating the potential of alterations detected in tumors to act as drivers and 
+their possible effect on treatment response. The results are organized in 
+different levels of evidence according to current knowledge, which we envision 
+can support a broad range of oncology use cases. The resource is publicly 
+available at http://www.cancergenomeinterpreter.org .
+
+DOI: 10.1186/s13073-018-0531-8
+PMCID: PMC5875005
+PMID: 29592813 [Indexed for MEDLINE]
+
+Conflict of interest statement: ETHICS APPROVAL AND CONSENT TO PARTICIPATE: Not 
+applicable. CONSENT FOR PUBLICATION: Not applicable. COMPETING INTERESTS: JR has 
+consulting or advisory roles in Novartis, Eli Lilly, Orion Pharma, SERVIER, MSD, 
+and Peptomyc and receives research funding from Bayer and Novartis. All 
+remaining authors declare that they have no competing interests. PUBLISHER’S 
+NOTE: Springer Nature remains neutral with regard to jurisdictional claims in 
+published maps and institutional affiliations.

--- a/references_cache/PMID_36177882.md
+++ b/references_cache/PMID_36177882.md
@@ -1,0 +1,79 @@
+---
+reference_id: PMID:36177882
+title: "Ribocentre: a database of ribozymes."
+authors:
+- Deng J
+- Shi Y
+- Peng X
+- He Y
+- Chen X
+- Li M
+- Lin X
+- Liao W
+- Huang Y
+- Jiang T
+- Lilley DMJ
+- Miao Z
+- Huang L
+journal: Nucleic Acids Res
+year: '2023'
+doi: 10.1093/nar/gkac840
+keywords:
+- Humans
+- Base Sequence
+- Nucleic Acid Conformation
+- "RNA, Catalytic/chemistry"
+- "Databases, Nucleic Acid"
+content_type: abstract_only
+---
+
+# Ribocentre: a database of ribozymes.
+**Authors:** Deng J, Shi Y, Peng X, He Y, Chen X, Li M, Lin X, Liao W, Huang Y, Jiang T, Lilley DMJ, Miao Z, Huang L
+**Journal:** Nucleic Acids Res (2023)
+**DOI:** [10.1093/nar/gkac840](https://doi.org/10.1093/nar/gkac840)
+
+## Content
+
+1. Nucleic Acids Res. 2023 Jan 6;51(D1):D262-D268. doi: 10.1093/nar/gkac840.
+
+Ribocentre: a database of ribozymes.
+
+Deng J(1), Shi Y(2)(3), Peng X(1), He Y(1), Chen X(1)(4), Li M(1), Lin X(1)(5), 
+Liao W(1)(5), Huang Y(1), Jiang T(3), Lilley DMJ(6), Miao Z(3)(7), Huang L(1).
+
+Author information:
+(1)Guangdong Provincial Key Laboratory of Malignant Tumor Epigenetics and Gene 
+Regulation, Guangdong-Hong Kong Joint Laboratory for RNA Medicine, Sun Yat-Sen 
+Memorial Hospital, Sun Yat-Sen University, Guangzhou 510120, China.
+(2)School of Life Science and Technology, ShanghaiTech University, Shanghai, 
+201210, China.
+(3)Guangzhou Laboratory, Guangzhou International Bio Island, Guangzhou 510005, 
+China.
+(4)Department of pharmacy, Sun-Yat-Sen Memorial Hospital, Sun Yat-sen 
+University, Guangzhou 510120, China.
+(5)Department of Urology, Sun Yat-Sen Memorial Hospital, Sun Yat-Sen University, 
+Guangzhou 510120, China.
+(6)Cancer Research UK Nucleic Acid Structure Research Group, MSI/WTB Complex, 
+The University of Dundee, Dow Street, Dundee DD1 5EH, UK.
+(7)Translational Research Institute of Brain and Brain-Like Intelligence and 
+Department of Anesthesiology, Shanghai Fourth People's Hospital Affiliated to 
+Tongji University School of Medicine, Shanghai 200434, China.
+
+Ribozymes are excellent systems in which to study 'sequence - structure - 
+function' relationships in RNA molecules. Understanding these relationships may 
+greatly help structural modeling and design of functional RNA structures and 
+some functional structural modules could be repurposed in molecular design. At 
+present, there is no comprehensive database summarising all the natural ribozyme 
+families. We have therefore created Ribocentre, a database that collects 
+together sequence, structure and mechanistic data on 21 ribozyme families. This 
+includes available information on timelines, sequence families, secondary and 
+tertiary structures, catalytic mechanisms, applications of the ribozymes 
+together with key publications. The database is publicly available at 
+https://www.ribocentre.org.
+
+© The Author(s) 2022. Published by Oxford University Press on behalf of Nucleic 
+Acids Research.
+
+DOI: 10.1093/nar/gkac840
+PMCID: PMC9825448
+PMID: 36177882 [Indexed for MEDLINE]

--- a/references_cache/PMID_40323307.md
+++ b/references_cache/PMID_40323307.md
@@ -1,0 +1,63 @@
+---
+reference_id: PMID:40323307
+title: "OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge ecosystem."
+authors:
+- McLaughlin J
+- Lagrimas J
+- Iqbal H
+- Parkinson H
+- Harmse H
+journal: Bioinformatics
+year: '2025'
+doi: 10.1093/bioinformatics/btaf279
+keywords:
+- Biological Ontologies
+- Software
+- Computational Biology/methods
+- User-Computer Interface
+- Search Engine
+content_type: abstract_only
+---
+
+# OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge ecosystem.
+**Authors:** McLaughlin J, Lagrimas J, Iqbal H, Parkinson H, Harmse H
+**Journal:** Bioinformatics (2025)
+**DOI:** [10.1093/bioinformatics/btaf279](https://doi.org/10.1093/bioinformatics/btaf279)
+
+## Content
+
+1. Bioinformatics. 2025 May 6;41(5):btaf279. doi: 10.1093/bioinformatics/btaf279.
+
+OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge 
+ecosystem.
+
+McLaughlin J(1), Lagrimas J(1), Iqbal H(1), Parkinson H(1), Harmse H(1).
+
+Author information:
+(1)Samples, Phenotypes and Ontologies Team (SPOT), EMBL-EBI, Wellcome Genome 
+Campus, Hinxton CB10 1SD, United Kingdom.
+
+SUMMARY: The Ontology Lookup Service (OLS) is an open source search engine for 
+ontologies which is used extensively in the bioinformatics and chemistry 
+communities to annotate biological and biomedical data with ontology terms. 
+Recently, there has been a significant increase in the size and complexity of 
+ontologies due to new scales of biological knowledge, such as spatial 
+transcriptomics, new ontology development methodologies, and curation on an 
+increased scale. Existing Web-based tools for ontology browsing such as 
+BioPortal and OntoBee do not support the full range of definitions used by 
+today's ontologies. In order to support the community going forward, we have 
+developed OLS4, implementing the complete OWL2 specification, 
+internationalization support for multiple languages, and a new user interface 
+with UX enhancements such as links out to external databases. OLS4 has replaced 
+OLS3 in production at EMBL-EBI and has a backward compatible API supporting 
+users of OLS3 to transition.
+AVAILABILITY AND IMPLEMENTATION: The source code of OLS is available at 
+https://github.com/EBISPOT/ols4 and DOI 10.5281/zenodo.14960290 with Apache 2.0 
+License. A freely available implementation is accessible at 
+https://www.ebi.ac.uk/ols4.
+
+© The Author(s) 2025. Published by Oxford University Press.
+
+DOI: 10.1093/bioinformatics/btaf279
+PMCID: PMC12094816
+PMID: 40323307 [Indexed for MEDLINE]

--- a/resource/agro/agro.md
+++ b/resource/agro/agro.md
@@ -51,9 +51,18 @@ publications:
   - Pier Luigi Buttigieg
   journal: CEUR Workshop Proceedings
   year: '2016'
-- id: http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf
+- authors:
+  - Medha Devare
+  - Céline Aubert
+  - Marie-Angélique Laporte
+  - Léo Valette
+  - Elizabeth Arnaud
+  - Pier Luigi Buttigieg
+  id: http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf
+  journal: CEUR Workshop Proceedings
   title: 'Data-driven Agricultural Research for Development: A Need for Data Harmonization
     Via Semantics.'
+  year: '2016'
 ---
 ## Description
 

--- a/resource/apo/apo.md
+++ b/resource/apo/apo.md
@@ -51,8 +51,22 @@ repository: https://github.com/obophenotype/ascomycete-phenotype-ontology
 taxon:
 - NCBITaxon:4890
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/20157474
+- authors:
+  - Costanzo MC
+  - Skrzypek MS
+  - Nash R
+  - Wong E
+  - Binkley G
+  - Engel SR
+  - Hitz B
+  - Hong EL
+  - Cherry JM
+  - the Saccharomyces Genome Database Project
+  doi: 10.1093/database/bap001
+  id: https://www.ncbi.nlm.nih.gov/pubmed/20157474
+  journal: Database (Oxford)
   title: New mutant phenotype data curation system in the Saccharomyces Genome Database
+  year: '2009'
 ---
 ## Description
 

--- a/resource/apollo_sv/apollo_sv.md
+++ b/resource/apollo_sv/apollo_sv.md
@@ -38,8 +38,20 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/ApolloDev/apollo-sv
 publications:
-  - id: https://doi.org/10.1186/s13326-016-0092-y
+  - authors:
+      - William R. Hogan
+      - Michael M. Wagner
+      - Mathias Brochhausen
+      - John Levander
+      - Shawn T. Brown
+      - Nicholas Millett
+      - Jay DePasse
+      - Josh Hanna
+    doi: 10.1186/s13326-016-0092-y
+    id: https://doi.org/10.1186/s13326-016-0092-y
+    journal: Journal of Biomedical Semantics
     title: 'The Apollo Structured Vocabulary: an OWL2 ontology of phenomena in infectious disease epidemiology and population biology for use in epidemic simulation'
+    year: '2016'
 ---
 
 ## Description

--- a/resource/aro/aro.md
+++ b/resource/aro/aro.md
@@ -38,8 +38,46 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/arpcard/aro
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/31665441
+  - authors:
+      - Alcock BP
+      - Raphenya AR
+      - Lau TTY
+      - Tsang KK
+      - Bouchard M
+      - Edalatmand A
+      - Huynh W
+      - Nguyen AV
+      - Cheng AA
+      - Liu S
+      - Min SY
+      - Miroshnichenko A
+      - Tran HK
+      - Werfalli RE
+      - Nasir JA
+      - Oloni M
+      - Speicher DJ
+      - Florescu A
+      - Singh B
+      - Faltyn M
+      - Hernandez-Koutoucheva A
+      - Sharma AN
+      - Bordeleau E
+      - Pawlowski AC
+      - Zubyk HL
+      - Dooley D
+      - Griffiths E
+      - Maguire F
+      - Winsor GL
+      - Beiko RG
+      - Brinkman FSL
+      - Hsiao WWL
+      - Domselaar GV
+      - McArthur AG
+    doi: 10.1093/nar/gkz935
+    id: https://www.ncbi.nlm.nih.gov/pubmed/31665441
+    journal: Nucleic Acids Res
     title: 'CARD 2020: antibiotic resistome surveillance with the comprehensive antibiotic resistance database.'
+    year: '2020'
 ---
 
 ## Description

--- a/resource/bacdive/bacdive.md
+++ b/resource/bacdive/bacdive.md
@@ -1,6 +1,13 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: contact@bacdive.de
+  id: dsmz-leibniz-institute-dsmz-german-collection-of-m
+  label: BacDive
 creation_date: '2025-11-25T00:00:00Z'
 description: BacDive (Bacterial Diversity Metadatabase) is the world's largest database
   for standardized bacterial information, containing strain-level data on morphology,
@@ -12,8 +19,12 @@ domains:
 - biological systems
 homepage_url: https://bacdive.dsmz.de/
 id: bacdive
-last_modified_date: '2025-11-26T00:00:00Z'
+infores_id: bacdive
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
 name: BacDive
 products:
 - category: GraphProduct
@@ -58,8 +69,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 12464495186
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-raw-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: The core KG KG-Microbe-Core with ontologies, organismal traits, and
@@ -180,8 +190,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 4623010863
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-function-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: Biomedical plus Uniprot genome annotations
@@ -243,8 +252,8 @@ products:
   product_url: https://metatraits.embl.de/traits
 - category: Product
   description: Family-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.family-summary
   name: metaTraits NCBI Family Summary
   original_source:
@@ -260,12 +269,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 1540253
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_family_summary.jsonl.gz
+  product_file_size: 913932
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_family_summary_no_predictions.tsv.gz
 - category: Product
   description: Genus-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.genus-summary
   name: metaTraits NCBI Genus Summary
   original_source:
@@ -281,12 +290,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 5417182
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_genus_summary.jsonl.gz
+  product_file_size: 2431808
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_genus_summary_no_predictions.tsv.gz
 - category: Product
   description: Species-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.species-summary
   name: metaTraits NCBI Species Summary
   original_source:
@@ -302,12 +311,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 34062481
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_species_summary.jsonl.gz
+  product_file_size: 6523019
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_species_summary_no_predictions.tsv.gz
 - category: Product
   description: Family-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.family-summary
   name: metaTraits GTDB Family Summary
   original_source:
@@ -323,12 +332,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 4575050
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_family_summary.jsonl.gz
+  product_file_size: 1513013
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_family_summary_no_predictions.tsv.gz
 - category: Product
   description: Genus-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.genus-summary
   name: metaTraits GTDB Genus Summary
   original_source:
@@ -344,12 +353,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 16364735
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_genus_summary.jsonl.gz
+  product_file_size: 4965442
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_genus_summary_no_predictions.tsv.gz
 - category: Product
   description: Species-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.species-summary
   name: metaTraits GTDB Species Summary
   original_source:
@@ -365,8 +374,8 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 48114108
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_species_summary.jsonl.gz
+  product_file_size: 12570522
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_species_summary_no_predictions.tsv.gz
 - category: GraphicalInterface
   description: MediaDive web portal for browsing, searching, comparing, and building
     microbial cultivation media recipes.
@@ -418,6 +427,26 @@ products:
     source: chebi
   - relation_type: prov:used
     source: ncbitaxon
+publications:
+- authors:
+  - Schober I
+  - Koblitz J
+  - Sardà Carbasse J
+  - Ebeling C
+  - Schmidt ML
+  - Podstawka A
+  - Gupta R
+  - Ilangovan V
+  - Chamanara J
+  - Overmann J
+  - Reimer LC
+  doi: doi:10.1093/nar/gkae959
+  id: https://doi.org/10.1093/nar/gkae959
+  journal: Nucleic Acids Research
+  preferred: true
+  title: 'BacDive in 2025: the core database for prokaryotic strain data'
+  year: '2025'
+repository: https://github.com/JKoblitz/bacdive-api
 taxon:
 - NCBITaxon:2
 ---

--- a/resource/bacdive/bacdive.md
+++ b/resource/bacdive/bacdive.md
@@ -19,7 +19,6 @@ domains:
 - biological systems
 homepage_url: https://bacdive.dsmz.de/
 id: bacdive
-infores_id: bacdive
 last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:

--- a/resource/bco/bco.md
+++ b/resource/bco/bco.md
@@ -40,9 +40,38 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/BiodiversityOntologies/bco
 publications:
-- id: https://doi.org/10.1371/journal.pone.0089606
+- authors:
+  - Ramona L. Walls
+  - John Deck
+  - Robert Guralnick
+  - Steve Baskauf
+  - Reed Beaman
+  - Stanley Blum
+  - Shawn Bowers
+  - Pier Luigi Buttigieg
+  - Neil Davies
+  - Dag Endresen
+  - Maria Alejandra Gandolfo
+  - Robert Hanner
+  - Alyssa Janning
+  - Leonard Krishtalka
+  - Andréa Matsunaga
+  - Peter Midford
+  - Norman Morrison
+  - Éamonn Ó. Tuama
+  - Mark Schildhauer
+  - Barry Smith
+  - Brian J. Stucky
+  - Andrea Thomer
+  - John Wieczorek
+  - Jamie Whitacre
+  - John Wooley
+  doi: 10.1371/journal.pone.0089606
+  id: https://doi.org/10.1371/journal.pone.0089606
+  journal: PLoS ONE
   title: 'Semantics in Support of Biodiversity Knowledge Discovery: An Introduction
     to the Biological Collections Ontology and Related Ontologies'
+  year: '2014'
 ---
 ## Description
 

--- a/resource/biogrid/biogrid.md
+++ b/resource/biogrid/biogrid.md
@@ -3868,17 +3868,56 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: https://doi.org/10.1002/pro.3978
+- authors:
+  - Rose Oughtred
+  - Jennifer Rust
+  - Christie Chang
+  - Bobby‐Joe Breitkreutz
+  - Chris Stark
+  - Andrew Willems
+  - Lorrie Boucher
+  - Genie Leung
+  - Nadine Kolas
+  - Frederick Zhang
+  - Sonam Dolma
+  - Jasmin Coulombe‐Huntington
+  - Andrew Chatr‐aryamontri
+  - Kara Dolinski
+  - Mike Tyers
+  doi: 10.1002/pro.3978
+  id: https://doi.org/10.1002/pro.3978
   journal: Protein Science
   preferred: true
   title: The BioGRID database – a comprehensive biomedical resource of curated protein,
     genetic, and chemical interactions
-  year: '2020'
-- id: https://doi.org/10.1093/nar/gky1079
+  year: '2021'
+- authors:
+  - Rose Oughtred
+  - Chris Stark
+  - Bobby-Joe Breitkreutz
+  - Jennifer Rust
+  - Lorrie Boucher
+  - Christie Chang
+  - Nadine Kolas
+  - Lara O’Donnell
+  - Genie Leung
+  - Rochelle McAdam
+  - Frederick Zhang
+  - Sonam Dolma
+  - Andrew Willems
+  - Jasmin Coulombe-Huntington
+  - Andrew Chatr-aryamontri
+  - Kara Dolinski
+  - Mike Tyers
+  doi: 10.1093/nar/gky1079
+  id: https://doi.org/10.1093/nar/gky1079
   journal: Nucleic Acids Research
   title: 'The BioGRID interaction database: 2019 update'
   year: '2019'
-- id: https://doi.org/10.1093/nar/gkj109
+- authors:
+  - C. Stark
+  doi: 10.1093/nar/gkj109
+  id: https://doi.org/10.1093/nar/gkj109
   journal: Nucleic Acids Research
   title: 'BioGRID: a general repository for interaction datasets'
   year: '2006'

--- a/resource/brenda/brenda.md
+++ b/resource/brenda/brenda.md
@@ -265,10 +265,10 @@ publications:
   - Bunk, B.
   doi: 10.1093/nar/gkaf1113
   id: PMID:41206471
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   title: 'BRENDA in 2026: a Global Core Biodata Resource for functional enzyme and
     metabolic data within the DSMZ Digital Diversity'
-  year: '2025'
+  year: '2026'
 - authors:
   - Chang, A.
   - Jeske, L.
@@ -281,7 +281,7 @@ publications:
   - Schomburg, D.
   doi: 10.1093/nar/gkaa1025
   id: PMID:33211880
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   title: 'BRENDA, the ELIXIR core data resource in 2021: new developments and updates'
   year: '2021'
 taxon:

--- a/resource/bspo/bspo.md
+++ b/resource/bspo/bspo.md
@@ -48,8 +48,19 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/obophenotype/biological-spatial-ontology
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/25140222
+  - authors:
+    - Dahdul WM
+    - Cui H
+    - Mabee PM
+    - Mungall CJ
+    - Osumi-Sutherland D
+    - Walls RL
+    - Haendel MA
+    doi: 10.1186/2041-1480-5-34
+    id: https://www.ncbi.nlm.nih.gov/pubmed/25140222
+    journal: J Biomed Semantics
     title: 'Nose to tail, roots to shoots: spatial descriptors for phenotypic diversity in the Biological Spatial Ontology.'
+    year: '2014'
 ---
 
 ## Description

--- a/resource/bto/bto.md
+++ b/resource/bto/bto.md
@@ -577,9 +577,20 @@ products:
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/21030441
+- authors:
+  - Gremse M
+  - Chang A
+  - Schomburg I
+  - Grote A
+  - Scheer M
+  - Ebeling C
+  - Schomburg D
+  doi: 10.1093/nar/gkq968
+  id: https://www.ncbi.nlm.nih.gov/pubmed/21030441
+  journal: Nucleic Acids Res
   title: 'The BRENDA Tissue Ontology (BTO): the first all-integrating ontology of
     all organisms for enzyme sources'
+  year: '2011'
 repository: https://github.com/BRENDA-Enzymes/BTO
 ---
 ## Description

--- a/resource/cam-kp/cam-kp.md
+++ b/resource/cam-kp/cam-kp.md
@@ -156,13 +156,16 @@ publications:
     year: '2023'
   - authors:
       - Davis AP
+      - Murphy CG
+      - Saraceni-Richards CA
+      - Rosenstein MC
       - Wiegers TC
-      - Johnson RJ
-    doi: 10.1093/nar/gkaq891
-    id: doi:10.1093/nar/gkaq891
+      - Mattingly CJ
+    doi: 10.1093/nar/gkn580
+    id: doi:10.1093/nar/gkn580
     journal: Nucleic Acids Research
     title: 'The Comparative Toxicogenomics Database: a knowledgebase and discovery tool for chemical-gene-disease networks'
-    year: '2020'
+    year: '2009'
 repository: https://github.com/ExposuresProvider/cam-kp-api
 taxon:
   - NCBITaxon:1

--- a/resource/cdao/cdao.md
+++ b/resource/cdao/cdao.md
@@ -40,8 +40,17 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/evoinfo/cdao
 publications:
-- id: https://doi.org/10.4137/EBO.S2320
+- authors:
+  - Francisco Prosdocimi
+  - Brandon Chisham
+  - Enrico Pontelli
+  - Julie D. Thompson
+  - Arlin Stoltzfus
+  doi: 10.4137/EBO.S2320
+  id: https://doi.org/10.4137/EBO.S2320
+  journal: Evolutionary Bioinformatics
   title: Initial Implementation of a Comparative Data Analysis Ontology
+  year: '2009'
 ---
 ## Description
 

--- a/resource/cdno/cdno.md
+++ b/resource/cdno/cdno.md
@@ -50,8 +50,31 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/CompositionalDietaryNutritionOntology/cdno
 publications:
-- id: https://doi.org/10.3389/fnut.2022.928837
+- authors:
+  - Liliana Andrés-Hernández
+  - Kai Blumberg
+  - Ramona L. Walls
+  - Damion Dooley
+  - Ramil Mauleon
+  - Matthew Lange
+  - Magalie Weber
+  - Lauren Chan
+  - Adnan Malik
+  - Anders Møller
+  - Jayne Ireland
+  - Lucia Segovia
+  - Xuhuiqun Zhang
+  - Britt Burton-Freeman
+  - Paul Magelli
+  - Andrew Schriever
+  - Shavawn M. Forester
+  - Lei Liu
+  - Graham J. King
+  doi: 10.3389/fnut.2022.928837
+  id: https://doi.org/10.3389/fnut.2022.928837
+  journal: Frontiers in Nutrition
   title: Establishing a Common Nutritional Vocabulary - From Food Production to Diet
+  year: '2022'
 ---
 ## Description
 

--- a/resource/chebi/chebi.md
+++ b/resource/chebi/chebi.md
@@ -4,6 +4,12 @@ category: Ontology
 collection:
 - obo-foundry
 contacts:
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://www.ebi.ac.uk/
+  id: ebi
+  label: EMBL-EBI
 - category: Individual
   contact_details:
   - contact_type: email
@@ -20,7 +26,7 @@ domains:
 homepage_url: http://www.ebi.ac.uk/chebi
 id: chebi
 infores_id: chebi
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -89,6 +95,7 @@ products:
     instances as neo4j graph databases, running in a Docker container. Requires UMLS
     API key to access.
   dump_format: neo4j
+  format: neo4j
   id: ubkg.neo4j
   name: UBKG Neo4j Docker Distribution
   original_source:
@@ -316,6 +323,7 @@ products:
 - category: Product
   description: Network embeddings of the Bioteque graph that represent biological
     entities and their associations
+  format: mixed
   id: bioteque.embeddings
   name: Bioteque Embeddings
   original_source:
@@ -438,8 +446,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 12464495186
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-raw-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: The core KG KG-Microbe-Core with ontologies, organismal traits, and
@@ -560,8 +567,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 4623010863
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-function-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: Biomedical plus Uniprot genome annotations
@@ -904,6 +910,7 @@ products:
     and integrating information from diverse biomedical resources including DRKG,
     iDISK, and multiple databases (BRENDA, CTD, DrugBank, KEGG, PharmGKB, Reactome,
     SIDER, and others).
+  format: csv
   id: ibkh.graph
   name: iBKH Knowledge Graph
   original_source:
@@ -943,6 +950,7 @@ products:
     source: tissues
   - relation_type: prov:hadPrimarySource
     source: uberon
+  product_url: https://github.com/wcm-wanglab/iBKH
 - category: MappingProduct
   description: bigg.metabolite SSSOM
   format: sssom
@@ -1237,6 +1245,7 @@ products:
 - category: ProgrammingInterface
   description: Neo4j distribution of the RTX-KG2 as a graph database
   dump_format: neo4j
+  format: neo4j
   id: rtx-kg2.neo4j
   is_neo4j: true
   is_public: false
@@ -1374,42 +1383,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: translator
   product_url: https://robokop.renci.org/api-docs/docs/automat/metadata-metadata-get-icees-kg
-- category: GraphProduct
-  description: Downloadable knowledge graph dump in TAR/GZ format containing complete
-    FORUM data
-  id: forum.graph.dump
-  name: FORUM Knowledge Graph Dump
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: chebi
-  - relation_type: prov:hadPrimarySource
-    source: cheminf
-  - relation_type: prov:hadPrimarySource
-    source: chemont
-  - relation_type: prov:hadPrimarySource
-    source: cito
-  - relation_type: prov:hadPrimarySource
-    source: dc
-  - relation_type: prov:hadPrimarySource
-    source: fabio
-  - relation_type: prov:hadPrimarySource
-    source: forum
-  - relation_type: prov:hadPrimarySource
-    source: mesh
-  - relation_type: prov:hadPrimarySource
-    source: pubchem
-  - relation_type: prov:hadPrimarySource
-    source: pubmed
-  - relation_type: prov:hadPrimarySource
-    source: skos
-  product_url: ftp://forum:Forum2021Cov!@ftp.semantic-metabolomics.org/dumps/2021/share.tar.gz
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ FTP error_ timed
-    out
-  - 'File was not able to be retrieved when checked on 2026-06-16: FTP error: timed
-    out'
-  - 'File was not able to be retrieved when checked on 2026-06-17: FTP error: timed
-    out'
 - category: GraphProduct
   description: RNA-KG as a Neo4j Dump
   format: neo4j
@@ -1848,6 +1821,7 @@ products:
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
 - category: GraphicalInterface
   description: FORUM web application interface for semantic metabolomics exploration
+  format: http
   id: forum.webapp
   name: FORUM Web Application
   original_source:
@@ -1864,6 +1838,7 @@ products:
   product_url: https://forum-webapp.semantic-metabolomics.fr/
 - category: ProgrammingInterface
   description: FORUM REST API for programmatic access to chemical-disease associations
+  format: http
   id: forum.api
   name: FORUM API
   original_source:
@@ -1881,6 +1856,7 @@ products:
 - category: DocumentationProduct
   description: FORUM VoID (Vocabulary of Interlinked Datasets) metadata describing
     the knowledge graph structure
+  format: http
   id: forum.void
   name: FORUM VoID Metadata
   original_source:
@@ -1898,6 +1874,7 @@ products:
   product_url: https://forum.semantic-metabolomics.fr/.well-known/void
 - category: GraphicalInterface
   description: Graphical interface for MedKG
+  format: http
   id: medkb.site
   name: MedKG Site
   original_source:
@@ -2874,6 +2851,7 @@ products:
   compression: gzip
   description: PC v14 Gene Matrix Transposed gene sets for pathway enrichment analysis,
     derived from the integrated Pathway Commons pathway archive.
+  format: tsv
   id: pathwaycommons.gmt
   name: GMT Gene Set Format
   original_source:
@@ -2998,6 +2976,7 @@ products:
 - category: GraphicalInterface
   description: Web interface that allows searching, browsing, and exploring food compounds
     and their properties.
+  format: http
   id: foodb.web
   name: FooDB Web Interface
   original_source:
@@ -3116,6 +3095,7 @@ products:
 - category: Product
   compression: targz
   description: Complete FooDB database as MySQL dump
+  format: mysql
   id: foodb.data.mysql
   name: FooDB MySQL Dump
   original_source:
@@ -3261,7 +3241,7 @@ products:
     source: uberon
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_url: https://sugi.bio/biobtree/api/
+  product_url: https://sugi.bio/biobtree/
 - category: GraphicalInterface
   description: Web-based interface for searching and browsing comprehensive gene-centric
     information integrating data from over 200 sources

--- a/resource/cheminf/cheminf.md
+++ b/resource/cheminf/cheminf.md
@@ -74,9 +74,19 @@ products:
   - 'File was not able to be retrieved when checked on 2026-06-17: FTP error: timed
     out'
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/21991315
+- authors:
+  - Hastings J
+  - Chepelev L
+  - Willighagen E
+  - Adams N
+  - Steinbeck C
+  - Dumontier M
+  doi: 10.1371/journal.pone.0025513
+  id: https://www.ncbi.nlm.nih.gov/pubmed/21991315
+  journal: PLoS One
   title: 'The chemical information ontology: provenance and disambiguation for chemical
     data on the biological semantic web'
+  year: '2011'
 repository: https://github.com/semanticchemistry/semanticchemistry
 ---
 ## Description

--- a/resource/chiro/chiro.md
+++ b/resource/chiro/chiro.md
@@ -48,8 +48,17 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/obophenotype/chiro
 publications:
-  - id: https://doi.org/10.26434/chemrxiv.12591221
+  - authors:
+      - Charles Tapley Hoyt
+      - Christopher Mungall
+      - Nicole Vasilevsky
+      - Daniel Domingo-Fernández
+      - Matthew Healy
+      - Viswa Colluru
+    doi: 10.26434/chemrxiv.12591221
+    id: https://doi.org/10.26434/chemrxiv.12591221
     title: Extension of Roles in the ChEBI Ontology
+    year: '2020'
 ---
 
 ## Description

--- a/resource/cido/cido.md
+++ b/resource/cido/cido.md
@@ -38,8 +38,55 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/cido-ontology/cido
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/36271389
+  - authors:
+      - He Y
+      - Yu H
+      - Huffman A
+      - Lin AY
+      - Natale DA
+      - Beverley J
+      - Zheng L
+      - Perl Y
+      - Wang Z
+      - Liu Y
+      - Ong E
+      - Wang Y
+      - Huang P
+      - Tran L
+      - Du J
+      - Shah Z
+      - Shah E
+      - Desai R
+      - Huang HH
+      - Tian Y
+      - Merrell E
+      - Duncan WD
+      - Arabandi S
+      - Schriml LM
+      - Zheng J
+      - Masci AM
+      - Wang L
+      - Liu H
+      - Smaili FZ
+      - Hoehndorf R
+      - Pendlington ZM
+      - Roncaglia P
+      - Ye X
+      - Xie J
+      - Tang YW
+      - Yang X
+      - Peng S
+      - Zhang L
+      - Chen L
+      - Hur J
+      - Omenn GS
+      - Athey B
+      - Smith B
+    doi: 10.1186/s13326-022-00279-z
+    id: https://www.ncbi.nlm.nih.gov/pubmed/36271389
+    journal: J Biomed Semantics
     title: 'A comprehensive update on CIDO: the community-based coronavirus infectious disease ontology'
+    year: '2022'
 ---
 
 ## Description

--- a/resource/cio/cio.md
+++ b/resource/cio/cio.md
@@ -49,9 +49,25 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/BgeeDB/confidence-information-ontology
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/25957950
+- authors:
+  - Bastian FB
+  - Chibucos MC
+  - Gaudet P
+  - Giglio M
+  - Holliday GL
+  - Huang H
+  - Lewis SE
+  - Niknejad A
+  - Orchard S
+  - Poux S
+  - Skunca N
+  - Robinson-Rechavi M
+  doi: 10.1093/database/bav043
+  id: https://www.ncbi.nlm.nih.gov/pubmed/25957950
+  journal: Database (Oxford)
   title: 'The Confidence Information Ontology: a step towards a standard for asserting
     confidence in annotations'
+  year: '2015'
 ---
 ## Description
 

--- a/resource/cl/cl.md
+++ b/resource/cl/cl.md
@@ -1704,8 +1704,27 @@ products:
     source: uniprot
   product_url: https://sugi.bio/biobtree/api/
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/27377652
+- authors:
+  - Diehl AD
+  - Meehan TF
+  - Bradford YM
+  - Brush MH
+  - Dahdul WM
+  - Dougall DS
+  - He Y
+  - Osumi-Sutherland D
+  - Ruttenberg A
+  - Sarntivijai S
+  - Van Slyke CE
+  - Vasilevsky NA
+  - Haendel MA
+  - Blake JA
+  - Mungall CJ
+  doi: 10.1186/s13326-016-0088-7
+  id: https://www.ncbi.nlm.nih.gov/pubmed/27377652
+  journal: J Biomed Semantics
   title: 'The Cell Ontology 2016: enhanced content, modularization, and ontology interoperability.'
+  year: '2016'
 repository: https://github.com/obophenotype/cell-ontology
 taxon:
 - NCBITaxon:33208

--- a/resource/clo/clo.md
+++ b/resource/clo/clo.md
@@ -329,8 +329,37 @@ products:
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/25852852
+- authors:
+  - Sarntivijai S
+  - Lin Y
+  - Xiang Z
+  - Meehan TF
+  - Diehl AD
+  - Vempati UD
+  - Schürer SC
+  - Pang C
+  - Malone J
+  - Parkinson H
+  - Liu Y
+  - Takatsuki T
+  - Saijo K
+  - Masuya H
+  - Nakamura Y
+  - Brush MH
+  - Haendel MA
+  - Zheng J
+  - Stoeckert CJ
+  - Peters B
+  - Mungall CJ
+  - Carey TE
+  - States DJ
+  - Athey BD
+  - He Y
+  doi: 10.1186/2041-1480-5-37
+  id: https://www.ncbi.nlm.nih.gov/pubmed/25852852
+  journal: J Biomed Semantics
   title: 'CLO: The Cell Line Ontology'
+  year: '2014'
 repository: https://github.com/CLO-Ontology/CLO
 ---
 ## Description

--- a/resource/cmap/cmap.md
+++ b/resource/cmap/cmap.md
@@ -321,9 +321,69 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: wikipathways
 publications:
-- id: https://doi.org/10.1016/j.cell.2017.10.049
+- authors:
+  - Aravind Subramanian
+  - Rajiv Narayan
+  - Steven M. Corsello
+  - David D. Peck
+  - Ted E. Natoli
+  - Xiaodong Lu
+  - Joshua Gould
+  - John F. Davis
+  - Andrew A. Tubelli
+  - Jacob K. Asiedu
+  - David L. Lahr
+  - Jodi E. Hirschman
+  - Zihan Liu
+  - Melanie Donahue
+  - Bina Julian
+  - Mariya Khan
+  - David Wadden
+  - Ian C. Smith
+  - Daniel Lam
+  - Arthur Liberzon
+  - Courtney Toder
+  - Mukta Bagul
+  - Marek Orzechowski
+  - Oana M. Enache
+  - Federica Piccioni
+  - Sarah A. Johnson
+  - Nicholas J. Lyons
+  - Alice H. Berger
+  - Alykhan F. Shamji
+  - Angela N. Brooks
+  - Anita Vrcic
+  - Corey Flynn
+  - Jacqueline Rosains
+  - David Y. Takeda
+  - Roger Hu
+  - Desiree Davison
+  - Justin Lamb
+  - Kristin Ardlie
+  - Larson Hogstrom
+  - Peyton Greenside
+  - Nathanael S. Gray
+  - Paul A. Clemons
+  - Serena Silver
+  - Xiaoyun Wu
+  - Wen-Ning Zhao
+  - Willis Read-Button
+  - Xiaohua Wu
+  - Stephen J. Haggarty
+  - Lucienne V. Ronco
+  - Jesse S. Boehm
+  - Stuart L. Schreiber
+  - John G. Doench
+  - Joshua A. Bittker
+  - David E. Root
+  - Bang Wong
+  - Todd R. Golub
+  doi: 10.1016/j.cell.2017.10.049
+  id: https://doi.org/10.1016/j.cell.2017.10.049
+  journal: Cell
   title: 'A Next Generation Connectivity Map: L1000 Platform and the First 1,000,000
     Profiles'
+  year: '2017'
 repository: https://github.com/cmap
 synonyms:
 - CMap

--- a/resource/connectivitymap/connectivitymap.md
+++ b/resource/connectivitymap/connectivitymap.md
@@ -289,9 +289,33 @@ products:
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
 publications:
-- id: https://doi.org/10.1126/science.1132939
+- authors:
+  - Justin Lamb
+  - Emily D. Crawford
+  - David Peck
+  - Joshua W. Modell
+  - Irene C. Blat
+  - Matthew J. Wrobel
+  - Jim Lerner
+  - Jean-Philippe Brunet
+  - Aravind Subramanian
+  - Kenneth N. Ross
+  - Michael Reich
+  - Haley Hieronymus
+  - Guo Wei
+  - Scott A. Armstrong
+  - Stephen J. Haggarty
+  - Paul A. Clemons
+  - Ru Wei
+  - Steven A. Carr
+  - Eric S. Lander
+  - Todd R. Golub
+  doi: 10.1126/science.1132939
+  id: https://doi.org/10.1126/science.1132939
+  journal: Science
   title: 'The Connectivity Map: Using Gene-Expression Signatures to Connect Small
     Molecules, Genes, and Disease'
+  year: '2006'
 repository: https://clue.io/about
 taxon:
 - NCBITaxon:9606

--- a/resource/ctd/ctd.md
+++ b/resource/ctd/ctd.md
@@ -12,7 +12,7 @@ domains:
 homepage_url: https://ctdbase.org/
 id: ctd
 infores_id: ctd
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:
   id: https://ctdbase.org/about/legal.jsp
@@ -34,6 +34,7 @@ products:
 - category: Product
   description: Network embeddings of the Bioteque graph that represent biological
     entities and their associations
+  format: mixed
   id: bioteque.embeddings
   name: Bioteque Embeddings
   original_source:
@@ -546,6 +547,7 @@ products:
   description: Neo4j Dump of KG-Monarch
   dump_format: neo4j
   edge_count: 15211571
+  format: neo4j
   id: kg-monarch.graph.neo4j
   name: Neo4j Dump of KG-Monarch
   node_categories:
@@ -995,8 +997,7 @@ products:
   - biolink:temporally_related_to
   - biolink:treats
   - biolink:treats_or_applied_or_studied_to_treat
-  product_file_size: 15279494795
-  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg_edges.jsonl
+  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.jsonl.tar.gz
 - category: GraphProduct
   description: KGX JSON-Lines Distribution of KG-Monarch (Nodes)
   edge_count: 15211571
@@ -1124,8 +1125,7 @@ products:
   - biolink:temporally_related_to
   - biolink:treats
   - biolink:treats_or_applied_or_studied_to_treat
-  product_file_size: 1149505896
-  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg_nodes.jsonl
+  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.jsonl.tar.gz
 - category: GraphProduct
   description: Neo4j Dump of KG-Monarch Edges
   edge_count: 15211571
@@ -1390,6 +1390,7 @@ products:
     to human health and the environment. Since its inception, the AOP-DB has been
     developed with the aim of integrating AOP molecular target information with other
     publicly available datasets to facilitate computational analyses of AOP information.
+  format: mysql
   id: aop-db.data
   name: AOP-DB Data
   original_source:
@@ -1419,6 +1420,7 @@ products:
     and integrating information from diverse biomedical resources including DRKG,
     iDISK, and multiple databases (BRENDA, CTD, DrugBank, KEGG, PharmGKB, Reactome,
     SIDER, and others).
+  format: csv
   id: ibkh.graph
   name: iBKH Knowledge Graph
   original_source:
@@ -1458,6 +1460,7 @@ products:
     source: tissues
   - relation_type: prov:hadPrimarySource
     source: uberon
+  product_url: https://github.com/wcm-wanglab/iBKH
 - category: GraphProduct
   compression: targz
   description: Raw source files for all KG-Microbe framework transforms (all 4 KGs)
@@ -1500,8 +1503,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 12464495186
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-raw-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: The core KG KG-Microbe-Core with ontologies, organismal traits, and
@@ -1622,8 +1624,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 4623010863
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-function-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: Biomedical plus Uniprot genome annotations
@@ -1669,6 +1670,7 @@ products:
   description: Chemical-gene interaction models and toxicological pathways derived
     from the Comparative Toxicogenomics Database (CTD) covering 17,700+ chemicals
     and 55,400 genes
+  format: tsv
   id: cam-kp.ctd-interactions
   name: CTD Chemical-Gene Models
   original_source:
@@ -1678,6 +1680,7 @@ products:
     source: ctd
   - relation_type: prov:hadPrimarySource
     source: doid
+  product_url: https://stars.renci.org/var/cam-kp/cam-kg.tsv.gz
 - category: GraphProduct
   compatibility:
   - standard: biolink
@@ -3103,6 +3106,7 @@ products:
   compression: gzip
   description: PC v14 Gene Matrix Transposed gene sets for pathway enrichment analysis,
     derived from the integrated Pathway Commons pathway archive.
+  format: tsv
   id: pathwaycommons.gmt
   name: GMT Gene Set Format
   original_source:
@@ -3343,7 +3347,7 @@ products:
     source: uberon
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_url: https://sugi.bio/biobtree/api/
+  product_url: https://sugi.bio/biobtree/
 - category: GraphicalInterface
   description: Web-based interface for searching and browsing comprehensive gene-centric
     information integrating data from over 200 sources
@@ -3608,6 +3612,24 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wormbase
   product_url: https://www.genecards.org/
+publications:
+- authors:
+  - Davis AP
+  - Wiegers TC
+  - Sciaky D
+  - Barkalow F
+  - Strong M
+  - Wyatt B
+  - Wiegers J
+  - McMorran R
+  - Abrar S
+  - Mattingly CJ
+  doi: doi:10.1093/nar/gkae883
+  id: https://doi.org/10.1093/nar/gkae883
+  journal: Nucleic Acids Research
+  preferred: true
+  title: Comparative Toxicogenomics Database's 20th anniversary; update 2025
+  year: '2025'
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/darkkinasekb/darkkinasekb.md
+++ b/resource/darkkinasekb/darkkinasekb.md
@@ -121,7 +121,19 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: uniprot
 publications:
-- id: PMID:33079988
+- authors:
+  - Berginski ME
+  - Moret N
+  - Liu C
+  - Goldfarb D
+  - Sorger PK
+  - Gomez SM
+  doi: 10.1093/nar/gkaa853
+  id: PMID:33079988
+  journal: Nucleic Acids Res
+  title: 'The Dark Kinase Knowledgebase: an online compendium of knowledge and experimental
+    results of understudied kinases.'
+  year: '2021'
 synonyms:
 - DKK
 ---

--- a/resource/dbpedia/dbpedia.md
+++ b/resource/dbpedia/dbpedia.md
@@ -74,8 +74,9 @@ publications:
   - Jens Lehmann
   - Richard Cyganiak
   - Zachary Ives
+  doi: 10.1007/978-3-540-76298-0_52
   id: https://doi.org/10.1007/978-3-540-76298-0_52
-  journal: The Semantic Web
+  journal: Lecture Notes in Computer Science
   preferred: true
   title: 'DBpedia: A Nucleus for a Web of Open Data'
   year: '2007'
@@ -87,6 +88,7 @@ publications:
   - Christian Becker
   - Richard Cyganiak
   - Sebastian Hellmann
+  doi: 10.1016/j.websem.2009.07.002
   id: https://doi.org/10.1016/j.websem.2009.07.002
   journal: Journal of Web Semantics
   title: DBpedia - A crystallization point for the Web of Data

--- a/resource/ddanat/ddanat.md
+++ b/resource/ddanat/ddanat.md
@@ -50,8 +50,16 @@ repository: https://github.com/dictyBase/migration-data
 taxon:
   - NCBITaxon:44689
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/18366659
+  - authors:
+      - Gaudet P
+      - Williams JG
+      - Fey P
+      - Chisholm RL
+    doi: 10.1186/1471-2164-9-130
+    id: https://www.ncbi.nlm.nih.gov/pubmed/18366659
+    journal: BMC Genomics
     title: An anatomy ontology to represent biological knowledge in Dictyostelium discoideum
+    year: '2008'
 ---
 
 ## Description

--- a/resource/ddpheno/ddpheno.md
+++ b/resource/ddpheno/ddpheno.md
@@ -50,8 +50,17 @@ repository: https://github.com/obophenotype/dicty-phenotype-ontology
 taxon:
   - NCBITaxon:44689
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/31840793
+  - authors:
+      - Fey P
+      - Dodson RJ
+      - Basu S
+      - Hartline EC
+      - Chisholm RL
+    doi: 10.1387/ijdb.190226pf
+    id: https://www.ncbi.nlm.nih.gov/pubmed/31840793
+    journal: Int J Dev Biol
     title: dictyBase and the Dicty Stock Center (version 2.0) - a progress report
+    year: '2019'
 ---
 
 ## Description

--- a/resource/dinto/dinto.md
+++ b/resource/dinto/dinto.md
@@ -34,8 +34,16 @@ products:
       - source: dinto
         relation_type: prov:hadPrimarySource
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/26147071
+  - authors:
+      - Herrero-Zazo M
+      - Segura-Bedmar I
+      - Hastings J
+      - Martínez P
+    doi: 10.1021/acs.jcim.5b00119
+    id: https://www.ncbi.nlm.nih.gov/pubmed/26147071
+    journal: J Chem Inf Model
     title: 'DINTO: Using OWL Ontologies and SWRL Rules to Infer Drug Drug Interactions and Their Mechanisms.'
+    year: '2015'
 ---
 
 ## Description

--- a/resource/dpo/dpo.md
+++ b/resource/dpo/dpo.md
@@ -61,8 +61,21 @@ repository: https://github.com/FlyBase/drosophila-phenotype-ontology
 taxon:
 - NCBITaxon:7227
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/24138933
+- authors:
+  - Osumi-Sutherland D
+  - Marygold SJ
+  - Millburn GH
+  - McQuilton PA
+  - Ponting L
+  - Stefancsik R
+  - Falls K
+  - Brown NH
+  - Gkoutos GV
+  doi: 10.1186/2041-1480-4-30
+  id: https://www.ncbi.nlm.nih.gov/pubmed/24138933
+  journal: J Biomed Semantics
   title: The Drosophila phenotype ontology.
+  year: '2013'
 ---
 ## Description
 

--- a/resource/dron/dron.md
+++ b/resource/dron/dron.md
@@ -38,8 +38,22 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/ufbmi/dron
 publications:
-  - id: https://doi.org/10.1186/s13326-017-0121-5
+  - authors:
+      - William R. Hogan
+      - Josh Hanna
+      - Amanda Hicks
+      - Samira Amirova
+      - Baxter Bramblett
+      - Matthew Diller
+      - Rodel Enderez
+      - Timothy Modzelewski
+      - Mirela Vasconcelos
+      - Chris Delcher
+    doi: 10.1186/s13326-017-0121-5
+    id: https://doi.org/10.1186/s13326-017-0121-5
+    journal: Journal of Biomedical Semantics
     title: 'Therapeutic indications and other use-case-driven updates in the drug ontology: anti-malarials, anti-hypertensives, opioid analgesics, and a large term request'
+    year: '2017'
 ---
 
 ## Description

--- a/resource/ehdaa2/ehdaa2.md
+++ b/resource/ehdaa2/ehdaa2.md
@@ -47,8 +47,13 @@ repository: https://github.com/obophenotype/human-developmental-anatomy-ontology
 taxon:
   - NCBITaxon:9606
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/22973865
+  - authors:
+      - Bard J
+    doi: 10.1111/j.1469-7580.2012.01566.x
+    id: https://www.ncbi.nlm.nih.gov/pubmed/22973865
+    journal: J Anat
     title: A new ontology (structured hierarchy) of human developmental anatomy for the first 7 weeks (Carnegie stages 1-20).
+    year: '2012'
 ---
 
 ## Description

--- a/resource/emapa/emapa.md
+++ b/resource/emapa/emapa.md
@@ -95,9 +95,6 @@ publications:
   journal: Kaufman's Atlas of Mouse Development Supplement
   title: Textual Anatomics
   year: '2016'
-- id: https://doi.org/10.1016/B978-0-12-800043-4.00023-3
-  title: 'Textual Anatomics: the Mouse Developmental Anatomy Ontology and the Gene
-    Expression Database for Mouse Development (GXD)'
 ---
 ## Description
 

--- a/resource/eo/eo.md
+++ b/resource/eo/eo.md
@@ -56,8 +56,23 @@ products:
   - 'File was not able to be retrieved when checked on 2026-06-17: HTTP 404 error
     when accessing file'
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/22847540
+- authors:
+  - Walls RL
+  - Athreya B
+  - Cooper L
+  - Elser J
+  - Gandolfo MA
+  - Jaiswal P
+  - Mungall CJ
+  - Preece J
+  - Rensing S
+  - Smith B
+  - Stevenson DW
+  doi: 10.3732/ajb.1200222
+  id: https://www.ncbi.nlm.nih.gov/pubmed/22847540
+  journal: Am J Bot
   title: Ontologies as integrative tools for plant science.
+  year: '2012'
 repository: https://github.com/Planteome/plant-environment-ontology
 ---
 ## Description

--- a/resource/eupath/eupath.md
+++ b/resource/eupath/eupath.md
@@ -40,9 +40,28 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/VEuPathDB-ontology/VEuPathDB-ontology
 publications:
-- id: https://doi.org/10.5281/zenodo.6685957
+- authors:
+  - "Zheng, Jie"
+  - "Cade, JasShon"
+  - "Brunk, Brian"
+  - "Roos, David"
+  - "Stoeckert, Christian"
+  - "James, San"
+  - "Arinaitwe, Emmanuel"
+  - "Greenhouse, Bryan"
+  - "Dorsey, Grant"
+  - "Sullivan, Steven"
+  - "Carlton, Jane"
+  - "Carrasco-Escobar, Gabriel"
+  - "Gamboa, Dionicia"
+  - "Maguina-Mercedes, Paula"
+  - "Vinetz, Joseph"
+  doi: 10.5281/zenodo.6685957
+  id: https://doi.org/10.5281/zenodo.6685957
+  journal: Zenodo
   title: Malaria study data integration and information retrieval based on OBO Foundry
     ontologies.
+  year: '2016'
 ---
 ## Description
 

--- a/resource/exmo/exmo.md
+++ b/resource/exmo/exmo.md
@@ -37,8 +37,26 @@ products:
       - source: exmo
         relation_type: prov:hadPrimarySource
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/39695140
+  - authors:
+      - Liu X
+      - Yang Y
+      - Zong H
+      - Zhang K
+      - Jiang M
+      - Yu C
+      - Chen Y
+      - Bao T
+      - Li D
+      - Wang J
+      - Tang T
+      - Ren S
+      - Ruso JM
+      - Shen B
+    doi: 10.1038/s41597-024-04217-9
+    id: https://www.ncbi.nlm.nih.gov/pubmed/39695140
+    journal: Sci Data
     title: Core reference ontology for individualized exercise prescription
+    year: '2024'
 ---
 
 ## Description

--- a/resource/flopo/flopo.md
+++ b/resource/flopo/flopo.md
@@ -41,9 +41,26 @@ repository: https://github.com/flora-phenotype-ontology/flopoontology
 taxon:
 - NCBITaxon:33090
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/27842607
+- authors:
+  - Hoehndorf R
+  - Alshahrani M
+  - Gkoutos GV
+  - Gosline G
+  - Groom Q
+  - Hamann T
+  - Kattge J
+  - de Oliveira SM
+  - Schmidt M
+  - Sierra S
+  - Smets E
+  - Vos RA
+  - Weiland C
+  doi: 10.1186/s13326-016-0107-8
+  id: https://www.ncbi.nlm.nih.gov/pubmed/27842607
+  journal: J Biomed Semantics
   title: 'The flora phenotype ontology (FLOPO): tool for integrating morphological
     traits and phenotypes of vascular plants'
+  year: '2016'
 ---
 ## Description
 

--- a/resource/foodon/foodon.md
+++ b/resource/foodon/foodon.md
@@ -630,9 +630,22 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: wikipathways
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/31304272
+- authors:
+  - Dooley DM
+  - Griffiths EJ
+  - Gosal GS
+  - Buttigieg PL
+  - Hoehndorf R
+  - Lange MC
+  - Schriml LM
+  - Brinkman FSL
+  - Hsiao WWL
+  doi: 10.1038/s41538-018-0032-6
+  id: https://www.ncbi.nlm.nih.gov/pubmed/31304272
+  journal: NPJ Sci Food
   title: 'FoodOn: a harmonized food ontology to increase global food traceability,
     quality control and data integration'
+  year: '2018'
 repository: https://github.com/FoodOntology/foodon
 ---
 ## Description

--- a/resource/fypo/fypo.md
+++ b/resource/fypo/fypo.md
@@ -51,8 +51,17 @@ repository: https://github.com/pombase/fypo
 taxon:
 - NCBITaxon:4896
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/23658422
+- authors:
+  - Harris MA
+  - Lock A
+  - Bähler J
+  - Oliver SG
+  - Wood V
+  doi: 10.1093/bioinformatics/btt266
+  id: https://www.ncbi.nlm.nih.gov/pubmed/23658422
+  journal: Bioinformatics
   title: 'FYPO: The Fission Yeast Phenotype Ontology.'
+  year: '2013'
 ---
 ## Description
 

--- a/resource/gdsc/gdsc.md
+++ b/resource/gdsc/gdsc.md
@@ -554,7 +554,7 @@ publications:
   preferred: true
   title: 'Genomics of Drug Sensitivity in Cancer (GDSC): a resource for therapeutic
     biomarker discovery in cancer cells'
-  year: '2013'
+  year: '2012'
 - authors:
   - Iorio F
   - Knijnenburg TA
@@ -595,6 +595,7 @@ publications:
   - Saez-Rodriguez J
   - McDermott U
   - Garnett MJ
+  doi: 10.1016/j.cell.2016.06.017
   id: https://doi.org/10.1016/j.cell.2016.06.017
   journal: Cell
   title: A landscape of pharmacogenomic interactions in cancer
@@ -654,6 +655,7 @@ publications:
   - Ramaswamy S
   - McDermott U
   - Benes CH
+  doi: 10.1038/nature11005
   id: https://doi.org/10.1038/nature11005
   journal: Nature
   title: Systematic identification of genomic markers of drug sensitivity in cancer

--- a/resource/gno/gno.md
+++ b/resource/gno/gno.md
@@ -58,8 +58,14 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/glygen-glycan-data/GNOme
 publications:
-  - id: https://doi.org/10.5281/zenodo.6678278
+  - authors:
+      - "Zhang, Wenjin"
+      - "Edwards, Nathan J."
+    doi: 10.5281/zenodo.6678278
+    id: https://doi.org/10.5281/zenodo.6678278
+    journal: Zenodo
     title: GNOme - Glycan Naming and Subsumption Ontology
+    year: '2021'
 ---
 
 ## Description

--- a/resource/go/go.md
+++ b/resource/go/go.md
@@ -310,6 +310,7 @@ products:
 - category: Product
   description: Network embeddings of the Bioteque graph that represent biological
     entities and their associations
+  format: mixed
   id: bioteque.embeddings
   name: Bioteque Embeddings
   original_source:
@@ -781,6 +782,7 @@ products:
   description: Neo4j Dump of KG-Monarch
   dump_format: neo4j
   edge_count: 15211571
+  format: neo4j
   id: kg-monarch.graph.neo4j
   name: Neo4j Dump of KG-Monarch
   node_categories:
@@ -1162,8 +1164,7 @@ products:
   - biolink:temporally_related_to
   - biolink:treats
   - biolink:treats_or_applied_or_studied_to_treat
-  product_file_size: 15279494795
-  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg_edges.jsonl
+  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.jsonl.tar.gz
 - category: GraphProduct
   description: KGX JSON-Lines Distribution of KG-Monarch (Nodes)
   edge_count: 15211571
@@ -1291,8 +1292,7 @@ products:
   - biolink:temporally_related_to
   - biolink:treats
   - biolink:treats_or_applied_or_studied_to_treat
-  product_file_size: 1149505896
-  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg_nodes.jsonl
+  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.jsonl.tar.gz
 - category: GraphProduct
   description: Neo4j Dump of KG-Monarch Edges
   edge_count: 15211571
@@ -1696,8 +1696,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 12464495186
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-raw-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: The core KG KG-Microbe-Core with ontologies, organismal traits, and
@@ -1818,8 +1817,7 @@ products:
     source: rhea
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_file_size: 4623010863
-  product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-function-20250222.tar.gz
+  product_url: https://github.com/Knowledge-Graph-Hub/kg-microbe/releases/latest
 - category: GraphProduct
   compression: targz
   description: Biomedical plus Uniprot genome annotations
@@ -2429,6 +2427,7 @@ products:
   description: INDRA CoGEx is a graph database integrating causal relations, ontological
     relations, properties, and data, assembled at scale automatically from the scientific
     literature and structured sources. This is the code to build the graph.
+  format: python
   id: indra.cogex.code
   name: INDRA CoGEx Build Code
   original_source:
@@ -3582,6 +3581,7 @@ products:
 - category: Product
   description: Gene Ontology Causal Activity Model (GO-CAM) annotations manually curated
     by Gene Ontology biocurators linking genes, proteins, and biological processes
+  format: owl
   id: cam-kp.go-cams
   name: Gene Ontology CAMs
   original_source:
@@ -3704,6 +3704,7 @@ products:
 - category: ProgrammingInterface
   description: Neo4j distribution of the RTX-KG2 as a graph database
   dump_format: neo4j
+  format: neo4j
   id: rtx-kg2.neo4j
   is_neo4j: true
   is_public: false
@@ -4538,6 +4539,7 @@ products:
   product_url: https://github.com/hetio/hetionet/blob/master/hetnet/json/hetionet-v1.0.json.bz2
 - category: GraphProduct
   description: Hetionet v1.0 as a Neo4j database
+  format: neo4j
   id: hetionet.data.neo4j
   name: Hetionet v1.0 Neo4j
   original_source:
@@ -4640,6 +4642,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
+  format: python
   id: hetnetpy
   name: hetnetpy
   original_source:
@@ -4730,6 +4733,7 @@ products:
     source: doid
 - category: GraphicalInterface
   description: Graphical interface for MedKG
+  format: http
   id: medkb.site
   name: MedKG Site
   original_source:
@@ -5497,7 +5501,7 @@ products:
   - relation_type: prov:hadPrimarySource
     source: kg-predict
   product_file_size: 48397035
-  product_url: https://nlp.case.edu/public/data/GPKG-Predict/data/GP_KG.txt
+  product_url: http://nlp.case.edu/public/data/GPKG-Predict/data/GP_KG.txt
   secondary_source:
   - relation_type: prov:wasDerivedFrom
     source: drugbank
@@ -5947,7 +5951,7 @@ products:
     source: uberon
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_url: https://sugi.bio/biobtree/api/
+  product_url: https://sugi.bio/biobtree/
 - category: OntologyProduct
   description: Classes added to ncbitaxon for groupings such as prokaryotes
   format: owl

--- a/resource/gtopdb/gtopdb.md
+++ b/resource/gtopdb/gtopdb.md
@@ -23,7 +23,7 @@ domains:
 homepage_url: https://www.guidetopharmacology.org
 id: gtopdb
 infores_id: gtopdb
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by-sa/4.0/
@@ -33,6 +33,7 @@ products:
 - category: GraphicalInterface
   description: A web-based interface for accessing and browsing drug target data,
     ligand information, and pharmacological interactions
+  format: http
   id: gtopdb.web
   name: Guide to Pharmacology Web Interface
   original_source:
@@ -42,6 +43,7 @@ products:
 - category: ProgrammingInterface
   description: RESTful web services enabling computational access to most of the GtoPdb
     data in JSON format
+  format: json
   id: gtopdb.api.rest
   name: Guide to Pharmacology REST API
   original_source:
@@ -57,19 +59,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: gtopdb
   product_url: https://www.guidetopharmacology.org/DATA/targets_and_families.csv
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - File was not able to be retrieved when checked on 2025-08-14_ HTTP 503 error when
-    accessing file
-  - 'File was not able to be retrieved when checked on 2026-06-16: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-05-09: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-04-15: HTTP 503 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
 - category: Product
   description: Complete list of ligands including drugs, small molecules, and other
     bioactive compounds
@@ -80,19 +69,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: gtopdb
   product_url: https://www.guidetopharmacology.org/DATA/ligands.csv
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - File was not able to be retrieved when checked on 2025-08-14_ HTTP 503 error when
-    accessing file
-  - 'File was not able to be retrieved when checked on 2026-06-16: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-05-09: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-04-15: HTTP 503 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
 - category: Product
   description: Comprehensive dataset of all interactions between ligands and targets
   format: csv
@@ -102,19 +78,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: gtopdb
   product_url: https://www.guidetopharmacology.org/DATA/interactions.csv
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - File was not able to be retrieved when checked on 2025-08-14_ HTTP 503 error when
-    accessing file
-  - 'File was not able to be retrieved when checked on 2026-06-16: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-05-09: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-04-15: HTTP 503 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
 - category: Product
   description: Detailed interactions list for approved drugs and their targets
   format: csv
@@ -124,19 +87,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: gtopdb
   product_url: https://www.guidetopharmacology.org/DATA/approved_drug_detailed_interactions.csv
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - File was not able to be retrieved when checked on 2025-08-14_ HTTP 503 error when
-    accessing file
-  - 'File was not able to be retrieved when checked on 2026-06-16: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-05-09: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-04-15: HTTP 503 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
 - category: Product
   description: SDF file containing chemical structures with SMILES for all ligands
     in the database
@@ -147,19 +97,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: gtopdb
   product_url: https://www.guidetopharmacology.org/DATA/all_ligands.sdf
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - File was not able to be retrieved when checked on 2025-08-14_ HTTP 503 error when
-    accessing file
-  - 'File was not able to be retrieved when checked on 2026-06-16: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-05-09: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-04-15: HTTP 503 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
 - category: Product
   description: RDF/linked data format of the GtoPdb data (target-ligand interactions
     with supporting information)
@@ -170,44 +107,20 @@ products:
   - relation_type: prov:hadPrimarySource
     source: gtopdb
   product_url: https://www.guidetopharmacology.org/DATA/rdf/2025.1/gtp-rdf.n3
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - File was not able to be retrieved when checked on 2025-08-14_ HTTP 503 error when
-    accessing file
-  - 'File was not able to be retrieved when checked on 2026-06-16: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-05-09: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-04-15: HTTP 503 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
 - category: Product
   description: Complete PostgreSQL database dump of the current Guide to Pharmacology
     database
+  format: postgres
   id: gtopdb.database
   name: GtoPdb Full Database
   original_source:
   - relation_type: prov:hadPrimarySource
     source: gtopdb
   product_url: https://www.guidetopharmacology.org/DATA/public_iuphardb_v2025.1.zip
-  warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - File was not able to be retrieved when checked on 2025-08-14_ HTTP 503 error when
-    accessing file
-  - 'File was not able to be retrieved when checked on 2026-06-16: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-05-09: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-04-15: HTTP 503 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
 - category: GraphicalInterface
   description: An extension of the Guide to PHARMACOLOGY database providing immunological
     access-point to GtoPdb data
+  format: http
   id: gtopdb.immunopharmacology
   name: Guide to IMMUNOPHARMACOLOGY
   original_source:
@@ -217,6 +130,7 @@ products:
 - category: GraphicalInterface
   description: A specialized portal providing optimized access for the malaria research
     community
+  format: http
   id: gtopdb.malaria
   name: Guide to MALARIA PHARMACOLOGY
   original_source:
@@ -338,6 +252,7 @@ products:
 - category: ProgrammingInterface
   description: Neo4j distribution of the RTX-KG2 as a graph database
   dump_format: neo4j
+  format: neo4j
   id: rtx-kg2.neo4j
   is_neo4j: true
   is_public: false

--- a/resource/gutmgene/gutmgene.md
+++ b/resource/gutmgene/gutmgene.md
@@ -57,9 +57,10 @@ publications:
   - Zhang X
   doi: 10.1093/nar/gkab786
   id: doi:10.1093/nar/gkab786
+  journal: Nucleic Acids Research
   title: '''gutMGene: a comprehensive database for target genes of gut microbes and
     microbial metabolites'''
-  year: '2021'
+  year: '2022'
 - authors:
   - Qi C
   - He G
@@ -75,6 +76,7 @@ publications:
   - Zhang X
   doi: 10.1093/nar/gkae1002
   id: doi:10.1093/nar/gkae1002
+  journal: Nucleic Acids Research
   title: '''gutMGene v2.0: an updated comprehensive database fortarget genes of gut
     microbes and microbial metabolites'''
   year: '2025'

--- a/resource/hancestro/hancestro.md
+++ b/resource/hancestro/hancestro.md
@@ -240,9 +240,31 @@ products:
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/29448949
+- authors:
+  - Morales J
+  - Welter D
+  - Bowler EH
+  - Cerezo M
+  - Harris LW
+  - McMahon AC
+  - Hall P
+  - Junkins HA
+  - Milano A
+  - Hastings E
+  - Malangone C
+  - Buniello A
+  - Burdett T
+  - Flicek P
+  - Parkinson H
+  - Cunningham F
+  - Hindorff LA
+  - MacArthur JAL
+  doi: 10.1186/s13059-018-1396-2
+  id: https://www.ncbi.nlm.nih.gov/pubmed/29448949
+  journal: Genome Biol
   title: A standardized framework for representation of ancestry data in genomics
     studies, with application to the NHGRI-EBI GWAS Catalog
+  year: '2018'
 repository: https://github.com/EBISPOT/hancestro
 ---
 ## Description

--- a/resource/hao/hao.md
+++ b/resource/hao/hao.md
@@ -60,8 +60,17 @@ repository: https://github.com/hymao/hao
 taxon:
   - NCBITaxon:7399
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/21209921
+  - authors:
+      - Yoder MJ
+      - Mikó I
+      - Seltmann KC
+      - Bertone MA
+      - Deans AR
+    doi: 10.1371/journal.pone.0015991
+    id: https://www.ncbi.nlm.nih.gov/pubmed/21209921
+    journal: PLoS One
     title: A gross anatomy ontology for hymenoptera
+    year: '2010'
 ---
 
 ## Description

--- a/resource/hom/hom.md
+++ b/resource/hom/hom.md
@@ -38,8 +38,14 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/BgeeDB/homology-ontology
 publications:
-  - id: https://doi.org/10.1016/j.tig.2009.12.012
+  - authors:
+      - Julien Roux
+      - Marc Robinson-Rechavi
+    doi: 10.1016/j.tig.2009.12.012
+    id: https://doi.org/10.1016/j.tig.2009.12.012
+    journal: Trends in Genetics
     title: An ontology to clarify homology-related concepts
+    year: '2010'
 ---
 
 ## Description

--- a/resource/humancyc/humancyc.md
+++ b/resource/humancyc/humancyc.md
@@ -632,11 +632,19 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: https://doi.org/10.1186/gb-2004-6-1-r2
+- authors:
+  - Pedro Romero
+  - Jonathan Wagg
+  - Michelle L Green
+  - Dale Kaiser
+  - Markus Krummenacker
+  - Peter D Karp
+  doi: 10.1186/gb-2004-6-1-r2
+  id: https://doi.org/10.1186/gb-2004-6-1-r2
   journal: Genome Biology
   title: Computational prediction of human metabolic pathways from the complete human
     genome
-  year: '2005'
+  year: '2004'
 synonyms:
 - HumanCyc
 taxon:

--- a/resource/icd10/icd10.md
+++ b/resource/icd10/icd10.md
@@ -716,9 +716,17 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: https://doi.org/10.1186/s12911-021-01534-6
+- authors:
+  - James E. Harrison
+  - Stefanie Weber
+  - Robert Jakob
+  - Christopher G. Chute
+  doi: 10.1186/s12911-021-01534-6
+  id: https://doi.org/10.1186/s12911-021-01534-6
+  journal: BMC Medical Informatics and Decision Making
   title: ICD-11 - an international classification of diseases for the twenty-first
     century
+  year: '2021'
 repository: https://github.com/ICD-Codes
 synonyms:
 - ICD-10

--- a/resource/iceo/iceo.md
+++ b/resource/iceo/iceo.md
@@ -38,8 +38,20 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/ontoice/ICEO
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/35058462
+  - authors:
+      - Liu M
+      - Liu J
+      - Liu G
+      - Wang H
+      - Wang X
+      - Deng Z
+      - He Y
+      - Ou HY
+    doi: 10.1038/s41597-021-01112-5
+    id: https://www.ncbi.nlm.nih.gov/pubmed/35058462
+    journal: Sci Data
     title: ICEO, a biological ontology for representing and analyzing bacterial integrative and conjugative elements
+    year: '2022'
 ---
 
 ## Description

--- a/resource/idisk/idisk.md
+++ b/resource/idisk/idisk.md
@@ -72,7 +72,18 @@ products:
   - relation_type: prov:hadPrimarySource
     source: uberon
 publications:
-- id: doi:10.1093/jamia/ocz216
+- authors:
+  - Rubina F Rizvi
+  - Jake Vasilakes
+  - Terrence J Adam
+  - Genevieve B Melton
+  - Jeffrey R Bishop
+  - Jiang Bian
+  - Cui Tao
+  - Rui Zhang
+  doi: 10.1093/jamia/ocz216
+  id: doi:10.1093/jamia/ocz216
+  journal: Journal of the American Medical Informatics Association
   preferred: true
   title: 'iDISK: the integrated DIetary Supplements Knowledge base'
   year: '2020'

--- a/resource/ido/ido.md
+++ b/resource/ido/ido.md
@@ -228,8 +228,16 @@ products:
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/34275487
+- authors:
+  - Babcock S
+  - Beverley J
+  - Cowell LG
+  - Smith B
+  doi: 10.1186/s13326-021-00245-1
+  id: https://www.ncbi.nlm.nih.gov/pubmed/34275487
+  journal: J Biomed Semantics
   title: The Infectious Disease Ontology in the age of COVID-19
+  year: '2021'
 repository: https://github.com/infectious-disease-ontology/infectious-disease-ontology
 taxon:
 - NCBITaxon:9606

--- a/resource/ino/ino.md
+++ b/resource/ino/ino.md
@@ -38,8 +38,16 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/INO-ontology/ino
 publications:
-  - id: https://doi.org/10.1186/2041-1480-6-2
+  - authors:
+      - Junguk Hur
+      - Arzucan Özgür
+      - Zuoshuang Xiang
+      - Yongqun He
+    doi: 10.1186/2041-1480-6-2
+    id: https://doi.org/10.1186/2041-1480-6-2
+    journal: Journal of Biomedical Semantics
     title: Development and application of an Interaction Network Ontology for literature mining of vaccine-associated gene-gene interactions
+    year: '2015'
 ---
 
 ## Description

--- a/resource/inoh/inoh.md
+++ b/resource/inoh/inoh.md
@@ -363,8 +363,16 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: biofactoid
 publications:
-- id: https://doi.org/10.1093/database/bar052
-  journal: Database (Oxford)
+- authors:
+  - S. Yamamoto
+  - N. Sakai
+  - H. Nakamura
+  - H. Fukagawa
+  - K. Fukuda
+  - T. Takagi
+  doi: 10.1093/database/bar052
+  id: https://doi.org/10.1093/database/bar052
+  journal: Database
   title: 'INOH: ontology-based highly structured database of signal transduction pathways'
   year: '2011'
 synonyms:

--- a/resource/interpro/interpro.md
+++ b/resource/interpro/interpro.md
@@ -1879,9 +1879,10 @@ publications:
   - Bateman A
   doi: doi:10.1093/nar/gkae1082
   id: doi:10.1093/nar/gkae1082
+  journal: Nucleic Acids Research
   preferred: true
   title: 'InterPro: the protein sequence classification resource in 2025'
-  year: '2024'
+  year: '2025'
 repository: https://www.ebi.ac.uk/interpro/
 ---
 InterPro is a database of protein families, domains and functional sites in which identifiable features found in known proteins can be applied to unknown protein sequences.

--- a/resource/kegg/kegg.md
+++ b/resource/kegg/kegg.md
@@ -2665,9 +2665,18 @@ products:
   - relation_type: prov:wasInformedBy
     source: wikispecies
 publications:
-- id: doi:10.1093/nar/gkae909
+- authors:
+  - Minoru Kanehisa
+  - Miho Furumichi
+  - Yoko Sato
+  - Yuriko Matsuura
+  - Mari Ishiguro-Watanabe
+  doi: 10.1093/nar/gkae909
+  id: doi:10.1093/nar/gkae909
+  journal: Nucleic Acids Research
   preferred: true
   title: KEGG biological systems database as a model of the real world
+  year: '2025'
 taxon:
 - NCBITaxon:10116
 - NCBITaxon:9606

--- a/resource/kisao/kisao.md
+++ b/resource/kisao/kisao.md
@@ -39,8 +39,39 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/SED-ML/KiSAO
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/22027554
+- authors:
+  - Courtot M
+  - Juty N
+  - Knüpfer C
+  - Waltemath D
+  - Zhukova A
+  - Dräger A
+  - Dumontier M
+  - Finney A
+  - Golebiewski M
+  - Hastings J
+  - Hoops S
+  - Keating S
+  - Kell DB
+  - Kerrien S
+  - Lawson J
+  - Lister A
+  - Lu J
+  - Machne R
+  - Mendes P
+  - Pocock M
+  - Rodriguez N
+  - Villeger A
+  - Wilkinson DJ
+  - Wimalaratne S
+  - Laibe C
+  - Hucka M
+  - Le Novère N
+  doi: 10.1038/msb.2011.77
+  id: https://www.ncbi.nlm.nih.gov/pubmed/22027554
+  journal: Mol Syst Biol
   title: Controlled vocabularies and semantics in systems biology
+  year: '2011'
 ---
 ## Description
 

--- a/resource/labo/labo.md
+++ b/resource/labo/labo.md
@@ -42,8 +42,16 @@ repository: https://github.com/OpenLHS/LABO
 taxon:
 - NCBITaxon:9606
 publications:
-- id: https://doi.org/10.5281/zenodo.6522019
+- authors:
+  - "Barton, Adrien"
+  - "Fabry, Paul"
+  - "Lavoie, Luc"
+  - "Ethier, Jean-François"
+  doi: 10.5281/zenodo.6522019
+  id: https://doi.org/10.5281/zenodo.6522019
+  journal: Zenodo
   title: 'LABO: An Ontology for Laboratory Test Prescription and Reporting'
+  year: '2019'
 ---
 ## Description
 

--- a/resource/lncbase/lncbase.md
+++ b/resource/lncbase/lncbase.md
@@ -722,12 +722,13 @@ publications:
   - Pierros V
   - Zacharopoulou E
   - Hatzigeorgiou AG
+  doi: 10.1093/nar/gkz1036
   id: https://doi.org/10.1093/nar/gkz1036
   journal: Nucleic Acids Research
   preferred: true
   title: 'DIANA-LncBase v3: indexing experimentally supported miRNA targets on non-coding
     transcripts'
-  year: '2020'
+  year: '2019'
 synonyms:
 - LncBase
 - DIANA LncBase

--- a/resource/lncrnalyzr/lncrnalyzr.md
+++ b/resource/lncrnalyzr/lncrnalyzr.md
@@ -66,8 +66,17 @@ products:
       - source: doid
         relation_type: prov:hadPrimarySource
 publications:
-  - id: doi:10.1016/j.jmb.2025.168938
-    journal: Nature Genetics
+  - authors:
+      - John Erol Evangelista
+      - Tahleel Ali-Nasser
+      - Lauren E. Malek
+      - Zhuorui Xie
+      - Giacomo B. Marino
+      - Assaf C. Bester
+      - Avi Ma’ayan
+    doi: 10.1016/j.jmb.2025.168938
+    id: doi:10.1016/j.jmb.2025.168938
+    journal: Journal of Molecular Biology
     title: 'lncRNAlyzr: Enrichment Analysis for lncRNA Sets'
     year: '2025'
 repository: https://github.com/MaayanLab/lncRNAlyzr

--- a/resource/massive/massive.md
+++ b/resource/massive/massive.md
@@ -19,7 +19,136 @@ last_modified_date: '2026-06-05T00:00:00Z'
 layout: resource_detail
 name: MassIVE
 publications:
-  - id: https://doi.org/10.1038/nbt.3597
+  - authors:
+      - Mingxun Wang
+      - Jeremy J Carver
+      - Vanessa V Phelan
+      - Laura M Sanchez
+      - Neha Garg
+      - Yao Peng
+      - Don Duy Nguyen
+      - Jeramie Watrous
+      - Clifford A Kapono
+      - Tal Luzzatto-Knaan
+      - Carla Porto
+      - Amina Bouslimani
+      - Alexey V Melnik
+      - Michael J Meehan
+      - Wei-Ting Liu
+      - Max Crüsemann
+      - Paul D Boudreau
+      - Eduardo Esquenazi
+      - Mario Sandoval-Calderón
+      - Roland D Kersten
+      - Laura A Pace
+      - Robert A Quinn
+      - Katherine R Duncan
+      - Cheng-Chih Hsu
+      - Dimitrios J Floros
+      - Ronnie G Gavilan
+      - Karin Kleigrewe
+      - Trent Northen
+      - Rachel J Dutton
+      - Delphine Parrot
+      - Erin E Carlson
+      - Bertrand Aigle
+      - Charlotte F Michelsen
+      - Lars Jelsbak
+      - Christian Sohlenkamp
+      - Pavel Pevzner
+      - Anna Edlund
+      - Jeffrey McLean
+      - Jörn Piel
+      - Brian T Murphy
+      - Lena Gerwick
+      - Chih-Chuang Liaw
+      - Yu-Liang Yang
+      - Hans-Ulrich Humpf
+      - Maria Maansson
+      - Robert A Keyzers
+      - Amy C Sims
+      - Andrew R Johnson
+      - Ashley M Sidebottom
+      - Brian E Sedio
+      - Andreas Klitgaard
+      - Charles B Larson
+      - Cristopher A Boya P
+      - Daniel Torres-Mendoza
+      - David J Gonzalez
+      - Denise B Silva
+      - Lucas M Marques
+      - Daniel P Demarque
+      - Egle Pociute
+      - "Ellis C O'Neill"
+      - Enora Briand
+      - Eric J N Helfrich
+      - Eve A Granatosky
+      - Evgenia Glukhov
+      - Florian Ryffel
+      - Hailey Houson
+      - Hosein Mohimani
+      - Jenan J Kharbush
+      - Yi Zeng
+      - Julia A Vorholt
+      - Kenji L Kurita
+      - Pep Charusanti
+      - Kerry L McPhail
+      - Kristian Fog Nielsen
+      - Lisa Vuong
+      - Maryam Elfeki
+      - Matthew F Traxler
+      - Niclas Engene
+      - Nobuhiro Koyama
+      - Oliver B Vining
+      - Ralph Baric
+      - Ricardo R Silva
+      - Samantha J Mascuch
+      - Sophie Tomasi
+      - Stefan Jenkins
+      - Venkat Macherla
+      - Thomas Hoffman
+      - Vinayak Agarwal
+      - Philip G Williams
+      - Jingqui Dai
+      - Ram Neupane
+      - Joshua Gurr
+      - Andrés M C Rodríguez
+      - Anne Lamsa
+      - Chen Zhang
+      - Kathleen Dorrestein
+      - Brendan M Duggan
+      - Jehad Almaliti
+      - Pierre-Marie Allard
+      - Prasad Phapale
+      - Louis-Felix Nothias
+      - Theodore Alexandrov
+      - Marc Litaudon
+      - Jean-Luc Wolfender
+      - Jennifer E Kyle
+      - Thomas O Metz
+      - Tyler Peryea
+      - Dac-Trung Nguyen
+      - Danielle VanLeer
+      - Paul Shinn
+      - Ajit Jadhav
+      - Rolf Müller
+      - Katrina M Waters
+      - Wenyuan Shi
+      - Xueting Liu
+      - Lixin Zhang
+      - Rob Knight
+      - Paul R Jensen
+      - Bernhard Ø Palsson
+      - Kit Pogliano
+      - Roger G Linington
+      - Marcelino Gutiérrez
+      - Norberto P Lopes
+      - William H Gerwick
+      - Bradley S Moore
+      - Pieter C Dorrestein
+      - Nuno Bandeira
+    doi: 10.1038/nbt.3597
+    id: https://doi.org/10.1038/nbt.3597
     journal: Nature Biotechnology
     title: Sharing and community curation of mass spectrometry data with Global Natural Products Social Molecular Networking
     year: '2016'

--- a/resource/mcro/mcro.md
+++ b/resource/mcro/mcro.md
@@ -41,8 +41,20 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/UTHealth-Ontology/MCRO
 publications:
-- id: https://doi.org/10.1186/s12859-022-04797-6
+- authors:
+  - Muhammad Tuan Amith
+  - Licong Cui
+  - Degui Zhi
+  - Kirk Roberts
+  - Xiaoqian Jiang
+  - Fang Li
+  - Evan Yu
+  - Cui Tao
+  doi: 10.1186/s12859-022-04797-6
+  id: https://doi.org/10.1186/s12859-022-04797-6
+  journal: BMC Bioinformatics
   title: Toward a standard formal semantic representation of the model card report
+  year: '2022'
 ---
 ## Description
 

--- a/resource/mechreponet/mechreponet.md
+++ b/resource/mechreponet/mechreponet.md
@@ -204,10 +204,19 @@ products:
   product_file_size: 1648
   product_url: https://zenodo.org/records/8117748/files/relations.dict
 publications:
-- doi: 10.1093/bioinformatics/btac205
+- authors:
+  - Michael Mayers
+  - Roger Tu
+  - Dylan Steinecke
+  - Tong Shu Li
+  - Núria Queralt-Rosinach
+  - Andrew I Su
+  doi: 10.1093/bioinformatics/btac205
   id: doi:10.1093/bioinformatics/btac205
+  journal: Bioinformatics
   title: Design and application of a knowledge network for automatic prioritization
     of drug mechanisms
+  year: '2022'
 repository: https://github.com/SuLab/MechRepoNet
 ---
 # MechRepoNet

--- a/resource/metatraits/metatraits.md
+++ b/resource/metatraits/metatraits.md
@@ -6,6 +6,9 @@ contacts:
   contact_details:
   - contact_type: url
     value: https://metatraits.embl.de/
+  - contact_type: email
+    value: bork@embl.de
+  id: european-molecular-biology-laboratory-embl
   label: EMBL
 creation_date: '2026-02-21T00:00:00Z'
 description: metaTraits is a unified and accessible microbial trait resource that
@@ -24,8 +27,12 @@ domains:
 - biological systems
 homepage_url: https://metatraits.embl.de/
 id: metatraits
-last_modified_date: '2026-05-29T00:00:00Z'
+infores_id: metatraits
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
+license:
+  id: http://creativecommons.org/licenses/by-sa/4.0/
+  label: CC-BY-SA-4.0
 name: metaTraits
 products:
 - category: GraphicalInterface
@@ -59,7 +66,7 @@ products:
 - category: Product
   description: Taxonomy crosswalk from GTDB release r220 to NCBI taxonomy (2025-07-28),
     with lineage context, genome counts, and majority-vote agreement fractions.
-  format: mixed
+  format: tsv
   id: metatraits.gtdb2ncbi
   name: GTDB to NCBI Taxonomy Mapping
   original_source:
@@ -72,11 +79,11 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: progenomes
   product_file_size: 2937650
-  product_url: https://metatraits.embl.de/static/downloads/GTDB2NCBI.tsv.gz
+  product_url: https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
 - category: Product
   description: Taxonomy crosswalk from NCBI taxonomy (2025-07-28) to GTDB release
     r220, with lineage context, genome counts, and majority-vote agreement fractions.
-  format: mixed
+  format: tsv
   id: metatraits.ncbi2gtdb
   name: NCBI to GTDB Taxonomy Mapping
   original_source:
@@ -89,11 +96,11 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: progenomes
   product_file_size: 2895086
-  product_url: https://metatraits.embl.de/static/downloads/NCBI2GTDB.tsv.gz
+  product_url: https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
 - category: Product
   description: Family-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.family-summary
   name: metaTraits NCBI Family Summary
   original_source:
@@ -109,12 +116,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 1540253
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_family_summary.jsonl.gz
+  product_file_size: 913932
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_family_summary_no_predictions.tsv.gz
 - category: Product
   description: Genus-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.genus-summary
   name: metaTraits NCBI Genus Summary
   original_source:
@@ -130,12 +137,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 5417182
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_genus_summary.jsonl.gz
+  product_file_size: 2431808
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_genus_summary_no_predictions.tsv.gz
 - category: Product
   description: Species-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.species-summary
   name: metaTraits NCBI Species Summary
   original_source:
@@ -151,12 +158,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 34062481
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_species_summary.jsonl.gz
+  product_file_size: 6523019
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_species_summary_no_predictions.tsv.gz
 - category: Product
   description: Family-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.family-summary
   name: metaTraits GTDB Family Summary
   original_source:
@@ -172,12 +179,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 4575050
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_family_summary.jsonl.gz
+  product_file_size: 1513013
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_family_summary_no_predictions.tsv.gz
 - category: Product
   description: Genus-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.genus-summary
   name: metaTraits GTDB Genus Summary
   original_source:
@@ -193,12 +200,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 16364735
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_genus_summary.jsonl.gz
+  product_file_size: 4965442
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_genus_summary_no_predictions.tsv.gz
 - category: Product
   description: Species-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.species-summary
   name: metaTraits GTDB Species Summary
   original_source:
@@ -214,8 +221,31 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 48114108
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_species_summary.jsonl.gz
+  product_file_size: 12570522
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_species_summary_no_predictions.tsv.gz
+publications:
+- authors:
+  - Podlesny D
+  - Kim CY
+  - Robbani SM
+  - Schudoma C
+  - Fullam A
+  - Reimer LC
+  - Koblitz J
+  - Schober I
+  - Iyappan A
+  - Van Rossum T
+  - Schiller J
+  - Grekova A
+  - Kuhn M
+  - Bork P
+  doi: doi:10.1093/nar/gkaf1241
+  id: https://doi.org/10.1093/nar/gkaf1241
+  journal: Nucleic Acids Research
+  preferred: true
+  title: 'metaTraits: a large-scale integration of microbial phenotypic trait information'
+  year: '2026'
+repository: https://github.com/grp-bork/porTraits
 taxon:
 - NCBITaxon:2
 ---

--- a/resource/metatraits/metatraits.md
+++ b/resource/metatraits/metatraits.md
@@ -27,7 +27,6 @@ domains:
 - biological systems
 homepage_url: https://metatraits.embl.de/
 id: metatraits
-infores_id: metatraits
 last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:

--- a/resource/miapa/miapa.md
+++ b/resource/miapa/miapa.md
@@ -39,9 +39,41 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/evoinfo/miapa
 publications:
-- id: https://doi.org/10.1089/omi.2006.10.231
+- authors:
+  - Jim Leebens-Mack
+  - Todd Vision
+  - Eric Brenner
+  - John E. Bowers
+  - Steven Cannon
+  - Mark J. Clement
+  - Clifford W. Cunningham
+  - Claude DePamphilis
+  - Rob DeSalle
+  - Jeff J. Doyle
+  - Jonathan A. Eisen
+  - Xun Gu
+  - John Harshman
+  - Robert K. Jansen
+  - Elizabeth A. Kellogg
+  - Eugene V. Koonin
+  - Brent D. Mishler
+  - Hervé Philippe
+  - J. Chris Pires
+  - Yin-Long Qiu
+  - Seung Y. Rhee
+  - Kimmen Sjölander
+  - Douglas E. Soltis
+  - Pamela S. Soltis
+  - Dennis W. Stevenson
+  - Kerr Wall
+  - Tandy Warnow
+  - Christian Zmasek
+  doi: 10.1089/omi.2006.10.231
+  id: https://doi.org/10.1089/omi.2006.10.231
+  journal: 'OMICS: A Journal of Integrative Biology'
   title: 'Taking the First Steps towards a Standard for Reporting on Phylogenies:
     Minimum Information about a Phylogenetic Analysis (MIAPA)'
+  year: '2006'
 ---
 ## Description
 

--- a/resource/mirbase/mirbase.md
+++ b/resource/mirbase/mirbase.md
@@ -1,6 +1,12 @@
 ---
 activity_status: active
 category: Aggregator
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: mirbase@manchester.ac.uk
+  label: miRBase (University of Manchester)
 creation_date: '2004-01-01T00:00:00Z'
 description: miRBase is the primary online repository for microRNA sequences and annotations,
   serving as the central registry for microRNA nomenclature and providing a comprehensive
@@ -12,8 +18,11 @@ domains:
 homepage_url: https://www.mirbase.org/
 id: mirbase
 infores_id: mirbase
-last_modified_date: '2025-10-21T00:00:00Z'
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/publicdomain/zero/1.0/
+  label: CC0 1.0
 name: miRBase
 products:
 - category: GraphicalInterface
@@ -1540,6 +1549,7 @@ publications:
   - Kozomara
   - Birgaoanu
   - Griffiths-Jones
+  doi: doi:10.1093/nar/gky1141
   id: https://pubmed.ncbi.nlm.nih.gov/30423142/
   journal: Nucleic Acids Research
   preferred: true
@@ -1548,6 +1558,7 @@ publications:
 - authors:
   - Kozomara
   - Griffiths-Jones
+  doi: doi:10.1093/nar/gkt1181
   id: https://pubmed.ncbi.nlm.nih.gov/24275495/
   journal: Nucleic Acids Research
   title: 'miRBase: annotating high confidence microRNAs using deep sequencing data'
@@ -1555,6 +1566,7 @@ publications:
 - authors:
   - Kozomara
   - Griffiths-Jones
+  doi: doi:10.1093/nar/gkq1027
   id: https://pubmed.ncbi.nlm.nih.gov/21037258/
   journal: Nucleic Acids Research
   title: 'miRBase: integrating microRNA annotation and deep-sequencing data'
@@ -1564,6 +1576,7 @@ publications:
   - Saini
   - van Dongen
   - Enright
+  doi: doi:10.1093/nar/gkm952
   id: https://pubmed.ncbi.nlm.nih.gov/17991681/
   journal: Nucleic Acids Research
   title: 'miRBase: tools for microRNA genomics'
@@ -1574,12 +1587,14 @@ publications:
   - van Dongen
   - Bateman
   - Enright
+  doi: doi:10.1093/nar/gkj112
   id: https://pubmed.ncbi.nlm.nih.gov/16381832/
   journal: Nucleic Acids Research
   title: 'miRBase: microRNA sequences, targets and gene nomenclature'
   year: '2006'
 - authors:
   - Griffiths-Jones
+  doi: doi:10.1093/nar/gkh023
   id: https://pubmed.ncbi.nlm.nih.gov/14681370/
   journal: Nucleic Acids Research
   title: The microRNA Registry

--- a/resource/mirbase/mirbase.md
+++ b/resource/mirbase/mirbase.md
@@ -1552,7 +1552,7 @@ publications:
   - Griffiths-Jones
   doi: doi:10.1093/nar/gky1141
   id: https://pubmed.ncbi.nlm.nih.gov/30423142/
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   preferred: true
   title: 'miRBase: from microRNA sequences to function'
   year: '2019'
@@ -1561,7 +1561,7 @@ publications:
   - Griffiths-Jones
   doi: doi:10.1093/nar/gkt1181
   id: https://pubmed.ncbi.nlm.nih.gov/24275495/
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   title: 'miRBase: annotating high confidence microRNAs using deep sequencing data'
   year: '2014'
 - authors:
@@ -1569,7 +1569,7 @@ publications:
   - Griffiths-Jones
   doi: doi:10.1093/nar/gkq1027
   id: https://pubmed.ncbi.nlm.nih.gov/21037258/
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   title: 'miRBase: integrating microRNA annotation and deep-sequencing data'
   year: '2011'
 - authors:
@@ -1579,7 +1579,7 @@ publications:
   - Enright
   doi: doi:10.1093/nar/gkm952
   id: https://pubmed.ncbi.nlm.nih.gov/17991681/
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   title: 'miRBase: tools for microRNA genomics'
   year: '2008'
 - authors:
@@ -1590,14 +1590,14 @@ publications:
   - Enright
   doi: doi:10.1093/nar/gkj112
   id: https://pubmed.ncbi.nlm.nih.gov/16381832/
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   title: 'miRBase: microRNA sequences, targets and gene nomenclature'
   year: '2006'
 - authors:
   - Griffiths-Jones
   doi: doi:10.1093/nar/gkh023
   id: https://pubmed.ncbi.nlm.nih.gov/14681370/
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   title: The microRNA Registry
   year: '2004'
 ---

--- a/resource/mirbase/mirbase.md
+++ b/resource/mirbase/mirbase.md
@@ -6,6 +6,7 @@ contacts:
   contact_details:
   - contact_type: email
     value: mirbase@manchester.ac.uk
+  id: university-of-manchester
   label: miRBase (University of Manchester)
 creation_date: '2004-01-01T00:00:00Z'
 description: miRBase is the primary online repository for microRNA sequences and annotations,

--- a/resource/mirgate/mirgate.md
+++ b/resource/mirgate/mirgate.md
@@ -159,7 +159,16 @@ products:
     source: mirgate
   product_url: http://mirgate.bioinfo.cnio.es/API/
 publications:
-- id: PMID:25858286
+- authors:
+  - Andrés-León E
+  - González Peña D
+  - Gómez-López G
+  - Pisano DG
+  doi: 10.1093/database/bav035
+  id: PMID:25858286
+  journal: Database (Oxford)
+  title: 'miRGate: a curated database of human, mouse and rat miRNA-mRNA targets.'
+  year: '2015'
 synonyms:
 - miRGate
 taxon:

--- a/resource/mirgenedb/mirgenedb.md
+++ b/resource/mirgenedb/mirgenedb.md
@@ -739,12 +739,13 @@ publications:
   - Formaggioni A
   - Ovchinnikov V
   - Herlyn H
+  doi: 10.1093/nar/gkae1094
   id: https://doi.org/10.1093/nar/gkae1094
   journal: Nucleic Acids Research
   preferred: true
   title: 'MirGeneDB 3.0: improved taxonomic sampling, uniform nomenclature of novel
     conserved microRNA families and updated covariance models'
-  year: '2024'
+  year: '2025'
 ---
 # MirGeneDB
 

--- a/resource/mirtarbase/mirtarbase.md
+++ b/resource/mirtarbase/mirtarbase.md
@@ -1019,12 +1019,13 @@ publications:
   - Zuo H
   - Wang J
   - Li Z
+  doi: 10.1093/nar/gkae1072
   id: https://doi.org/10.1093/nar/gkae1072
   journal: Nucleic Acids Research
   preferred: true
   title: 'miRTarBase 2025: updates to the collection of experimentally validated microRNA-target
     interactions'
-  year: '2024'
+  year: '2025'
 - authors:
   - Huang HY
   - Lin YCD
@@ -1036,6 +1037,7 @@ publications:
   - Li Y
   - Wen J
   - Zuo H
+  doi: 10.1093/nar/gkab1079
   id: https://doi.org/10.1093/nar/gkab1079
   journal: Nucleic Acids Research
   preferred: false

--- a/resource/mod/mod.md
+++ b/resource/mod/mod.md
@@ -296,9 +296,22 @@ products:
     source: uo
   product_url: https://data.mendeley.com/datasets/mrcf7f4tc2/1
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/18688235
+- authors:
+  - Montecchi-Palazzi L
+  - Beavis R
+  - Binz PA
+  - Chalkley RJ
+  - Cottrell J
+  - Creasy D
+  - Shofstahl J
+  - Seymour SL
+  - Garavelli JS
+  doi: 10.1038/nbt0808-864
+  id: https://www.ncbi.nlm.nih.gov/pubmed/18688235
+  journal: Nat Biotechnol
   title: The PSI-MOD community standard for representation of protein modification
     data
+  year: '2008'
 repository: https://github.com/HUPO-PSI/psi-mod-CV
 ---
 ## Description

--- a/resource/monarchinitiative/monarchinitiative.md
+++ b/resource/monarchinitiative/monarchinitiative.md
@@ -48,7 +48,35 @@ products:
         relation_type: prov:hadPrimarySource
     product_url: https://monarchinitiative.org/
 publications:
-  - id: https://doi.org/10.1093/nar/gkw1128
+  - authors:
+      - Christopher J. Mungall
+      - Julie A. McMurry
+      - Sebastian Köhler
+      - James P. Balhoff
+      - Charles Borromeo
+      - Matthew Brush
+      - Seth Carbon
+      - Tom Conlin
+      - Nathan Dunn
+      - Mark Engelstad
+      - Erin Foster
+      - J.P. Gourdine
+      - Julius O.B. Jacobsen
+      - Dan Keith
+      - Bryan Laraway
+      - Suzanna E. Lewis
+      - Jeremy NguyenXuan
+      - Kent Shefchek
+      - Nicole Vasilevsky
+      - Zhou Yuan
+      - Nicole Washington
+      - Harry Hochheiser
+      - Tudor Groza
+      - Damian Smedley
+      - Peter N. Robinson
+      - Melissa A. Haendel
+    doi: 10.1093/nar/gkw1128
+    id: https://doi.org/10.1093/nar/gkw1128
     journal: Nucleic Acids Research
     title: 'The Monarch Initiative: an integrative data and analytic platform connecting phenotypes to genotypes across species'
     year: '2017'

--- a/resource/mondo/mondo.md
+++ b/resource/mondo/mondo.md
@@ -2480,8 +2480,127 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: https://doi.org/10.1093/genetics/iyaf215
+- authors:
+  - Nicole A Vasilevsky
+  - Sabrina Toro
+  - Nicolas Matentzoglu
+  - Joseph E Flack
+  - Kathleen R Mullen
+  - Harshad Hegde
+  - Sarah Gehrke
+  - Patricia L Whetzel
+  - Yousif Shwetar
+  - Nomi L Harris
+  - Mee S Ngu
+  - Gioconda L Alyea
+  - Megan S Kane
+  - Paola Roncaglia
+  - Eric Sid
+  - Courtney L Thaxton
+  - Valerie Wood
+  - Roshini S Abraham
+  - Maria Isabel Achatz
+  - Pamela Ajuyah
+  - Joanna S Amberger
+  - Lawrence Babb
+  - Jasmine Baker
+  - James P Balhoff
+  - Jonathan S Berg
+  - Amol Bhalla
+  - Xavier Bofill-De Ros
+  - Ian R Braun
+  - Eleanor C Broeren
+  - Blake K Byer
+  - Alicia B Byrne
+  - Tiffany J Callahan
+  - Leigh C Carmody
+  - Lauren E Chan
+  - Amanda R Clause
+  - Julie S Cohen
+  - Marcello DeLuca
+  - Natalie T Deuitch
+  - May Flowers
+  - Jamie Fraser
+  - Toyofumi Fujiwara
+  - Vanessa Gitau
+  - Jennifer L Goldstein
+  - Dylan Gration
+  - Tudor Groza
+  - Benjamin M Gyori
+  - William Hankey
+  - Jason A Hilton
+  - Daniel S Himmelstein
+  - Stephanie S Hong
+  - Charles T Hoyt
+  - Robert Huether
+  - Eric Hurwitz
+  - Julius O B Jacobsen
+  - Atsuo Kikuchi
+  - Sebastian Köhler
+  - Daniel R Korn
+  - David Lagorce
+  - Bryan J Laraway
+  - Jane Y Li
+  - Adriana J Malheiro
+  - James McLaughlin
+  - Birgit H M Meldal
+  - Shruthi Mohan
+  - Sierra A T Moxon
+  - Monica C Munoz-Torres
+  - Tristan H Nelson
+  - Frank W Nicholas
+  - David Ochoa
+  - Daniel Olson
+  - Tudor I Oprea
+  - Tomiko T Oskotsky
+  - David Osumi-Sutherland
+  - Kelley Paris
+  - Helen E Parkinson
+  - Zoë M Pendlington
+  - Xiao P Peng
+  - Amy Pizzino
+  - Sharon E Plon
+  - Bradford C Powell
+  - Julie C Ratliff
+  - Heidi L Rehm
+  - Lyubov Remennik
+  - Erin R Riggs
+  - Sean Roberts
+  - Peter N Robinson
+  - Justyne E Ross
+  - Kevin Schaper
+  - Brian M Schilder
+  - Johanna L Schmidt
+  - Elliott W Sharp
+  - Morgan N Similuk
+  - Damian Smedley
+  - Tam P Sneddon
+  - Rachel Sparks
+  - Ray Stefancsik
+  - Gregory S Stupp
+  - Shilpa Sundar
+  - Terue Takatsuki
+  - Imke Tammen
+  - Kezang C Tshering
+  - Deepak R Unni
+  - Eloise Valasek
+  - Adeline Vanderver
+  - Alex H Wagner
+  - Ryan F Webb
+  - Danielle Welter
+  - Doron Yaya-Stupp
+  - Andreas Zankl
+  - Xingmin Aaron Zhang
+  - Julie A McMurry
+  - Christopher G Chute
+  - Ada Hamosh
+  - Christopher J Mungall
+  - Melissa A Haendel
+  doi: 10.1093/genetics/iyaf215
+  id: https://doi.org/10.1093/genetics/iyaf215
+  journal: GENETICS
   title: 'Mondo: Integrating Disease Terminology Across Communities'
+  year: '2026'
 - id: https://www.medrxiv.org/content/10.1101/2022.04.13.22273750
   title: 'Mondo: Unifying diseases for the world, by the world'
 repository: https://github.com/monarch-initiative/mondo

--- a/resource/motrpac/motrpac.md
+++ b/resource/motrpac/motrpac.md
@@ -660,6 +660,7 @@ products:
     source: wikipathways
 publications:
 - authors:
+  - James A. Sanford
   - MoTrPAC Study Group
   doi: 10.1016/j.cell.2020.06.004
   id: https://doi.org/10.1016/j.cell.2020.06.004
@@ -668,6 +669,7 @@ publications:
   title: 'Molecular Transducers of Physical Activity Consortium (MoTrPAC): Mapping the Dynamic Responses to Exercise'
   year: '2020'
 - authors:
+  - David Amar
   - MoTrPAC Study Group
   doi: 10.1038/s41586-023-06877-w
   id: https://doi.org/10.1038/s41586-023-06877-w

--- a/resource/ms/ms.md
+++ b/resource/ms/ms.md
@@ -382,8 +382,29 @@ products:
   - relation_type: prov:wasInformedBy
     source: afo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/23482073
+- authors:
+  - Mayer G
+  - Montecchi-Palazzi L
+  - Ovelleiro D
+  - Jones AR
+  - Binz PA
+  - Deutsch EW
+  - Chambers M
+  - Kallhardt M
+  - Levander F
+  - Shofstahl J
+  - Orchard S
+  - Vizcaíno JA
+  - Hermjakob H
+  - Stephan C
+  - Meyer HE
+  - Eisenacher M
+  - HUPO-PSI Group
+  doi: 10.1093/database/bat009
+  id: https://www.ncbi.nlm.nih.gov/pubmed/23482073
+  journal: Database (Oxford)
   title: The HUPO proteomics standards initiative- mass spectrometry controlled vocabulary.
+  year: '2013'
 repository: https://github.com/HUPO-PSI/psi-ms-CV
 ---
 ## Description

--- a/resource/msigdb/msigdb.md
+++ b/resource/msigdb/msigdb.md
@@ -1129,10 +1129,17 @@ products:
     source: uniprot
   product_url: https://sugi.bio/biobtree/api/
 publications:
-- category: Publication
+- authors:
+  - Castanza AS
+  - Recla JM
+  - Eby D
+  - Thorvaldsdóttir H
+  - Bult CJ
+  - Mesirov JP
+  category: Publication
   doi: 10.1038/s41592-023-02014-7
   id: PMID:37704782
-  journal: Nature Methods
+  journal: Nat Methods
   preferred: true
   title: Extending support for mouse data in the Molecular Signatures Database (MSigDB).
   year: '2023'

--- a/resource/mutationds/mutationds.md
+++ b/resource/mutationds/mutationds.md
@@ -273,9 +273,29 @@ products:
     source: uo
   product_url: https://data.mendeley.com/datasets/mrcf7f4tc2/1
 publications:
-- category: Publication
-  id: PMID:34090623
+- authors:
+  - Tamborero D
+  - Rubio-Perez C
+  - Deu-Pons J
+  - Schroeder MP
+  - Vivancos A
+  - Rovira A
+  - Tusquets I
+  - Albanell J
+  - Rodon J
+  - Tabernero J
+  - de Torres C
+  - Dienstmann R
+  - Gonzalez-Perez A
+  - Lopez-Bigas N
+  category: Publication
+  doi: 10.1186/s13073-018-0531-8
+  id: PMID:29592813
+  journal: Genome Medicine
   preferred: true
+  title: Cancer Genome Interpreter annotates the biological and clinical relevance
+    of tumor alterations
+  year: '2018'
 synonyms:
 - MutationDS
 - CGI Mutations

--- a/resource/mutationds/mutationds.md
+++ b/resource/mutationds/mutationds.md
@@ -291,7 +291,7 @@ publications:
   category: Publication
   doi: 10.1186/s13073-018-0531-8
   id: PMID:29592813
-  journal: Genome Medicine
+  journal: Genome Med
   preferred: true
   title: Cancer Genome Interpreter annotates the biological and clinical relevance
     of tumor alterations

--- a/resource/nbo/nbo.md
+++ b/resource/nbo/nbo.md
@@ -38,8 +38,18 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/obo-behavior/behavior-ontology
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/24177753
+  - authors:
+      - Hoehndorf R
+      - Hancock JM
+      - Hardy NW
+      - Mallon AM
+      - Schofield PN
+      - Gkoutos GV
+    doi: 10.1007/s00335-013-9481-z
+    id: https://www.ncbi.nlm.nih.gov/pubmed/24177753
+    journal: Mamm Genome
     title: Analyzing gene expression data in mice with the Neuro Behavior Ontology
+    year: '2014'
 ---
 
 ## Description

--- a/resource/netpath/netpath.md
+++ b/resource/netpath/netpath.md
@@ -358,7 +358,49 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: biofactoid
 publications:
-- id: https://doi.org/10.1186/gb-2010-11-1-r3
+- authors:
+  - Kumaran Kandasamy
+  - S Sujatha Mohan
+  - Rajesh Raju
+  - Shivakumar Keerthikumar
+  - Ghantasala S Sameer Kumar
+  - Abhilash K Venugopal
+  - Deepthi Telikicherla
+  - J Daniel Navarro
+  - Suresh Mathivanan
+  - Christian Pecquet
+  - Sashi Kanth Gollapudi
+  - Sudhir Gopal Tattikota
+  - Shyam Mohan
+  - Hariprasad Padhukasahasram
+  - Yashwanth Subbannayya
+  - Renu Goel
+  - Harrys KC Jacob
+  - Jun Zhong
+  - Raja Sekhar
+  - Vishalakshi Nanjappa
+  - Lavanya Balakrishnan
+  - Roopashree Subbaiah
+  - YL Ramachandra
+  - B Abdul Rahiman
+  - TS Keshava Prasad
+  - Jian-Xin Lin
+  - Jon CD Houtman
+  - Stephen Desiderio
+  - Jean-Christophe Renauld
+  - Stefan N Constantinescu
+  - Osamu Ohara
+  - Toshio Hirano
+  - Masato Kubo
+  - Sujay Singh
+  - Purvesh Khatri
+  - Sorin Draghici
+  - Gary D Bader
+  - Chris Sander
+  - Warren J Leonard
+  - Akhilesh Pandey
+  doi: 10.1186/gb-2010-11-1-r3
+  id: https://doi.org/10.1186/gb-2010-11-1-r3
   journal: Genome Biology
   title: 'NetPath: a public resource of curated signal transduction pathways'
   year: '2010'

--- a/resource/npo/npo.md
+++ b/resource/npo/npo.md
@@ -259,8 +259,15 @@ products:
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
 publications:
-- doi: 10.1007/s12021-022-09566-7
+- authors:
+  - Gillespie TH
+  - Tripathy SJ
+  - Sy MF
+  - Martone ME
+  - Hill SL
+  doi: 10.1007/s12021-022-09566-7
   id: PMID:35267146
+  journal: Neuroinformatics
   title: 'The Neuron Phenotype Ontology: A FAIR Approach to Proposing and Classifying
     Neuronal Types'
   year: '2022'

--- a/resource/oba/oba.md
+++ b/resource/oba/oba.md
@@ -247,9 +247,39 @@ products:
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
 publications:
-- id: https://doi.org/10.1007/s00335-023-09992-1
+- authors:
+  - Ray Stefancsik
+  - James P. Balhoff
+  - Meghan A. Balk
+  - Robyn L. Ball
+  - Susan M. Bello
+  - Anita R. Caron
+  - Elissa J. Chesler
+  - Vinicius de Souza
+  - Sarah Gehrke
+  - Melissa Haendel
+  - Laura W. Harris
+  - Nomi L. Harris
+  - Arwa Ibrahim
+  - Sebastian Koehler
+  - Nicolas Matentzoglu
+  - Julie A. McMurry
+  - Christopher J. Mungall
+  - Monica C. Munoz-Torres
+  - Tim Putman
+  - Peter Robinson
+  - Damian Smedley
+  - Elliot Sollis
+  - Anne E. Thessen
+  - Nicole Vasilevsky
+  - David O. Walton
+  - David Osumi-Sutherland
+  doi: 10.1007/s00335-023-09992-1
+  id: https://doi.org/10.1007/s00335-023-09992-1
+  journal: Mammalian Genome
   title: The Ontology of Biological Attributes (OBA) - computational traits for the
     life sciences
+  year: '2023'
 repository: https://github.com/obophenotype/bio-attribute-ontology
 ---
 ## Description

--- a/resource/obi/obi.md
+++ b/resource/obi/obi.md
@@ -522,8 +522,56 @@ products:
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/27128319
+- authors:
+  - Bandrowski A
+  - Brinkman R
+  - Brochhausen M
+  - Brush MH
+  - Bug B
+  - Chibucos MC
+  - Clancy K
+  - Courtot M
+  - Derom D
+  - Dumontier M
+  - Fan L
+  - Fostel J
+  - Fragoso G
+  - Gibson F
+  - Gonzalez-Beltran A
+  - Haendel MA
+  - He Y
+  - Heiskanen M
+  - Hernandez-Boussard T
+  - Jensen M
+  - Lin Y
+  - Lister AL
+  - Lord P
+  - Malone J
+  - Manduchi E
+  - McGee M
+  - Morrison N
+  - Overton JA
+  - Parkinson H
+  - Peters B
+  - Rocca-Serra P
+  - Ruttenberg A
+  - Sansone SA
+  - Scheuermann RH
+  - Schober D
+  - Smith B
+  - Soldatova LN
+  - Stoeckert CJ Jr
+  - Taylor CF
+  - Torniai C
+  - Turner JA
+  - Vita R
+  - Whetzel PL
+  - Zheng J
+  doi: 10.1371/journal.pone.0154556
+  id: https://www.ncbi.nlm.nih.gov/pubmed/27128319
+  journal: PLoS One
   title: The Ontology for Biomedical Investigations
+  year: '2016'
 repository: https://github.com/obi-ontology/obi
 ---
 ## Description

--- a/resource/ohd/ohd.md
+++ b/resource/ohd/ohd.md
@@ -52,9 +52,23 @@ products:
   - 'File was not able to be retrieved when checked on 2026-06-17: HTTP 404 error
     when accessing file'
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/32819435
+- authors:
+  - Duncan WD
+  - Thyvalikakath T
+  - Haendel M
+  - Torniai C
+  - Hernandez P
+  - Song M
+  - Acharya A
+  - Caplan DJ
+  - Schleyer T
+  - Ruttenberg A
+  doi: 10.1186/s13326-020-00222-0
+  id: https://www.ncbi.nlm.nih.gov/pubmed/32819435
+  journal: J Biomed Semantics
   title: Structuring, reuse and analysis of electronic dental data using the Oral
     Health and Disease Ontology
+  year: '2020'
 repository: https://github.com/oral-health-and-disease-ontologies/ohd-ontology
 ---
 ## Description

--- a/resource/ohpi/ohpi.md
+++ b/resource/ohpi/ohpi.md
@@ -38,8 +38,28 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/OHPI/ohpi
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/30365026
+  - authors:
+      - Sayers S
+      - Li L
+      - Ong E
+      - Deng S
+      - Fu G
+      - Lin Y
+      - Yang B
+      - Zhang S
+      - Fa Z
+      - Zhao B
+      - Xiang Z
+      - Li Y
+      - Zhao XM
+      - Olszewski MA
+      - Chen L
+      - He Y
+    doi: 10.1093/nar/gky999
+    id: https://www.ncbi.nlm.nih.gov/pubmed/30365026
+    journal: Nucleic Acids Res
     title: 'Victors: a web-based knowledge base of virulence factors in human and animal pathogens'
+    year: '2019'
 ---
 
 ## Description

--- a/resource/ols/ols.md
+++ b/resource/ols/ols.md
@@ -84,8 +84,18 @@ products:
       - source: ols
         relation_type: prov:hadPrimarySource
 publications:
-  - id: PMID:39913645
+  - authors:
+      - James McLaughlin
+      - Josh Lagrimas
+      - Haider Iqbal
+      - Helen Parkinson
+      - Henriette Harmse
+    doi: 10.1093/bioinformatics/btaf279
+    id: PMID:40323307
+    journal: Bioinformatics
     preferred: true
+    title: 'OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge ecosystem'
+    year: '2025'
 repository: https://github.com/EBISPOT/ols4
 synonyms:
   - OLS

--- a/resource/omp/omp.md
+++ b/resource/omp/omp.md
@@ -49,8 +49,21 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/microbialphenotypes/OMP-ontology
 publications:
-- id: https://doi.org/10.1186/s12866-014-0294-3
+- authors:
+  - Marcus C Chibucos
+  - Adrienne E Zweifel
+  - Jonathan C Herrera
+  - William Meza
+  - Shabnam Eslamfam
+  - Peter Uetz
+  - Deborah A Siegele
+  - James C Hu
+  - Michelle G Giglio
+  doi: 10.1186/s12866-014-0294-3
+  id: https://doi.org/10.1186/s12866-014-0294-3
+  journal: BMC Microbiology
   title: An ontology for microbial phenotypes
+  year: '2014'
 ---
 ## Description
 

--- a/resource/omrse/omrse.md
+++ b/resource/omrse/omrse.md
@@ -40,8 +40,17 @@ repository: https://github.com/mcwdsi/OMRSE
 taxon:
   - NCBITaxon:9606
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/27406187
+  - authors:
+      - Hicks A
+      - Hanna J
+      - Welch D
+      - Brochhausen M
+      - Hogan WR
+    doi: 10.1186/s13326-016-0087-8
+    id: https://www.ncbi.nlm.nih.gov/pubmed/27406187
+    journal: J Biomed Semantics
     title: 'The ontology of medically related social entities: recent developments'
+    year: '2016'
 ---
 
 ## Description

--- a/resource/oncokb/oncokb.md
+++ b/resource/oncokb/oncokb.md
@@ -340,6 +340,7 @@ publications:
   - Nikolaus Schultz
   doi: 10.1200/PO.17.00011
   id: doi:10.1200/PO.17.00011
+  journal: JCO Precision Oncology
   title: 'OncoKB: A Precision Oncology Knowledge Base'
   year: '2017'
 - authors:
@@ -362,9 +363,10 @@ publications:
   - Debyani Chakravarty
   doi: 10.1158/2159-8290.CD-23-0467
   id: doi:10.1158/2159-8290.CD-23-0467
+  journal: Cancer Discovery
   title: Quantifying the Expanding Landscape of Clinical Actionability for Patients
     with Cancer
-  year: '2023'
+  year: '2024'
 repository: https://github.com/oncokb
 taxon:
 - NCBITaxon:9606

--- a/resource/ons/ons.md
+++ b/resource/ons/ons.md
@@ -39,9 +39,34 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/29736190
+- authors:
+  - Vitali F
+  - Lombardo R
+  - Rivero D
+  - Mattivi F
+  - Franceschi P
+  - Bordoni A
+  - Trimigno A
+  - Capozzi F
+  - Felici G
+  - Taglino F
+  - Miglietta F
+  - De Cock N
+  - Lachat C
+  - De Baets B
+  - De Tré G
+  - Pinart M
+  - Nimptsch K
+  - Pischon T
+  - Bouwman J
+  - Cavalieri D
+  - ENPADASI consortium
+  doi: 10.1186/s12263-018-0601-y
+  id: https://www.ncbi.nlm.nih.gov/pubmed/29736190
+  journal: Genes Nutr
   title: 'ONS: an ontology for a standardized description of interventions and observational
     studies in nutrition'
+  year: '2018'
 ---
 ## Description
 

--- a/resource/ontoavida/ontoavida.md
+++ b/resource/ontoavida/ontoavida.md
@@ -52,8 +52,15 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://gitlab.com/fortunalab/ontoavida
 publications:
-- id: https://doi.org/10.1038/s41597-023-02514-3
+- authors:
+  - Raúl Ortega
+  - Enrique Wulff
+  - Miguel A. Fortuna
+  doi: 10.1038/s41597-023-02514-3
+  id: https://doi.org/10.1038/s41597-023-02514-3
+  journal: Scientific Data
   title: Ontology for the Avida digital evolution platform
+  year: '2023'
 ---
 ## Description
 

--- a/resource/ontoneo/ontoneo.md
+++ b/resource/ontoneo/ontoneo.md
@@ -40,8 +40,16 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/ontoneo-project/Ontoneo
 publications:
-- id: https://doi.org/10.5281/zenodo.17429771
+- authors:
+  - Farinelli, Fernanda
+  - Almeida, Mauricio Barcellos
+  - Elkin, Peter
+  - Smith, Barry
+  doi: 10.5281/zenodo.17429771
+  id: https://doi.org/10.5281/zenodo.17429771
+  journal: CEUR-WS
   title: 'OntONeo: The Obstetric and Neonatal Ontology'
+  year: '2025'
 - id: doi:10.5281/zenodo.17508651
   doi: 10.5281/zenodo.17508651
   title: Ontologias Formais na Organização do Conhecimento no Domínio Obstétrico e
@@ -50,9 +58,14 @@ publications:
   - Farinelli, Fernanda
   journal: Zenodo
   year: '2025'
-- id: https://doi.org/10.5281/zenodo.17508651
-  title: Formal Ontologies in Knowledge Organization within the Obstetric and Neonatal
-    Domain
+- authors:
+  - Farinelli, Fernanda
+  doi: 10.5281/zenodo.17508651
+  id: https://doi.org/10.5281/zenodo.17508651
+  journal: Zenodo
+  title: Ontologias Formais na Organização do Conhecimento no Domínio Obstétrico e
+    Neonatal
+  year: '2025'
 ---
 ## Description
 

--- a/resource/pcl/pcl.md
+++ b/resource/pcl/pcl.md
@@ -4,6 +4,12 @@ category: Ontology
 collection:
 - obo-foundry
 contacts:
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://www.ebi.ac.uk/
+  id: ebi
+  label: EMBL-EBI
 - category: Individual
   contact_details:
   - contact_type: email
@@ -21,7 +27,8 @@ domains:
 - phenotype
 homepage_url: https://github.com/obophenotype/provisional_cell_ontology
 id: pcl
-last_modified_date: '2026-06-05T00:00:00Z'
+infores_id: pcl
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -49,166 +56,6 @@ products:
     source: pcl
   product_file_size: 39796128
   product_url: http://purl.obolibrary.org/obo/pcl.obo
-- category: OntologyProduct
-  description: Provisional Cell Ontology in JSON format
-  format: json
-  id: pcl.json
-  name: pcl.json
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl.json
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-12: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in OWL format
-  format: owl
-  id: pcl-base.owl
-  name: pcl-base.owl
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-base.owl
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-13: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in OBO format
-  format: obo
-  id: pcl-base.obo
-  name: pcl-base.obo
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-base.obo
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-12: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: HTTP 404 error
-    when accessing file'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in JSON format
-  format: json
-  id: pcl-base.json
-  name: pcl-base.json
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-base.json
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-13: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in OWL format
-  format: owl
-  id: pcl-full.owl
-  name: pcl-full.owl
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-full.owl
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-15: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in OBO format
-  format: obo
-  id: pcl-full.obo
-  name: pcl-full.obo
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-full.obo
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-12: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in JSON format
-  format: json
-  id: pcl-full.json
-  name: pcl-full.json
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-full.json
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-12: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in OWL format
-  format: owl
-  id: pcl-simple.owl
-  name: pcl-simple.owl
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-simple.owl
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-12: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-17: HTTP 404 error
-    when accessing file'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in OBO format
-  format: obo
-  id: pcl-simple.obo
-  name: pcl-simple.obo
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-simple.obo
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-15: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
-    to URL'
-- category: OntologyProduct
-  description: Provisional Cell Ontology in JSON format
-  format: json
-  id: pcl-simple.json
-  name: pcl-simple.json
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: pcl
-  product_url: http://purl.obolibrary.org/obo/pcl-simple.json
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-06-16: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-13: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-06-17: HTTP 404 error
-    when accessing file'
 publications:
 - authors:
   - Shawn Zheng Kai Tan

--- a/resource/pcl/pcl.md
+++ b/resource/pcl/pcl.md
@@ -27,7 +27,6 @@ domains:
 - phenotype
 homepage_url: https://github.com/obophenotype/provisional_cell_ontology
 id: pcl
-infores_id: pcl
 last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:

--- a/resource/pdbe/pdbe.md
+++ b/resource/pdbe/pdbe.md
@@ -902,9 +902,84 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: https://doi.org/10.1093/nar/gkab988
+- authors:
+  - Mihaly Varadi
+  - Stephen Anyango
+  - David Armstrong
+  - John Berrisford
+  - Preeti Choudhary
+  - Mandar Deshpande
+  - Nurul Nadzirin
+  - Sreenath S Nair
+  - Lukas Pravda
+  - Ahsan Tanweer
+  - Bissan Al-Lazikani
+  - Claudia Andreini
+  - Geoffrey J Barton
+  - David Bednar
+  - Karel Berka
+  - Tom Blundell
+  - Kelly P Brock
+  - Jose Maria Carazo
+  - Jiri Damborsky
+  - Alessia David
+  - Sucharita Dey
+  - Roland Dunbrack
+  - Juan Fernandez Recio
+  - Franca Fraternali
+  - Toby Gibson
+  - Manuela Helmer-Citterich
+  - David Hoksza
+  - Thomas Hopf
+  - David Jakubec
+  - Natarajan Kannan
+  - Radoslav Krivak
+  - Manjeet Kumar
+  - Emmanuel D Levy
+  - Nir London
+  - Jose Ramon Macias
+  - Madhusudhan M Srivatsan
+  - Debora S Marks
+  - Lennart Martens
+  - Stuart A McGowan
+  - Jake E McGreig
+  - Vivek Modi
+  - R Gonzalo Parra
+  - Gerardo Pepe
+  - Damiano Piovesan
+  - Jaime Prilusky
+  - Valeria Putignano
+  - Leandro G Radusky
+  - Pathmanaban Ramasamy
+  - Atilio O Rausch
+  - Nathalie Reuter
+  - Luis A Rodriguez
+  - Nathan J Rollins
+  - Antonio Rosato
+  - Paweł Rubach
+  - Luis Serrano
+  - Gulzar Singh
+  - Petr Skoda
+  - Carlos Oscar S Sorzano
+  - Jan Stourac
+  - Joanna I Sulkowska
+  - Radka Svobodova
+  - Natalia Tichshenko
+  - Silvio C E Tosatto
+  - Wim Vranken
+  - Mark N Wass
+  - Dandan Xue
+  - Daniel Zaidman
+  - Janet Thornton
+  - Michael Sternberg
+  - Christine Orengo
+  - Sameer Velankar
+  doi: 10.1093/nar/gkab988
+  id: https://doi.org/10.1093/nar/gkab988
+  journal: Nucleic Acids Research
   preferred: true
   title: 'PDBe-KB: collaboratively defining the biological context of structural data'
+  year: '2022'
 repository: https://github.com/PDBe-KB
 ---
 # PDBe Knowledge Base

--- a/resource/pdro/pdro.md
+++ b/resource/pdro/pdro.md
@@ -39,8 +39,16 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/OpenLHS/PDRO
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/34831777
+- authors:
+  - Ethier JF
+  - Goyer F
+  - Fabry P
+  - Barton A
+  doi: 10.3390/ijerph182212025
+  id: https://www.ncbi.nlm.nih.gov/pubmed/34831777
+  journal: Int J Environ Res Public Health
   title: 'The Prescription of Drug Ontology 2.0 (PDRO): More Than the Sum of Its Parts'
+  year: '2021'
 ---
 ## Description
 

--- a/resource/peco/peco.md
+++ b/resource/peco/peco.md
@@ -73,9 +73,32 @@ products:
     source: interpro
   product_url: https://datacommons.cyverse.org/browse/iplant/home/shared/genophenoenvo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+- authors:
+  - Cooper L
+  - Meier A
+  - Laporte MA
+  - Elser JL
+  - Mungall C
+  - Sinn BT
+  - Cavaliere D
+  - Carbon S
+  - Dunn NA
+  - Smith B
+  - Qu B
+  - Preece J
+  - Zhang E
+  - Todorovic S
+  - Gkoutos G
+  - Doonan JH
+  - Stevenson DW
+  - Arnaud E
+  - Jaiswal P
+  doi: 10.1093/nar/gkx1152
+  id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+  journal: Nucleic Acids Res
   title: 'The Planteome database: an integrated resource for reference ontologies,
     plant genomics and phenomics.'
+  year: '2018'
 repository: https://github.com/Planteome/plant-experimental-conditions-ontology
 ---
 ## Description

--- a/resource/pfam/pfam.md
+++ b/resource/pfam/pfam.md
@@ -1464,11 +1464,12 @@ publications:
   - E. Sonnhammer
   - V. Wood
   - A. Bateman
+  doi: 10.1093/nar/gkae997
   id: https://doi.org/10.1093/nar/gkae997
   journal: Nucleic Acids Research
   preferred: true
   title: 'The Pfam protein families database: embracing AI/ML'
-  year: '2024'
+  year: '2025'
 - authors:
   - J. Mistry
   - S. Chuguransky
@@ -1482,10 +1483,11 @@ publications:
   - L.J. Richardson
   - R.D. Finn
   - A. Bateman
+  doi: 10.1093/nar/gkaa913
   id: https://doi.org/10.1093/nar/gkaa913
   journal: Nucleic Acids Research
   title: 'Pfam: The protein families database in 2021'
-  year: '2020'
+  year: '2021'
 - authors:
   - S. El-Gebali
   - J. Mistry
@@ -1503,6 +1505,7 @@ publications:
   - D. Piovesan
   - S.C.E. Tosatto
   - R.D. Finn
+  doi: 10.1093/nar/gky995
   id: https://doi.org/10.1093/nar/gky995
   journal: Nucleic Acids Research
   title: The Pfam protein families database in 2019

--- a/resource/phipo/phipo.md
+++ b/resource/phipo/phipo.md
@@ -50,8 +50,26 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/PHI-base/phipo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/34788826
+- authors:
+  - Urban M
+  - Cuzick A
+  - Seager J
+  - Wood V
+  - Rutherford K
+  - Venkatesh SY
+  - Sahu J
+  - Iyer SV
+  - Khamari L
+  - De Silva N
+  - Martinez MC
+  - Pedro H
+  - Yates AD
+  - Hammond-Kosack KE
+  doi: 10.1093/nar/gkab1037
+  id: https://www.ncbi.nlm.nih.gov/pubmed/34788826
+  journal: Nucleic Acids Res
   title: 'PHI-base in 2022: a multi-species phenotype database for Pathogen-Host Interactions'
+  year: '2022'
 ---
 ## Description
 

--- a/resource/phosphat/phosphat.md
+++ b/resource/phosphat/phosphat.md
@@ -124,7 +124,7 @@ publications:
   preferred: true
   title: PhosPhAt goes kinases - searchable protein kinase target information in the
     plant phosphorylation site database PhosPhAt
-  year: '2013'
+  year: '2012'
 - authors:
   - Petra Durek
   - Rebecca Schmidt
@@ -152,7 +152,7 @@ publications:
   journal: Nucleic Acids Research
   title: PhosPhAt, a database of phosphorylation sites in Arabidopsis thaliana and
     a plant-specific phosphorylation site predictor
-  year: '2008'
+  year: '2007'
 synonyms:
 - Arabidopsis Protein Phosphorylation Site Database
 taxon:

--- a/resource/phosphogrid/phosphogrid.md
+++ b/resource/phosphogrid/phosphogrid.md
@@ -96,13 +96,34 @@ products:
       - relation_type: prov:wasDerivedFrom
         source: uniprot
 publications:
-  - doi: 10.1093/database/bat026
+  - authors:
+      - I. Sadowski
+      - B.-J. Breitkreutz
+      - C. Stark
+      - T.-C. Su
+      - M. Dahabieh
+      - S. Raithatha
+      - W. Bernhard
+      - R. Oughtred
+      - K. Dolinski
+      - K. Barreto
+      - M. Tyers
+    doi: 10.1093/database/bat026
     id: doi:10.1093/database/bat026
     journal: Database
     preferred: true
     title: 'The PhosphoGRID Saccharomyces cerevisiae protein phosphorylation site database: version 2.0 update'
     year: '2013'
-  - doi: 10.1093/database/bap026
+  - authors:
+      - C. Stark
+      - T.-C. Su
+      - A. Breitkreutz
+      - P. Lourenco
+      - M. Dahabieh
+      - B.-J. Breitkreutz
+      - M. Tyers
+      - I. Sadowski
+    doi: 10.1093/database/bap026
     id: doi:10.1093/database/bap026
     journal: Database
     title: PhosphoGRID, a database of experimentally verified in vivo protein phosphorylation sites from the budding yeast Saccharomyces cerevisiae

--- a/resource/phosphositeplus/phosphositeplus.md
+++ b/resource/phosphositeplus/phosphositeplus.md
@@ -1272,11 +1272,18 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: biofactoid
 publications:
-- doi: 10.1093/nar/gku1267
+- authors:
+  - Peter V. Hornbeck
+  - Bin Zhang
+  - Beth Murray
+  - Jon M. Kornhauser
+  - Vaughan Latham
+  - Elzbieta Skrzypek
+  doi: 10.1093/nar/gku1267
   id: doi:10.1093/nar/gku1267
   journal: Nucleic Acids Research
   title: 'PhosphoSitePlus, 2014: mutations, PTMs and recalibrations.'
-  year: '2014'
+  year: '2015'
 ---
 # PhosphoSitePlus
 

--- a/resource/pid/pid.md
+++ b/resource/pid/pid.md
@@ -1318,8 +1318,19 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: https://doi.org/10.1093/nar/gkn653
+- authors:
+  - Carl F. Schaefer
+  - Kira Anthony
+  - Shiva Krupa
+  - Jeffrey Buchoff
+  - Matthew Day
+  - Timo Hannay
+  - Kenneth H. Buetow
+  doi: 10.1093/nar/gkn653
+  id: https://doi.org/10.1093/nar/gkn653
+  journal: Nucleic Acids Research
   title: 'PID: the Pathway Interaction Database'
+  year: '2009'
 repository: https://github.com/NCIP/pathway-interaction-database
 synonyms:
 - PID

--- a/resource/pirbase/pirbase.md
+++ b/resource/pirbase/pirbase.md
@@ -635,8 +635,9 @@ publications:
       - Zeng
       - He
       - Chen
+    doi: 10.1093/nar/gkab1012
     id: https://pubmed.ncbi.nlm.nih.gov/34871445/
-    journal: Nucleic Acids Research
+    journal: Nucleic Acids Res
     preferred: true
     title: 'piRBase: integrating piRNA annotation in all aspects'
     year: '2022'
@@ -649,8 +650,9 @@ publications:
       - Kan
       - Chen
       - He
+    doi: 10.1093/nar/gky1043
     id: https://pubmed.ncbi.nlm.nih.gov/30371818/
-    journal: Nucleic Acids Research
+    journal: Nucleic Acids Res
     title: 'piRBase: a comprehensive database of piRNA sequences'
     year: '2019'
   - authors:
@@ -666,6 +668,7 @@ publications:
       - Chen
       - He
       - Huang
+    doi: 10.1093/database/bau110
     id: https://pubmed.ncbi.nlm.nih.gov/25425034/
     journal: Database (Oxford)
     title: 'piRBase: a web resource assisting piRNA functional study'

--- a/resource/plana/plana.md
+++ b/resource/plana/plana.md
@@ -48,8 +48,21 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/obophenotype/planaria-ontology
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/34318308
+  - authors:
+      - Nowotarski SH
+      - Davies EL
+      - Robb SMC
+      - Ross EJ
+      - Matentzoglu N
+      - Doddihal V
+      - Mir M
+      - McClain M
+      - Sánchez Alvarado A
+    doi: 10.1242/dev.196097
+    id: https://www.ncbi.nlm.nih.gov/pubmed/34318308
+    journal: Development
     title: 'Planarian Anatomy Ontology: a resource to connect data within and across experimental platforms'
+    year: '2021'
 ---
 
 ## Description

--- a/resource/po/po.md
+++ b/resource/po/po.md
@@ -260,11 +260,60 @@ products:
     source: interpro
   product_url: https://datacommons.cyverse.org/browse/iplant/home/shared/genophenoenvo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/23220694
+- authors:
+  - Cooper L
+  - Walls RL
+  - Elser J
+  - Gandolfo MA
+  - Stevenson DW
+  - Smith B
+  - Preece J
+  - Athreya B
+  - Mungall CJ
+  - Rensing S
+  - Hiss M
+  - Lang D
+  - Reski R
+  - Berardini TZ
+  - Li D
+  - Huala E
+  - Schaeffer M
+  - Menda N
+  - Arnaud E
+  - Shrestha R
+  - Yamazaki Y
+  - Jaiswal P
+  doi: 10.1093/pcp/pcs163
+  id: https://www.ncbi.nlm.nih.gov/pubmed/23220694
+  journal: Plant Cell Physiol
   title: The plant ontology as a tool for comparative plant anatomy and genomic analyses.
-- id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+  year: '2013'
+- authors:
+  - Cooper L
+  - Meier A
+  - Laporte MA
+  - Elser JL
+  - Mungall C
+  - Sinn BT
+  - Cavaliere D
+  - Carbon S
+  - Dunn NA
+  - Smith B
+  - Qu B
+  - Preece J
+  - Zhang E
+  - Todorovic S
+  - Gkoutos G
+  - Doonan JH
+  - Stevenson DW
+  - Arnaud E
+  - Jaiswal P
+  doi: 10.1093/nar/gkx1152
+  id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+  journal: Nucleic Acids Res
   title: 'The Planteome database: an integrated resource for reference ontologies,
     plant genomics and phenomics.'
+  year: '2018'
 repository: https://github.com/Planteome/plant-ontology
 taxon:
 - NCBITaxon:33090

--- a/resource/poro/poro.md
+++ b/resource/poro/poro.md
@@ -50,8 +50,19 @@ repository: https://github.com/obophenotype/porifera-ontology
 taxon:
   - NCBITaxon:6040
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/25276334
+  - authors:
+      - Thacker RW
+      - Díaz MC
+      - Kerner A
+      - Vignes-Lebbe R
+      - Segerdell E
+      - Haendel MA
+      - Mungall CJ
+    doi: 10.1186/2041-1480-5-39
+    id: https://www.ncbi.nlm.nih.gov/pubmed/25276334
+    journal: J Biomed Semantics
     title: 'The Porifera Ontology (PORO): enhancing sponge systematics with an anatomy ontology'
+    year: '2014'
 ---
 
 ## Description

--- a/resource/pr/pr.md
+++ b/resource/pr/pr.md
@@ -589,9 +589,35 @@ products:
   - 1.0.2
   - '1.0'
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/27899649
+- authors:
+  - Natale DA
+  - Arighi CN
+  - Blake JA
+  - Bona J
+  - Chen C
+  - Chen SC
+  - Christie KR
+  - Cowart J
+  - "D'Eustachio P"
+  - Diehl AD
+  - Drabkin HJ
+  - Duncan WD
+  - Huang H
+  - Ren J
+  - Ross K
+  - Ruttenberg A
+  - Shamovsky V
+  - Smith B
+  - Wang Q
+  - Zhang J
+  - El-Sayed A
+  - Wu CH
+  doi: 10.1093/nar/gkw1075
+  id: https://www.ncbi.nlm.nih.gov/pubmed/27899649
+  journal: Nucleic Acids Res
   title: 'Protein Ontology (PRO): enhancing and scaling up the representation of protein
     entities'
+  year: '2017'
 repository: https://github.com/PROconsortium/PRoteinOntology
 ---
 ## Description

--- a/resource/progenomes/progenomes.md
+++ b/resource/progenomes/progenomes.md
@@ -17,7 +17,6 @@ domains:
 - biological systems
 homepage_url: https://progenomes.embl.de/
 id: progenomes
-infores_id: progenomes
 last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:

--- a/resource/progenomes/progenomes.md
+++ b/resource/progenomes/progenomes.md
@@ -1,6 +1,13 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://progenomes.embl.de/
+  id: european-molecular-biology-laboratory-embl
+  label: EMBL
 creation_date: '2026-01-30T00:00:00Z'
 description: A large-scale microbial genome resource with consistent annotation, species
   clustering, and downloadable representative genome and protein datasets.
@@ -10,8 +17,12 @@ domains:
 - biological systems
 homepage_url: https://progenomes.embl.de/
 id: progenomes
-last_modified_date: '2026-02-15T00:00:00Z'
+infores_id: progenomes
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://progenomes.embl.de/other.cgi
+  label: Free for academic and non-commercial use
 name: proGenomes
 products:
 - category: GraphicalInterface
@@ -761,7 +772,7 @@ products:
 - category: Product
   description: Taxonomy crosswalk from GTDB release r220 to NCBI taxonomy (2025-07-28),
     with lineage context, genome counts, and majority-vote agreement fractions.
-  format: mixed
+  format: tsv
   id: metatraits.gtdb2ncbi
   name: GTDB to NCBI Taxonomy Mapping
   original_source:
@@ -774,11 +785,11 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: progenomes
   product_file_size: 2937650
-  product_url: https://metatraits.embl.de/static/downloads/GTDB2NCBI.tsv.gz
+  product_url: https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
 - category: Product
   description: Taxonomy crosswalk from NCBI taxonomy (2025-07-28) to GTDB release
     r220, with lineage context, genome counts, and majority-vote agreement fractions.
-  format: mixed
+  format: tsv
   id: metatraits.ncbi2gtdb
   name: NCBI to GTDB Taxonomy Mapping
   original_source:
@@ -791,11 +802,11 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: progenomes
   product_file_size: 2895086
-  product_url: https://metatraits.embl.de/static/downloads/NCBI2GTDB.tsv.gz
+  product_url: https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
 - category: Product
   description: Family-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.family-summary
   name: metaTraits NCBI Family Summary
   original_source:
@@ -811,12 +822,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 1540253
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_family_summary.jsonl.gz
+  product_file_size: 913932
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_family_summary_no_predictions.tsv.gz
 - category: Product
   description: Genus-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.genus-summary
   name: metaTraits NCBI Genus Summary
   original_source:
@@ -832,12 +843,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 5417182
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_genus_summary.jsonl.gz
+  product_file_size: 2431808
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_genus_summary_no_predictions.tsv.gz
 - category: Product
   description: Species-level harmonized trait annotations aggregated for NCBI taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.ncbi.species-summary
   name: metaTraits NCBI Species Summary
   original_source:
@@ -853,12 +864,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 34062481
-  product_url: https://metatraits.embl.de/static/downloads/ncbi_species_summary.jsonl.gz
+  product_file_size: 6523019
+  product_url: https://www.bork.embl.de/~robbani/metatraits/ncbi_species_summary_no_predictions.tsv.gz
 - category: Product
   description: Family-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.family-summary
   name: metaTraits GTDB Family Summary
   original_source:
@@ -874,12 +885,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 4575050
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_family_summary.jsonl.gz
+  product_file_size: 1513013
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_family_summary_no_predictions.tsv.gz
 - category: Product
   description: Genus-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.genus-summary
   name: metaTraits GTDB Genus Summary
   original_source:
@@ -895,12 +906,12 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 16364735
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_genus_summary.jsonl.gz
+  product_file_size: 4965442
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_genus_summary_no_predictions.tsv.gz
 - category: Product
   description: Species-level harmonized trait annotations aggregated for GTDB taxonomy
-    in compressed JSONL format.
-  format: mixed
+    in compressed TSV format.
+  format: tsv
   id: metatraits.gtdb.species-summary
   name: metaTraits GTDB Species Summary
   original_source:
@@ -916,8 +927,31 @@ products:
     source: goldterms
   - relation_type: prov:wasDerivedFrom
     source: progenomes
-  product_file_size: 48114108
-  product_url: https://metatraits.embl.de/static/downloads/gtdb_species_summary.jsonl.gz
+  product_file_size: 12570522
+  product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_species_summary_no_predictions.tsv.gz
+publications:
+- authors:
+  - Fullam A
+  - Letunic I
+  - Maistrenko OM
+  - Areias Castro A
+  - Coelho LP
+  - Grekova A
+  - Schudoma C
+  - Khedkar S
+  - Robbani M
+  - Kuhn M
+  - Schmidt TSB
+  - Bork P
+  - Mende DR
+  doi: doi:10.1093/nar/gkaf1208
+  id: https://doi.org/10.1093/nar/gkaf1208
+  journal: Nucleic Acids Research
+  preferred: true
+  title: 'proGenomes4: providing 2 million accurately and consistently annotated high-quality
+    prokaryotic genomes'
+  year: '2026'
+repository: https://github.com/BigDataBiology/progenomes-cli
 synonyms:
 - proGenomes
 - ProGenomes Database

--- a/resource/pso/pso.md
+++ b/resource/pso/pso.md
@@ -48,8 +48,31 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/Planteome/plant-stress-ontology
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+  - authors:
+      - Cooper L
+      - Meier A
+      - Laporte MA
+      - Elser JL
+      - Mungall C
+      - Sinn BT
+      - Cavaliere D
+      - Carbon S
+      - Dunn NA
+      - Smith B
+      - Qu B
+      - Preece J
+      - Zhang E
+      - Todorovic S
+      - Gkoutos G
+      - Doonan JH
+      - Stevenson DW
+      - Arnaud E
+      - Jaiswal P
+    doi: 10.1093/nar/gkx1152
+    id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+    journal: Nucleic Acids Res
     title: 'The Planteome database: an integrated resource for reference ontologies, plant genomics and phenomics.'
+    year: '2018'
 ---
 
 ## Description

--- a/resource/pw/pw.md
+++ b/resource/pw/pw.md
@@ -247,10 +247,44 @@ products:
   product_file_size: 18370248815
   product_url: https://rna-kg.biodata.di.unimi.it/edges.csv
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/21478484
+- authors:
+  - Petri V
+  - Shimoyama M
+  - Hayman GT
+  - Smith JR
+  - Tutaj M
+  - de Pons J
+  - Dwinell MR
+  - Munzenmaier DH
+  - Twigger SN
+  - Jacob HJ
+  - RGD Team
+  doi: 10.1093/database/bar010
+  id: https://www.ncbi.nlm.nih.gov/pubmed/21478484
+  journal: Database (Oxford)
   title: The Rat Genome Database pathway portal.
-- id: https://www.ncbi.nlm.nih.gov/pubmed/24499703
+  year: '2011'
+- authors:
+  - Petri V
+  - Jayaraman P
+  - Tutaj M
+  - Hayman GT
+  - Smith JR
+  - De Pons J
+  - Laulederkind SJ
+  - Lowry TF
+  - Nigam R
+  - Wang SJ
+  - Shimoyama M
+  - Dwinell MR
+  - Munzenmaier DH
+  - Worthey EA
+  - Jacob HJ
+  doi: 10.1186/2041-1480-5-7
+  id: https://www.ncbi.nlm.nih.gov/pubmed/24499703
+  journal: J Biomed Semantics
   title: The pathway ontology - updates and applications.
+  year: '2014'
 repository: https://github.com/rat-genome-database/PW-Pathway-Ontology
 ---
 ## Description

--- a/resource/reactome/reactome.md
+++ b/resource/reactome/reactome.md
@@ -4,6 +4,12 @@ category: DataSource
 collection:
 - ber
 contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: reactome-help@reactome.org
+  id: ebi
+  label: Reactome
 - category: Individual
   contact_details:
   - contact_type: email
@@ -26,7 +32,7 @@ domains:
 homepage_url: https://reactome.org
 id: reactome
 infores_id: reactome
-last_modified_date: '2026-05-30T00:00:00Z'
+last_modified_date: '2026-06-17T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -334,6 +340,7 @@ products:
     instances as neo4j graph databases, running in a Docker container. Requires UMLS
     API key to access.
   dump_format: neo4j
+  format: neo4j
   id: ubkg.neo4j
   name: UBKG Neo4j Docker Distribution
   original_source:
@@ -673,6 +680,7 @@ products:
 - category: ProgrammingInterface
   description: Neo4j distribution of the RTX-KG2 as a graph database
   dump_format: neo4j
+  format: neo4j
   id: rtx-kg2.neo4j
   is_neo4j: true
   is_public: false
@@ -833,6 +841,7 @@ products:
 - category: Product
   description: Network embeddings of the Bioteque graph that represent biological
     entities and their associations
+  format: mixed
   id: bioteque.embeddings
   name: Bioteque Embeddings
   original_source:
@@ -958,6 +967,7 @@ products:
   description: INDRA CoGEx is a graph database integrating causal relations, ontological
     relations, properties, and data, assembled at scale automatically from the scientific
     literature and structured sources. This is the code to build the graph.
+  format: python
   id: indra.cogex.code
   name: INDRA CoGEx Build Code
   original_source:
@@ -1511,6 +1521,7 @@ products:
   description: Neo4j Dump of KG-Monarch
   dump_format: neo4j
   edge_count: 15211571
+  format: neo4j
   id: kg-monarch.graph.neo4j
   name: Neo4j Dump of KG-Monarch
   node_categories:
@@ -2092,8 +2103,7 @@ products:
   - biolink:temporally_related_to
   - biolink:treats
   - biolink:treats_or_applied_or_studied_to_treat
-  product_file_size: 15279494795
-  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg_edges.jsonl
+  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.jsonl.tar.gz
 - category: GraphProduct
   description: KGX JSON-Lines Distribution of KG-Monarch (Nodes)
   edge_count: 15211571
@@ -2221,8 +2231,7 @@ products:
   - biolink:temporally_related_to
   - biolink:treats
   - biolink:treats_or_applied_or_studied_to_treat
-  product_file_size: 1149505896
-  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg_nodes.jsonl
+  product_url: https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.jsonl.tar.gz
 - category: GraphProduct
   description: Neo4j Dump of KG-Monarch Edges
   edge_count: 15211571
@@ -2627,6 +2636,7 @@ products:
     and integrating information from diverse biomedical resources including DRKG,
     iDISK, and multiple databases (BRENDA, CTD, DrugBank, KEGG, PharmGKB, Reactome,
     SIDER, and others).
+  format: csv
   id: ibkh.graph
   name: iBKH Knowledge Graph
   original_source:
@@ -2666,10 +2676,12 @@ products:
     source: tissues
   - relation_type: prov:hadPrimarySource
     source: uberon
+  product_url: https://github.com/wcm-wanglab/iBKH
 - category: DatabaseProduct
   description: Multi-sourced relational database integrating metabolomic pathway information,
     biochemical reactions, ontologies, and chemical descriptors for genes, proteins,
     and metabolites with query and enrichment analysis capabilities.
+  format: sqlite
   id: rampdb.database
   is_public: true
   name: RaMP-DB Integrated Database
@@ -2688,6 +2700,7 @@ products:
 - category: Product
   description: Causal Activity Model graphs automatically generated from Reactome
     pathways using the Pathways2GO tool, translating pathway reactions to causal relationships
+  format: tsv
   id: cam-kp.reactome-cams
   name: Reactome Pathway CAMs
   original_source:
@@ -2695,6 +2708,7 @@ products:
     source: cam-kp
   - relation_type: prov:hadPrimarySource
     source: reactome
+  product_url: https://stars.renci.org/var/cam-kp/cam-kg.tsv.gz
 - category: GraphProduct
   description: Core UniBioMap graph edges file.
   format: csv
@@ -3852,6 +3866,7 @@ products:
 - category: Product
   description: Standardized gene set collections from Common Fund programs in GMT
     format
+  format: mixed
   id: cfde-gse.genesets
   name: CFDE Gene Set Collections
   original_source:
@@ -3989,6 +4004,7 @@ products:
   product_url: https://github.com/hetio/hetionet/blob/master/hetnet/json/hetionet-v1.0.json.bz2
 - category: GraphProduct
   description: Hetionet v1.0 as a Neo4j database
+  format: neo4j
   id: hetionet.data.neo4j
   name: Hetionet v1.0 Neo4j
   original_source:
@@ -4091,6 +4107,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
+  format: python
   id: hetnetpy
   name: hetnetpy
   original_source:
@@ -4157,6 +4174,7 @@ products:
   product_url: https://het.io/search
 - category: GraphicalInterface
   description: Graphical interface for MedKG
+  format: http
   id: medkb.site
   name: MedKG Site
   original_source:
@@ -5431,6 +5449,7 @@ products:
   compression: gzip
   description: PC v14 Gene Matrix Transposed gene sets for pathway enrichment analysis,
     derived from the integrated Pathway Commons pathway archive.
+  format: tsv
   id: pathwaycommons.gmt
   name: GMT Gene Set Format
   original_source:
@@ -5702,7 +5721,7 @@ products:
     source: uberon
   - relation_type: prov:hadPrimarySource
     source: uniprot
-  product_url: https://sugi.bio/biobtree/api/
+  product_url: https://sugi.bio/biobtree/
 - category: GraphicalInterface
   description: Web-based interface for searching and browsing comprehensive gene-centric
     information integrating data from over 200 sources

--- a/resource/reconx/reconx.md
+++ b/resource/reconx/reconx.md
@@ -365,7 +365,17 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: biofactoid
 publications:
-- id: https://doi.org/10.1073/pnas.0610772104
+- authors:
+  - Natalie C. Duarte
+  - Scott A. Becker
+  - Neema Jamshidi
+  - Ines Thiele
+  - Monica L. Mo
+  - Thuy D. Vo
+  - Rohith Srivas
+  - Bernhard Ø. Palsson
+  doi: 10.1073/pnas.0610772104
+  id: https://doi.org/10.1073/pnas.0610772104
   journal: Proceedings of the National Academy of Sciences
   title: Global reconstruction of the human metabolic network based on genomic and
     bibliomic data

--- a/resource/refseq/refseq.md
+++ b/resource/refseq/refseq.md
@@ -1997,14 +1997,78 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- doi: 10.1093/nar/gkv1189
+- authors:
+  - "Nuala A. O'Leary"
+  - Mathew W. Wright
+  - J. Rodney Brister
+  - Stacy Ciufo
+  - Diana Haddad
+  - Rich McVeigh
+  - Bhanu Rajput
+  - Barbara Robbertse
+  - Brian Smith-White
+  - Danso Ako-Adjei
+  - Alexander Astashyn
+  - Azat Badretdin
+  - Yiming Bao
+  - Olga Blinkova
+  - Vyacheslav Brover
+  - Vyacheslav Chetvernin
+  - Jinna Choi
+  - Eric Cox
+  - Olga Ermolaeva
+  - Catherine M. Farrell
+  - Tamara Goldfarb
+  - Tripti Gupta
+  - Daniel Haft
+  - Eneida Hatcher
+  - Wratko Hlavina
+  - Vinita S. Joardar
+  - Vamsi K. Kodali
+  - Wenjun Li
+  - Donna Maglott
+  - Patrick Masterson
+  - Kelly M. McGarvey
+  - Michael R. Murphy
+  - "Kathleen O'Neill"
+  - Shashikant Pujar
+  - Sanjida H. Rangwala
+  - Daniel Rausch
+  - Lillian D. Riddick
+  - Conrad Schoch
+  - Andrei Shkeda
+  - Susan S. Storz
+  - Hanzhen Sun
+  - Francoise Thibaud-Nissen
+  - Igor Tolstoy
+  - Raymond E. Tully
+  - Anjana R. Vatsan
+  - Craig Wallin
+  - David Webb
+  - Wendy Wu
+  - Melissa J. Landrum
+  - Avi Kimchi
+  - Tatiana Tatusova
+  - Michael DiCuccio
+  - Paul Kitts
+  - Terence D. Murphy
+  - Kim D. Pruitt
+  doi: 10.1093/nar/gkv1189
   id: doi:10.1093/nar/gkv1189
+  journal: Nucleic Acids Research
   title: 'Reference sequence (RefSeq) database at NCBI: current status, taxonomic
     expansion, and functional annotation'
-- doi: 10.1093/nar/gkl842
+  year: '2016'
+- authors:
+  - K. D. Pruitt
+  - T. Tatusova
+  - D. R. Maglott
+  doi: 10.1093/nar/gkl842
   id: doi:10.1093/nar/gkl842
+  journal: Nucleic Acids Research
   title: 'NCBI reference sequences (RefSeq): a curated non-redundant sequence database
     of genomes, transcripts and proteins'
+  year: '2007'
 repository: https://ftp.ncbi.nlm.nih.gov/refseq/
 ---
 # RefSeq: NCBI Reference Sequence Database

--- a/resource/repodb/repodb.md
+++ b/resource/repodb/repodb.md
@@ -149,12 +149,23 @@ products:
     source: tissues
   product_url: https://bioteque.irbbarcelona.org/downloads/embeddings
 publications:
-- doi: 10.1038/sdata.2017.29
+- authors:
+  - Adam S. Brown
+  - Chirag J. Patel
+  doi: 10.1038/sdata.2017.29
   id: doi:10.1038/sdata.2017.29
+  journal: Scientific Data
   preferred: true
   title: A standard database for drug repositioning
-- id: pmid:28291243
+  year: '2017'
+- authors:
+  - Brown AS
+  - Patel CJ
+  doi: 10.1038/sdata.2017.29
+  id: pmid:28291243
+  journal: Sci Data
   title: A standard database for drug repositioning
+  year: '2017'
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/rhea/rhea.md
+++ b/resource/rhea/rhea.md
@@ -514,9 +514,10 @@ publications:
   - Bridge A
   doi: doi:10.1093/nar/gkab1016
   id: doi:10.1093/nar/gkab1016
+  journal: Nucleic Acids Research
   preferred: true
   title: Rhea, the reaction knowledgebase in 2022
-  year: '2021'
+  year: '2022'
 ---
 Rhea is an expert-curated knowledgebase of chemical and transport reactions of biological interest. Enzyme-catalyzed and spontaneously occurring reactions are curated from peer-reviewed literature and represented in a computationally tractable manner by using the ChEBI (Chemical Entities of Biological Interest) ontology to describe reaction participants.
 

--- a/resource/ribocentre/ribocentre.md
+++ b/resource/ribocentre/ribocentre.md
@@ -475,7 +475,7 @@ publications:
       - Huang L
     doi: 10.1093/nar/gkac840
     id: https://www.ncbi.nlm.nih.gov/pubmed/36177882
-    journal: Nucleic Acids Research
+    journal: Nucleic Acids Res
     preferred: true
     title: 'Ribocentre: a database of ribozymes'
     year: '2023'

--- a/resource/ribocentre/ribocentre.md
+++ b/resource/ribocentre/ribocentre.md
@@ -459,9 +459,26 @@ products:
         relation_type: prov:hadPrimarySource
     product_url: https://rnacentral.org/help/public-database
 publications:
-  - id: PMID:36399504
+  - authors:
+      - Deng J
+      - Shi Y
+      - Peng X
+      - He Y
+      - Chen X
+      - Li M
+      - Lin X
+      - Liao W
+      - Huang Y
+      - Jiang T
+      - Lilley DMJ
+      - Miao Z
+      - Huang L
+    doi: 10.1093/nar/gkac840
+    id: https://www.ncbi.nlm.nih.gov/pubmed/36177882
+    journal: Nucleic Acids Research
     preferred: true
-  - id: PMID:37883399
+    title: 'Ribocentre: a database of ribozymes'
+    year: '2023'
 synonyms:
   - RiboCentre
 ---

--- a/resource/rs/rs.md
+++ b/resource/rs/rs.md
@@ -50,9 +50,19 @@ repository: https://github.com/rat-genome-database/RS-Rat-Strain-Ontology
 taxon:
 - NCBITaxon:10114
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/24267899
+- authors:
+  - Nigam R
+  - Munzenmaier DH
+  - Worthey EA
+  - Dwinell MR
+  - Shimoyama M
+  - Jacob HJ
+  doi: 10.1186/2041-1480-4-36
+  id: https://www.ncbi.nlm.nih.gov/pubmed/24267899
+  journal: J Biomed Semantics
   title: 'Rat Strain Ontology: structured controlled vocabulary designed to facilitate
     access to strain data at RGD.'
+  year: '2013'
 ---
 ## Description
 

--- a/resource/rxnorm/rxnorm.md
+++ b/resource/rxnorm/rxnorm.md
@@ -295,8 +295,18 @@ products:
     source: rxnorm
 publications:
 - category: Publication
+  authors:
+  - Nelson SJ
+  - Zeng K
+  - Kilbourne J
+  - Powell T
+  - Moore R
+  doi: 10.1136/amiajnl-2011-000116
   id: PMID:21515544
+  journal: J Am Med Inform Assoc
   preferred: true
+  title: "Normalized names for clinical drugs: RxNorm at 6 years."
+  year: '2011'
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/signor/signor.md
+++ b/resource/signor/signor.md
@@ -884,11 +884,20 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: https://doi.org/10.1093/nar/gkac883
+- authors:
+  - Prisca Lo Surdo
+  - Marta Iannuccelli
+  - Silvia Contino
+  - Luisa Castagnoli
+  - Luana Licata
+  - Gianni Cesareni
+  - Livia Perfetto
+  doi: 10.1093/nar/gkac883
+  id: https://doi.org/10.1093/nar/gkac883
   journal: Nucleic Acids Research
   preferred: true
   title: 'SIGNOR 3.0, the SIGnaling network open resource 3.0: 2022 update'
-  year: '2022'
+  year: '2023'
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/silva/silva.md
+++ b/resource/silva/silva.md
@@ -776,9 +776,10 @@ publications:
   - "Frank Oliver Gl\xF6ckner"
   doi: 10.1093/nar/gks1219
   id: doi:10.1093/nar/gks1219
+  journal: Nucleic Acids Research
   title: 'The SILVA ribosomal RNA gene database project: improved data processing
     and web-based tools'
-  year: '2013'
+  year: '2012'
 - authors:
   - Pelin Yilmaz
   - Linda Wegener Parfrey
@@ -792,6 +793,7 @@ publications:
   - "Frank Oliver Gl\xF6ckner"
   doi: 10.1093/nar/gkt1209
   id: doi:10.1093/nar/gkt1209
+  journal: Nucleic Acids Research
   title: The SILVA and 'All-species Living Tree Project (LTP)' taxonomic frameworks
   year: '2014'
 repository: https://github.com/epruesse/SINA

--- a/resource/smpdb/smpdb.md
+++ b/resource/smpdb/smpdb.md
@@ -1340,7 +1340,9 @@ publications:
       - Su Y
       - Disfany FM
       - et al.
+    doi: 10.1093/nar/gkt1067
     id: https://doi.org/10.1093/nar/gkt1067
+    journal: Nucleic Acids Research
     title: 'SMPDB 2.0: Big Improvements to the Small Molecule Pathway Database'
     year: '2014'
 synonyms:

--- a/resource/snodb/snodb.md
+++ b/resource/snodb/snodb.md
@@ -888,8 +888,9 @@ publications:
   - Catez
   - Marcel
   - Scott
+  doi: 10.1093/nar/gkac835
   id: https://pubmed.ncbi.nlm.nih.gov/36165892/
-  journal: Nucleic Acids Research
+  journal: Nucleic Acids Res
   preferred: true
   title: 'snoDB 2.0: an enhanced interactive database, specializing in human snoRNAs'
   year: '2023'

--- a/resource/snpeff/snpeff.md
+++ b/resource/snpeff/snpeff.md
@@ -89,8 +89,9 @@ publications:
       - Land SJ
       - Lu X
       - Ruden DM
+    doi: 10.4161/fly.19695
     id: https://pubmed.ncbi.nlm.nih.gov/22728672/
-    journal: Fly
+    journal: Fly (Austin)
     preferred: true
     title: 'A program for annotating and predicting the effects of single nucleotide polymorphisms, SnpEff: SNPs in the genome of Drosophila melanogaster strain w1118; iso-2; iso-3'
     year: '2012'

--- a/resource/so/so.md
+++ b/resource/so/so.md
@@ -327,10 +327,28 @@ products:
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/15892872
+- authors:
+  - Eilbeck K
+  - Lewis SE
+  - Mungall CJ
+  - Yandell M
+  - Stein L
+  - Durbin R
+  - Ashburner M
+  doi: 10.1186/gb-2005-6-5-r44
+  id: https://www.ncbi.nlm.nih.gov/pubmed/15892872
+  journal: Genome Biol
   title: 'The Sequence Ontology: a tool for the unification of genome annotations.'
-- id: https://www.ncbi.nlm.nih.gov/pubmed/20226267
+  year: '2005'
+- authors:
+  - Mungall CJ
+  - Batchelor C
+  - Eilbeck K
+  doi: 10.1016/j.jbi.2010.03.002
+  id: https://www.ncbi.nlm.nih.gov/pubmed/20226267
+  journal: J Biomed Inform
   title: Evolution of the Sequence Ontology terms and relationships.
+  year: '2011'
 repository: https://github.com/The-Sequence-Ontology/SO-Ontologies
 ---
 ## Description

--- a/resource/spd/spd.md
+++ b/resource/spd/spd.md
@@ -40,8 +40,14 @@ repository: https://github.com/obophenotype/spider-ontology
 taxon:
   - NCBITaxon:6893
 publications:
-  - id: https://doi.org/10.3390/d11100202
+  - authors:
+      - Martín J. Ramírez
+      - Peter Michalik
+    doi: 10.3390/d11100202
+    id: https://doi.org/10.3390/d11100202
+    journal: Diversity
     title: The Spider Anatomy Ontology (SPD) A Versatile Tool to Link Anatomy with Cross-Disciplinary Data
+    year: '2019'
 ---
 
 ## Description

--- a/resource/spoke-okn/spoke-okn.md
+++ b/resource/spoke-okn/spoke-okn.md
@@ -77,6 +77,7 @@ publications:
   - Peter W Rose
   - Charlotte A Nelson
   - Sergio E Baranzini
+  doi: 10.1093/bioinformatics/btad080
   id: https://doi.org/10.1093/bioinformatics/btad080
   journal: Bioinformatics
   preferred: true
@@ -94,6 +95,7 @@ publications:
   - Atul Butte
   - Mark Musen
   - Sui Huang
+  doi: 10.1002/aaai.12037
   id: https://doi.org/10.1002/aaai.12037
   journal: AI Magazine
   title: A biomedical open knowledge network harnesses the power of AI to understand

--- a/resource/srpdb/srpdb.md
+++ b/resource/srpdb/srpdb.md
@@ -979,8 +979,9 @@ publications:
   - Larsen
   - Samuelsson
   - Zwieb
+  doi: 10.4161/rna.6.5.9753
   id: https://pubmed.ncbi.nlm.nih.gov/19838050/
-  journal: RNA Biology
+  journal: RNA Biol
   title: Kinship in the SRP RNA family
   year: '2009'
 ---

--- a/resource/stato/stato.md
+++ b/resource/stato/stato.md
@@ -79,10 +79,30 @@ products:
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/31831744
+- authors:
+  - Rocca-Serra P
+  - Sansone SA
+  doi: 10.1038/s41597-019-0286-0
+  id: https://www.ncbi.nlm.nih.gov/pubmed/31831744
+  journal: Sci Data
   title: Experiment design driven FAIRification of omics data matrices, an exemplar
-- id: https://www.ncbi.nlm.nih.gov/pubmed/32109232
+  year: '2019'
+- authors:
+  - Ćwiek-Kupczyńska H
+  - Filipiak K
+  - Markiewicz A
+  - Rocca-Serra P
+  - Gonzalez-Beltran AN
+  - Sansone SA
+  - Millet EJ
+  - van Eeuwijk F
+  - Ławrynowicz A
+  - Krajewski P
+  doi: 10.1038/s41597-020-0409-7
+  id: https://www.ncbi.nlm.nih.gov/pubmed/32109232
+  journal: Sci Data
   title: Semantic concept schema of the linear mixed model of experimental observations
+  year: '2020'
 repository: https://github.com/ISA-tools/stato
 ---
 ## Description

--- a/resource/swo/swo.md
+++ b/resource/swo/swo.md
@@ -52,9 +52,20 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/allysonlister/swo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/25068035
+- authors:
+  - Malone J
+  - Brown A
+  - Lister AL
+  - Ison J
+  - Hull D
+  - Parkinson H
+  - Stevens R
+  doi: 10.1186/2041-1480-5-25
+  id: https://www.ncbi.nlm.nih.gov/pubmed/25068035
+  journal: J Biomed Semantics
   title: 'The Software Ontology (SWO): a resource for reproducibility in biomedical
     data analysis, curation and digital preservation'
+  year: '2014'
 ---
 ## Description
 

--- a/resource/symp/symp.md
+++ b/resource/symp/symp.md
@@ -50,10 +50,45 @@ repository: https://github.com/DiseaseOntology/SymptomOntology
 taxon:
   - NCBITaxon:9606
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/19850722
+  - authors:
+      - Schriml LM
+      - Arze C
+      - Nadendla S
+      - Ganapathy A
+      - Felix V
+      - Mahurkar A
+      - Phillippy K
+      - Gussman A
+      - Angiuoli S
+      - Ghedin E
+      - White O
+      - Hall N
+    doi: 10.1093/nar/gkp832
+    id: https://www.ncbi.nlm.nih.gov/pubmed/19850722
+    journal: Nucleic Acids Res
     title: GeMInA, Genomic Metadata for Infectious Agents, a geospatial surveillance pathogen database
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/34755882
+    year: '2010'
+  - authors:
+      - Schriml LM
+      - Munro JB
+      - Schor M
+      - Olley D
+      - McCracken C
+      - Felix V
+      - Baron JA
+      - Jackson R
+      - Bello SM
+      - Bearer C
+      - Lichenstein R
+      - Bisordi K
+      - Dialo NC
+      - Giglio M
+      - Greene C
+    doi: 10.1093/nar/gkab1063
+    id: https://www.ncbi.nlm.nih.gov/pubmed/34755882
+    journal: Nucleic Acids Res
     title: The Human Disease Ontology 2022 update
+    year: '2022'
 ---
 
 ## Description

--- a/resource/t4fs/t4fs.md
+++ b/resource/t4fs/t4fs.md
@@ -109,9 +109,16 @@ products:
   - 'File was not able to be retrieved when checked on 2026-06-17: Timeout connecting
     to URL'
 publications:
-- id: https://doi.org/10.5281/zenodo.4705219
+- authors:
+  - Molloy, Laura
+  - McQuilton, Peter
+  - Le Franc, Yann
+  doi: 10.5281/zenodo.4705219
+  id: https://doi.org/10.5281/zenodo.4705219
+  journal: Zenodo
   title: 'EOSC Co-creation funded project 074: Delivery of a proof of concept for
     terms4FAIRskills: Technical report'
+  year: '2021'
 repository: https://github.com/terms4fairskills/FAIRterminology
 ---
 ## Description

--- a/resource/tao/tao.md
+++ b/resource/tao/tao.md
@@ -37,8 +37,21 @@ products:
 taxon:
   - NCBITaxon:32443
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/20547776
+  - authors:
+      - Dahdul WM
+      - Lundberg JG
+      - Midford PE
+      - Balhoff JP
+      - Lapp H
+      - Vision TJ
+      - Haendel MA
+      - Westerfield M
+      - Mabee PM
+    doi: 10.1093/sysbio/syq013
+    id: https://www.ncbi.nlm.nih.gov/pubmed/20547776
+    journal: Syst Biol
     title: 'The teleost anatomy ontology: anatomical representation for the genomics age'
+    year: '2010'
 ---
 
 ## Description

--- a/resource/tarbase/tarbase.md
+++ b/resource/tarbase/tarbase.md
@@ -816,12 +816,13 @@ publications:
   - Georgakopoulos
   - Plagianakos
   - Hatzigeorgiou
+  doi: 10.1093/nar/gkad1071
   id: https://doi.org/10.1093/nar/gkad1071
   journal: Nucleic Acids Research
   preferred: true
   title: TarBase-v9.0 extends experimentally supported miRNA–gene interactions to
     cell-types and virally encoded miRNAs
-  year: '2023'
+  year: '2024'
 ---
 # TarBase
 

--- a/resource/taxrank/taxrank.md
+++ b/resource/taxrank/taxrank.md
@@ -49,9 +49,25 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/phenoscape/taxrank
 publications:
-- id: https://doi.org/10.1186/2041-1480-4-34
+- authors:
+  - Peter E Midford
+  - Thomas Alex Dececchi
+  - James P Balhoff
+  - Wasila M Dahdul
+  - Nizar Ibrahim
+  - Hilmar Lapp
+  - John G Lundberg
+  - Paula M Mabee
+  - Paul C Sereno
+  - Monte Westerfield
+  - Todd J Vision
+  - David C Blackburn
+  doi: 10.1186/2041-1480-4-34
+  id: https://doi.org/10.1186/2041-1480-4-34
+  journal: Journal of Biomedical Semantics
   title: 'The vertebrate taxonomy ontology: a framework for reasoning across model
     organism and species phenotypes'
+  year: '2013'
 ---
 ## Description
 

--- a/resource/tbkg/tbkg.md
+++ b/resource/tbkg/tbkg.md
@@ -29,8 +29,8 @@ publications:
       - He X
       - Huang W
       - Liu X
-    journal: Frontiers in Genetics
-    year: '2021'
+    journal: Front Genet
+    year: '2020'
     doi: 10.3389/fgene.2020.625659
 license:
   id: https://creativecommons.org/licenses/by/4.0/

--- a/resource/tcrd/tcrd.md
+++ b/resource/tcrd/tcrd.md
@@ -205,8 +205,31 @@ products:
   product_file_size: 1686928
   product_url: https://research.bioinformatics.udel.edu/prokn_dp/downloads/current/DDKG_IDGD.Compound.INDICATION.DiseaseOrPhenotype.edges.csv
 publications:
-- id: https://doi.org/10.1093/nar/gkaa993
+- authors:
+  - Timothy K Sheils
+  - Stephen L Mathias
+  - Keith J Kelleher
+  - Vishal B Siramshetty
+  - Dac-Trung Nguyen
+  - Cristian G Bologa
+  - Lars Juhl Jensen
+  - Dušica Vidović
+  - Amar Koleti
+  - Stephan C Schürer
+  - Anna Waller
+  - Jeremy J Yang
+  - Jayme Holmes
+  - Giovanni Bocci
+  - Noel Southall
+  - Poorva Dharkar
+  - Ewy Mathé
+  - Anton Simeonov
+  - Tudor I Oprea
+  doi: 10.1093/nar/gkaa993
+  id: https://doi.org/10.1093/nar/gkaa993
+  journal: Nucleic Acids Research
   title: 'Pharos 2021: mining the human proteome for disease biology'
+  year: '2021'
 - authors:
   - Dac-Trung Nguyen
   - Stephen Mathias

--- a/resource/tera/tera.md
+++ b/resource/tera/tera.md
@@ -183,8 +183,9 @@ publications:
       - Raoul Wolf
       - Knut Erik Tollefsen
     category: Publication
+    doi: 10.48550/arXiv.1908.10128
     id: https://doi.org/10.48550/arXiv.1908.10128
-    journal: arXiv:1908.10128
+    journal: arXiv
     preferred: true
     title: 'TERA: the Toxicological Effect and Risk Assessment Knowledge Graph'
     year: '2019'
@@ -195,8 +196,9 @@ publications:
       - Raoul Wolf
       - Knut Erik Tollefsen
     category: Publication
+    doi: 10.3233/sw-222804
     id: https://doi.org/10.3233/sw-222804
-    journal: Semantic Web Journal
+    journal: Semantic Web
     preferred: false
     title: Prediction of Adverse Biological Effects of Chemicals Using Knowledge Graph Embeddings
     year: '2022'

--- a/resource/tissues/tissues.md
+++ b/resource/tissues/tissues.md
@@ -1701,9 +1701,18 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: PMID:29617745
+- authors:
+  - Palasca O
+  - Santos A
+  - Stolte C
+  - Gorodkin J
+  - Jensen LJ
+  doi: 10.1093/database/bay003
+  id: PMID:29617745
+  journal: Database (Oxford)
   preferred: true
   title: 'TISSUES 2.0: an integrative web resource on mammalian tissue expression.'
+  year: '2018'
 - authors:
   - Alberto Santos
   - Kalliopi Tsafou

--- a/resource/to/to.md
+++ b/resource/to/to.md
@@ -260,9 +260,32 @@ products:
     source: interpro
   product_url: https://datacommons.cyverse.org/browse/iplant/home/shared/genophenoenvo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+- authors:
+  - Cooper L
+  - Meier A
+  - Laporte MA
+  - Elser JL
+  - Mungall C
+  - Sinn BT
+  - Cavaliere D
+  - Carbon S
+  - Dunn NA
+  - Smith B
+  - Qu B
+  - Preece J
+  - Zhang E
+  - Todorovic S
+  - Gkoutos G
+  - Doonan JH
+  - Stevenson DW
+  - Arnaud E
+  - Jaiswal P
+  doi: 10.1093/nar/gkx1152
+  id: https://www.ncbi.nlm.nih.gov/pubmed/29186578
+  journal: Nucleic Acids Res
   title: 'The Planteome database: an integrated resource for reference ontologies,
     plant genomics and phenomics.'
+  year: '2018'
 repository: https://github.com/Planteome/plant-trait-ontology
 taxon:
 - NCBITaxon:33090

--- a/resource/toxin/toxin.md
+++ b/resource/toxin/toxin.md
@@ -34,8 +34,21 @@ products:
       - source: toxin
         relation_type: prov:hadPrimarySource
 publications:
-  - id: https://doi.org/10.1093/database/baae121
-    journal: Database (Oxford)
+  - authors:
+      - Sara Sepehri
+      - Anja Heymans
+      - Dinja De Win
+      - Jan Maushagen
+      - Audrey Sanctorum
+      - Christophe Debruyne
+      - Robim M Rodrigues
+      - Joery De Kock
+      - Vera Rogiers
+      - Olga De Troyer
+      - Tamara Vanhaecke
+    doi: 10.1093/database/baae121
+    id: https://doi.org/10.1093/database/baae121
+    journal: Database
     preferred: true
     title: 'The TOXIN knowledge graph: supporting animal-free risk assessment of cosmetics'
     year: '2025'

--- a/resource/trans/trans.md
+++ b/resource/trans/trans.md
@@ -48,10 +48,45 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/DiseaseOntology/PathogenTransmissionOntology
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/19850722
+  - authors:
+      - Schriml LM
+      - Arze C
+      - Nadendla S
+      - Ganapathy A
+      - Felix V
+      - Mahurkar A
+      - Phillippy K
+      - Gussman A
+      - Angiuoli S
+      - Ghedin E
+      - White O
+      - Hall N
+    doi: 10.1093/nar/gkp832
+    id: https://www.ncbi.nlm.nih.gov/pubmed/19850722
+    journal: Nucleic Acids Res
     title: GeMInA, Genomic Metadata for Infectious Agents, a geospatial surveillance pathogen database
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/34755882
+    year: '2010'
+  - authors:
+      - Schriml LM
+      - Munro JB
+      - Schor M
+      - Olley D
+      - McCracken C
+      - Felix V
+      - Baron JA
+      - Jackson R
+      - Bello SM
+      - Bearer C
+      - Lichenstein R
+      - Bisordi K
+      - Dialo NC
+      - Giglio M
+      - Greene C
+    doi: 10.1093/nar/gkab1063
+    id: https://www.ncbi.nlm.nih.gov/pubmed/34755882
+    journal: Nucleic Acids Res
     title: The Human Disease Ontology 2022 update
+    year: '2022'
 ---
 
 ## Description

--- a/resource/ttd/ttd.md
+++ b/resource/ttd/ttd.md
@@ -1380,6 +1380,7 @@ publications:
   - Yuzong Chen
   - Feng Zhu
   category: Publication
+  doi: 10.1093/nar/gkad751
   id: doi:10.1093/nar/gkad751
   journal: Nucleic Acids Research
   preferred: true
@@ -1395,6 +1396,7 @@ publications:
   - Yunqing Qiu
   - Yuzong Chen
   category: Publication
+  doi: 10.1093/nar/gkab953
   id: doi:10.1093/nar/gkab953
   journal: Nucleic Acids Research
   preferred: false

--- a/resource/tto/tto.md
+++ b/resource/tto/tto.md
@@ -51,8 +51,21 @@ repository: https://github.com/phenoscape/teleost-taxonomy-ontology
 taxon:
 - NCBITaxon:32443
 publications:
-- id: https://doi.org/10.1038/npre.2010.4629.1
+- authors:
+  - Peter Midford
+  - James Balhoff
+  - Wasila Dahdul
+  - Cartik Kothari
+  - Hilmar Lapp
+  - John Lundberg
+  - Paula Mabee
+  - Todd Vision
+  - Monte Westerfield
+  doi: 10.1038/npre.2010.4629.1
+  id: https://doi.org/10.1038/npre.2010.4629.1
+  journal: Nature Precedings
   title: The Teleost Taxonomy Ontology
+  year: '2010'
 ---
 ## Description
 

--- a/resource/txpo/txpo.md
+++ b/resource/txpo/txpo.md
@@ -38,8 +38,14 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/txpo-ontology/TXPO
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/32883995
+  - authors:
+      - Yamagata Y
+      - Yamada H
+    doi: 10.1038/s41598-020-71370-7
+    id: https://www.ncbi.nlm.nih.gov/pubmed/32883995
+    journal: Sci Rep
     title: Ontological approach to the knowledge systematization of a toxic process and toxic course representation framework for early drug risk management
+    year: '2020'
 ---
 
 ## Description

--- a/resource/uberon/uberon.md
+++ b/resource/uberon/uberon.md
@@ -2713,11 +2713,42 @@ products:
     source: uniprot
   product_url: https://sugi.bio/biobtree/api/
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/22293552
+- authors:
+  - Mungall CJ
+  - Torniai C
+  - Gkoutos GV
+  - Lewis SE
+  - Haendel MA
+  doi: 10.1186/gb-2012-13-1-r5
+  id: https://www.ncbi.nlm.nih.gov/pubmed/22293552
+  journal: Genome Biol
   title: Uberon, an integrative multi-species anatomy ontology
-- id: https://www.ncbi.nlm.nih.gov/pubmed/25009735
+  year: '2012'
+- authors:
+  - Haendel MA
+  - Balhoff JP
+  - Bastian FB
+  - Blackburn DC
+  - Blake JA
+  - Bradford Y
+  - Comte A
+  - Dahdul WM
+  - Dececchi TA
+  - Druzinsky RE
+  - Hayamizu TF
+  - Ibrahim N
+  - Lewis SE
+  - Mabee PM
+  - Niknejad A
+  - Robinson-Rechavi M
+  - Sereno PC
+  - Mungall CJ
+  doi: 10.1186/2041-1480-5-21
+  id: https://www.ncbi.nlm.nih.gov/pubmed/25009735
+  journal: J Biomed Semantics
   title: Unification of multi-species vertebrate anatomy ontologies for comparative
     biology in Uberon
+  year: '2014'
 repository: https://github.com/obophenotype/uberon
 taxon:
 - NCBITaxon:33208

--- a/resource/umls/umls.md
+++ b/resource/umls/umls.md
@@ -1741,9 +1741,14 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: PMID:14681409
+- authors:
+  - Bodenreider O
+  doi: 10.1093/nar/gkh061
+  id: PMID:14681409
+  journal: Nucleic Acids Res
   preferred: true
   title: 'The Unified Medical Language System (UMLS): integrating biomedical terminology.'
+  year: '2004'
 synonyms:
 - UMLS
 taxon:

--- a/resource/unichem/unichem.md
+++ b/resource/unichem/unichem.md
@@ -26,7 +26,19 @@ license:
   label: EMBL-EBI Terms of Use
 name: UniChem
 publications:
-  - id: https://doi.org/10.1186/1758-2946-5-3
+  - authors:
+      - Jon Chambers
+      - Mark Davies
+      - Anna Gaulton
+      - Anne Hersey
+      - Sameer Velankar
+      - Robert Petryszak
+      - Janna Hastings
+      - Louisa Bellis
+      - Shaun McGlinchey
+      - John P Overington
+    doi: 10.1186/1758-2946-5-3
+    id: https://doi.org/10.1186/1758-2946-5-3
     journal: Journal of Cheminformatics
     title: 'UniChem: a unified chemical structure cross-referencing and identifier tracking system'
     year: '2013'

--- a/resource/uo/uo.md
+++ b/resource/uo/uo.md
@@ -758,8 +758,15 @@ products:
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/23060432
+- authors:
+  - Gkoutos GV
+  - Schofield PN
+  - Hoehndorf R
+  doi: 10.1093/database/bas033
+  id: https://www.ncbi.nlm.nih.gov/pubmed/23060432
+  journal: Database (Oxford)
   title: 'The Units Ontology: a tool for integrating units of measurement in science'
+  year: '2012'
 repository: https://github.com/bio-ontology-research-group/unit-ontology
 ---
 ## Description

--- a/resource/upa/upa.md
+++ b/resource/upa/upa.md
@@ -48,8 +48,22 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/geneontology/unipathway
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/22102589
+  - authors:
+      - Morgat A
+      - Coissac E
+      - Coudert E
+      - Axelsen KB
+      - Keller G
+      - Bairoch A
+      - Bridge A
+      - Bougueleret L
+      - Xenarios I
+      - Viari A
+    doi: 10.1093/nar/gkr1023
+    id: https://www.ncbi.nlm.nih.gov/pubmed/22102589
+    journal: Nucleic Acids Res
     title: 'UniPathway: a resource for the exploration and annotation of metabolic pathways'
+    year: '2012'
 ---
 
 ## Description

--- a/resource/upheno/upheno.md
+++ b/resource/upheno/upheno.md
@@ -64,9 +64,58 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/obophenotype/upheno
 publications:
-- id: https://doi.org/10.1101/2024.09.18.613276
+- authors:
+  - Nicolas Matentzoglu
+  - Susan M Bello
+  - Ray Stefancsik
+  - Sarah M. Alghamdi
+  - Anna V. Anagnostopoulos
+  - James P. Balhoff
+  - Meghan A. Balk
+  - Yvonne M. Bradford
+  - Yasemin Bridges
+  - Tiffany J. Callahan
+  - Harry Caufield
+  - Alayne Cuzick
+  - Leigh C Carmody
+  - Anita R. Caron
+  - Vinicius de Souza
+  - Stacia R. Engel
+  - Petra Fey
+  - Malcolm Fisher
+  - Sarah Gehrke
+  - Christian Grove
+  - Peter Hansen
+  - Nomi L. Harris
+  - Midori A. Harris
+  - Laura Harris
+  - Arwa Ibrahim
+  - Julius O.B. Jacobsen
+  - Sebastian Köhler
+  - Julie A. McMurry
+  - Violeta Munoz-Fuentes
+  - Monica C. Munoz-Torres
+  - Helen Parkinson
+  - Zoë M Pendlington
+  - Clare Pilgrim
+  - Sofia MC Robb
+  - Peter N. Robinson
+  - James Seager
+  - Erik Segerdell
+  - Damian Smedley
+  - Elliot Sollis
+  - Sabrina Toro
+  - Nicole Vasilevsky
+  - Valerie Wood
+  - Melissa A. Haendel
+  - Christopher J. Mungall
+  - James A. McLaughlin
+  - David Osumi-Sutherland
+  doi: 10.1101/2024.09.18.613276
+  id: https://doi.org/10.1101/2024.09.18.613276
   title: 'The Unified Phenotype Ontology (uPheno): A framework for cross-species integrative
     phenomics'
+  year: '2024'
 - id: https://zenodo.org/record/2382757
   title: Phenotype Ontologies Traversing All The Organisms (POTATO) workshop aims
     to reconcile logical definitions across species

--- a/resource/vbo/vbo.md
+++ b/resource/vbo/vbo.md
@@ -90,8 +90,28 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/monarch-initiative/vertebrate-breed-ontology
 publications:
-- id: https://doi.org/10.1111/jvim.70133
+- authors:
+  - Kathleen R. Mullen
+  - Imke Tammen
+  - Nicolas A. Matentzoglu
+  - Marius Mather
+  - James P. Balhoff
+  - Elizabeth Esdaile
+  - Gregoire Leroy
+  - Carissa A. Park
+  - Halie M. Rando
+  - Nadia T. Saklou
+  - Tracy L. Webb
+  - Nicole A. Vasilevsky
+  - Christopher J. Mungall
+  - Melissa A. Haendel
+  - Frank W. Nicholas
+  - Sabrina Toro
+  doi: 10.1111/jvim.70133
+  id: https://doi.org/10.1111/jvim.70133
+  journal: Journal of Veterinary Internal Medicine
   title: 'The Vertebrate Breed Ontology: Toward Effective Breed Data Standardization'
+  year: '2025'
 ---
 ## Description
 

--- a/resource/vo/vo.md
+++ b/resource/vo/vo.md
@@ -237,12 +237,26 @@ products:
   product_file_size: 18370248815
   product_url: https://rna-kg.biodata.di.unimi.it/edges.csv
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/23256535
+- authors:
+  - Lin Y
+  - He Y
+  doi: 10.1186/2041-1480-3-17
+  id: https://www.ncbi.nlm.nih.gov/pubmed/23256535
+  journal: J Biomed Semantics
   title: Ontology representation and analysis of vaccine formulation and administration
     and their effects on vaccine immune responses
-- id: https://www.ncbi.nlm.nih.gov/pubmed/21624163
+  year: '2012'
+- authors:
+  - Ozgür A
+  - Xiang Z
+  - Radev DR
+  - He Y
+  doi: 10.1186/2041-1480-2-S2-S8
+  id: https://www.ncbi.nlm.nih.gov/pubmed/21624163
+  journal: J Biomed Semantics
   title: Mining of vaccine-associated IFN-  gene interaction networks using the Vaccine
     Ontology
+  year: '2011'
 repository: https://github.com/vaccineontology/VO
 ---
 ## Description

--- a/resource/vto/vto.md
+++ b/resource/vto/vto.md
@@ -49,9 +49,25 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/phenoscape/vertebrate-taxonomy-ontology
 publications:
-- id: https://doi.org/10.1186/2041-1480-4-34
+- authors:
+  - Peter E Midford
+  - Thomas Alex Dececchi
+  - James P Balhoff
+  - Wasila M Dahdul
+  - Nizar Ibrahim
+  - Hilmar Lapp
+  - John G Lundberg
+  - Paula M Mabee
+  - Paul C Sereno
+  - Monte Westerfield
+  - Todd J Vision
+  - David C Blackburn
+  doi: 10.1186/2041-1480-4-34
+  id: https://doi.org/10.1186/2041-1480-4-34
+  journal: Journal of Biomedical Semantics
   title: 'The vertebrate taxonomy ontology: a framework for reasoning across model
     organism and species phenotypes'
+  year: '2013'
 ---
 ## Description
 

--- a/resource/wbbt/wbbt.md
+++ b/resource/wbbt/wbbt.md
@@ -50,8 +50,14 @@ repository: https://github.com/obophenotype/c-elegans-gross-anatomy-ontology
 taxon:
   - NCBITaxon:6237
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/18629098
+  - authors:
+      - Lee RY
+      - Sternberg PW
+    doi: 10.1002/cfg.248
+    id: https://www.ncbi.nlm.nih.gov/pubmed/18629098
+    journal: Comp Funct Genomics
     title: Building a cell and anatomy ontology of Caenorhabditis elegans
+    year: '2003'
 ---
 
 ## Description

--- a/resource/wbls/wbls.md
+++ b/resource/wbls/wbls.md
@@ -236,8 +236,40 @@ products:
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/31642470
+- authors:
+  - Harris TW
+  - Arnaboldi V
+  - Cain S
+  - Chan J
+  - Chen WJ
+  - Cho J
+  - Davis P
+  - Gao S
+  - Grove CA
+  - Kishore R
+  - Lee RYN
+  - Muller HM
+  - Nakamura C
+  - Nuin P
+  - Paulini M
+  - Raciti D
+  - Rodgers FH
+  - Russell M
+  - Schindelman G
+  - Auken KV
+  - Wang Q
+  - Williams G
+  - Wright AJ
+  - Yook K
+  - Howe KL
+  - Schedl T
+  - Stein L
+  - Sternberg PW
+  doi: 10.1093/nar/gkz920
+  id: https://www.ncbi.nlm.nih.gov/pubmed/31642470
+  journal: Nucleic Acids Res
   title: 'WormBase: a modern Model Organism Information Resource'
+  year: '2020'
 repository: https://github.com/obophenotype/c-elegans-development-ontology
 taxon:
 - NCBITaxon:6237

--- a/resource/wbphenotype/wbphenotype.md
+++ b/resource/wbphenotype/wbphenotype.md
@@ -61,9 +61,18 @@ repository: https://github.com/obophenotype/c-elegans-phenotype-ontology
 taxon:
 - NCBITaxon:6237
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/21261995
+- authors:
+  - Schindelman G
+  - Fernandes JS
+  - Bastiani CA
+  - Yook K
+  - Sternberg PW
+  doi: 10.1186/1471-2105-12-32
+  id: https://www.ncbi.nlm.nih.gov/pubmed/21261995
+  journal: BMC Bioinformatics
   title: 'Worm Phenotype Ontology: integrating phenotype data within and beyond the
     C. elegans community.'
+  year: '2011'
 ---
 ## Description
 

--- a/resource/wormbase/wormbase.md
+++ b/resource/wormbase/wormbase.md
@@ -1058,9 +1058,45 @@ products:
     source: wormbase
   product_url: https://www.genecards.org/
 publications:
-- id: PMID:19910365
+- authors:
+  - Harris TW
+  - Antoshechkin I
+  - Bieri T
+  - Blasiar D
+  - Chan J
+  - Chen WJ
+  - De La Cruz N
+  - Davis P
+  - Duesbury M
+  - Fang R
+  - Fernandes J
+  - Han M
+  - Kishore R
+  - Lee R
+  - Müller HM
+  - Nakamura C
+  - Ozersky P
+  - Petcherski A
+  - Rangarajan A
+  - Rogers A
+  - Schindelman G
+  - Schwarz EM
+  - Tuli MA
+  - Van Auken K
+  - Wang D
+  - Wang X
+  - Williams G
+  - Yook K
+  - Durbin R
+  - Stein LD
+  - Spieth J
+  - Sternberg PW
+  doi: 10.1093/nar/gkp952
+  id: PMID:19910365
+  journal: Nucleic Acids Res
   preferred: true
   title: 'WormBase: a comprehensive resource for nematode research.'
+  year: '2010'
 repository: https://github.com/WormBase
 synonyms:
 - WB

--- a/resource/xao/xao.md
+++ b/resource/xao/xao.md
@@ -50,10 +50,30 @@ repository: https://github.com/xenopus-anatomy/xao
 taxon:
   - NCBITaxon:8353
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/18817563
+  - authors:
+      - Segerdell E
+      - Bowes JB
+      - Pollet N
+      - Vize PD
+    doi: 10.1186/1471-213X-8-92
+    id: https://www.ncbi.nlm.nih.gov/pubmed/18817563
+    journal: BMC Dev Biol
     title: An ontology for Xenopus anatomy and development.
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/24139024
+    year: '2008'
+  - authors:
+      - Segerdell E
+      - Ponferrada VG
+      - James-Zorn C
+      - Burns KA
+      - Fortriede JD
+      - Dahdul WM
+      - Vize PD
+      - Zorn AM
+    doi: 10.1186/2041-1480-4-31
+    id: https://www.ncbi.nlm.nih.gov/pubmed/24139024
+    journal: J Biomed Semantics
     title: 'Enhanced XAO: the ontology of Xenopus anatomy and development underpins more accurate annotation of gene expression and queries on Xenbase.'
+    year: '2013'
 ---
 
 ## Description

--- a/resource/xco/xco.md
+++ b/resource/xco/xco.md
@@ -48,10 +48,39 @@ products:
         relation_type: prov:hadPrimarySource
 repository: https://github.com/rat-genome-database/XCO-experimental-condition-ontology
 publications:
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
+  - authors:
+      - Shimoyama M
+      - Nigam R
+      - McIntosh LS
+      - Nagarajan R
+      - Rice T
+      - Rao DC
+      - Dwinell MR
+    doi: 10.3389/fgene.2012.00087
+    id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
+    journal: Front Genet
     title: Three ontologies to define phenotype measurement data.
-  - id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
+    year: '2012'
+  - authors:
+      - Smith JR
+      - Park CA
+      - Nigam R
+      - Laulederkind SJ
+      - Hayman GT
+      - Wang SJ
+      - Lowry TF
+      - Petri V
+      - Pons JD
+      - Tutaj M
+      - Liu W
+      - Worthey EA
+      - Shimoyama M
+      - Dwinell MR
+    doi: 10.1186/2041-1480-4-26
+    id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
+    journal: J Biomed Semantics
     title: 'The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications.'
+    year: '2013'
 ---
 
 ## Description

--- a/resource/xenbase/xenbase.md
+++ b/resource/xenbase/xenbase.md
@@ -1304,9 +1304,31 @@ products:
     source: hgnc
   product_url: https://downloads.thebiogrid.org/File/BioGRID/Latest-Release/BIOGRID-IDENTIFIERS-LATEST.tab.zip
 publications:
-- id: https://doi.org/10.1093/genetics/iyad018
+- authors:
+  - Malcolm Fisher
+  - Christina James-Zorn
+  - Virgilio Ponferrada
+  - Andrew J Bell
+  - Nivitha Sundararaj
+  - Erik Segerdell
+  - Praneet Chaturvedi
+  - Nadia Bayyari
+  - Stanley Chu
+  - Troy Pells
+  - Vaneet Lotay
+  - Sergei Agalakov
+  - Dong Zhuo Wang
+  - Bradley I Arshinoff
+  - Saoirse Foley
+  - Kamran Karimi
+  - Peter D Vize
+  - Aaron M Zorn
+  doi: 10.1093/genetics/iyad018
+  id: https://doi.org/10.1093/genetics/iyad018
+  journal: GENETICS
   preferred: true
   title: 'Xenbase: key features and resources of the Xenopus model organism knowledgebase'
+  year: '2023'
 repository: https://github.com/xenopus-anatomy
 taxon:
 - NCBITaxon:8355

--- a/resource/xpo/xpo.md
+++ b/resource/xpo/xpo.md
@@ -52,9 +52,33 @@ repository: https://github.com/obophenotype/xenopus-phenotype-ontology
 taxon:
 - NCBITaxon:8353
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/35317743
+- authors:
+  - Fisher ME
+  - Segerdell E
+  - Matentzoglu N
+  - Nenni MJ
+  - Fortriede JD
+  - Chu S
+  - Pells TJ
+  - Osumi-Sutherland D
+  - Chaturvedi P
+  - James-Zorn C
+  - Sundararaj N
+  - Lotay VS
+  - Ponferrada V
+  - Wang DZ
+  - Kim E
+  - Agalakov S
+  - Arshinoff BI
+  - Karimi K
+  - Vize PD
+  - Zorn AM
+  doi: 10.1186/s12859-022-04636-8
+  id: https://www.ncbi.nlm.nih.gov/pubmed/35317743
+  journal: BMC Bioinformatics
   title: 'The Xenopus phenotype ontology: bridging model organism phenotype data to
     human health and development.'
+  year: '2022'
 ---
 ## Description
 

--- a/resource/zfa/zfa.md
+++ b/resource/zfa/zfa.md
@@ -237,9 +237,17 @@ products:
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
 publications:
-- id: https://www.ncbi.nlm.nih.gov/pubmed/24568621
+- authors:
+  - Van Slyke CE
+  - Bradford YM
+  - Westerfield M
+  - Haendel MA
+  doi: 10.1186/2041-1480-5-12
+  id: https://www.ncbi.nlm.nih.gov/pubmed/24568621
+  journal: J Biomed Semantics
   title: 'The zebrafish anatomy and stage ontologies: representing the anatomy and
     development of Danio rerio.'
+  year: '2014'
 repository: https://github.com/cerivs/zebrafish-anatomical-ontology
 taxon:
 - NCBITaxon:7954


### PR DESCRIPTION
This branch is a large metadata-curation pass over the registry, in three parts.

## 1. Data-quality dashboard "top 10 most in need of improvement"

Worked through the 10 highest-scoring resources on the data-quality dashboard (gtopdb, go, metatraits, bacdive, progenomes, pcl, reactome, mirbase, ctd, chebi):

- **Broken links** — re-verified every flagged URL live first. Most had simply *moved* (Monarch KG → single `jsonl.tar.gz` bundle; KG-Microbe → GitHub releases; biobtree → corrected path; GP-KG → http scheme; metaTraits downloads → new host, TSV not JSONL). Updated those; dropped genuinely-dead ones (FORUM FTP, old NERSC snapshots). All replacements verified HTTP 200.
- **Product formats** — filled missing `format` on interface/data products where determinable (left DuckDB/Memgraph unset — no schema enum value).
- **Metadata** — filled missing `infores_id`/`license`/`repository`/`publications`/`contacts` for metaTraits, BacDive, proGenomes (web-researched, verified).
- Stripped stale false-positive retrieval `warnings:`; dropped unpublished PCL release-variant products.

A follow-up commit removed four `infores_id`s that aren't actually registered upstream (metatraits, bacdive, progenomes, pcl) and added a **University of Manchester** organization entry so miRBase's contact links properly.

## 2. Mis-curated publication IDs corrected

Found and fixed several publications pointing at entirely unrelated papers (verified replacements via CrossRef/PubMed):

- **ribocentre** — both IDs wrong (a *Yersinia/insect* paper and a *soccer-turf* paper) → correct ribozyme-database paper.
- **ols** — a *transverse-myelitis case report* → OLS4 paper.
- **mutationds** — a *Lancet eating-disorders* paper → Cancer Genome Interpreter paper.
- **cam-kp** — a malformed CTD DOI (`gkaq891`), wrong year, truncated authors → correct `10.1093/nar/gkn580`.

## 3. Citation-metadata backfill (≈150 resources)

Worked through the publication-reference validation backlog in batches of 10. For each, backfilled missing `authors`/`doi`/`journal`/`year`/`title` from the cached reference metadata, and aligned journal names / years to the cache. Each publication's title was checked against the cached paper before backfilling, so mis-curated IDs (see part 2) were caught rather than blindly copied. New/corrected references were fetched into `references_cache/` where the fetcher supported the source.

A handful of publications remain with benign "no cached reference" notes (arXiv preprints, bibkey-style IDs, and a couple of very recent Nature DOIs the fetcher can't retrieve) — these have complete metadata already and are non-blocking.

All touched resources pass `extract-metadata.py validate` (strict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)