### PR TITLE
Exclude references_cache from the Jekyll build

### DIFF
--- a/_config_header.yml
+++ b/_config_header.yml
@@ -18,5 +18,24 @@ feed:
 # dotfile directory Jekyll would otherwise skip.
 include:
   - ".well-known"
+# Keep the reference-validation cache out of the Jekyll build. These files are
+# fetched abstracts/HTML used only by util/reference_validation.py (read straight
+# from disk); nothing on the site links to them. They often contain raw LaTeX or
+# code with `{{ ... }}`, which Liquid tries to parse as a template variable and
+# fails on (e.g. PMID_30564458.md). Excluding the directory avoids that whole
+# class of build break. The remaining entries restore Jekyll's default excludes,
+# which setting `exclude` would otherwise override.
+exclude:
+  - "references_cache"
+  - ".sass-cache"
+  - ".jekyll-cache"
+  - "gemfiles"
+  - "Gemfile"
+  - "Gemfile.lock"
+  - "node_modules"
+  - "vendor/bundle/"
+  - "vendor/cache/"
+  - "vendor/gems/"
+  - "vendor/ruby/"
 ## --Anything above this line can be edited in _config_header.yml --
 ## --Everything below this line automatically generated in _config.yml --


### PR DESCRIPTION
## Problem

The GitHub Pages build is failing with a Liquid error:

```
Liquid Exception: Liquid syntax error (line 131): Variable
'{{\left| {X\mathop { \cap }' was not properly terminated with regexp: /\}\}/
in references_cache/PMID_30564458.md
```

(seen in [this Actions run](https://github.com/Knowledge-Graph-Hub/kg-registry/actions/runs/28056608591/job/83060435891))

`references_cache/PMID_30564458.md` has raw LaTeX math pasted into the cached abstract (`\frac{{\left| {X\mathop { \cap }...`). Because the file has YAML front matter, Jekyll runs it through Liquid, which interprets `{{ ... }}` as a template variable and fails when it can't find the closing `}}` it expects.

## Fix

The `references_cache/` files are a build-time cache of fetched abstracts/HTML, read straight from disk by `util/reference_validation.py`. Nothing on the site links to them, so there's no reason for Jekyll to process them at all.

This adds `references_cache` to `exclude` in `_config_header.yml` (and regenerates the committed `_config.yml`), so Jekyll skips the directory before Liquid ever sees the content. This fixes the current break **and** any future cache entry with the same hazard — there are already 3 cached files containing `{{` sequences, and the cache grows from arbitrary PubMed/web content.

The remaining entries in the `exclude` block restore Jekyll's default excludes, which setting `exclude` would otherwise override.

## Notes

- Couldn't run a local Jekyll build (no Ruby/Jekyll in the dev env), but `exclude` is honored at the file-discovery stage, so the parser never reaches the offending content.
- YAML validated; all resources preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)