### PR TITLE
biobtree: add KGX human subgraph graph dump (#630)

### DIFF
--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -367,6 +367,24 @@ entries:
     source_path: resource/bio2rdf/bio2rdf.md
     status: valid
     warnings: []
+  resource/biobtree/biobtree.md#publication[0]#DOI:10.5281/zenodo.18962899:
+    checked_at: '2026-06-24T15:55:55Z'
+    errors: []
+    fingerprint: 17d3fc4a29dd6bd37fc2813f3e947b8bdb1436912d74ce95cbda79564bd04024
+    publication_index: 0
+    reference_id: DOI:10.5281/zenodo.18962899
+    source_path: resource/biobtree/biobtree.md
+    status: valid
+    warnings: []
+  resource/biobtree/biobtree.md#publication[1]#DOI:10.12688/f1000research.17927.1:
+    checked_at: '2026-06-24T15:55:55Z'
+    errors: []
+    fingerprint: a6fb7317382a3136652b324c54bcf353bfe9d10faeaf01ddf7c73876eb3db444
+    publication_index: 1
+    reference_id: DOI:10.12688/f1000research.17927.1
+    source_path: resource/biobtree/biobtree.md
+    status: valid
+    warnings: []
   resource/biofactoid/biofactoid.md#publication[0]#DOI:10.7554/eLife.68292:
     checked_at: '2026-06-22T16:25:07Z'
     errors: []

--- a/resource/biobtree/biobtree.md
+++ b/resource/biobtree/biobtree.md
@@ -26,19 +26,190 @@ license:
 name: BioBTree
 products:
   - category: GraphProduct
+    compatibility:
+      - standard: biolink
+        version: 4.2.1
     compression: gzip
     description: Human-scoped, Neo4j-ready subgraph of the BioBTree knowledge graph, exported as a biolink-typed KGX graph (~40M nodes / ~132M edges, ~8.3 GB compressed across separate node and edge files). A practical projection of the full graph for human-centric biomedical use. Published on Zenodo.
-    edge_count: 132000000
+    edge_count: 132075627
     format: kgx
     id: biobtree.graph.human-subgraph
     license:
       id: https://creativecommons.org/licenses/by-nc-sa/4.0/
       label: CC-BY-NC-SA-4.0
     name: BioBTree Knowledge Graph - Human Subgraph (KGX)
-    node_count: 40000000
+    node_categories:
+      - biolink:BiologicalProcess
+      - biolink:Cell
+      - biolink:CellLine
+      - biolink:CellularComponent
+      - biolink:CodingSequence
+      - biolink:Disease
+      - biolink:DiseaseOrPhenotypicFeature
+      - biolink:Drug
+      - biolink:Exon
+      - biolink:Gene
+      - biolink:GrossAnatomicalStructure
+      - biolink:MacromolecularComplex
+      - biolink:MolecularActivity
+      - biolink:NoncodingRNAProduct
+      - biolink:NucleicAcidSequenceMotif
+      - biolink:OrganismTaxon
+      - biolink:Pathway
+      - biolink:PhenotypicFeature
+      - biolink:Protein
+      - biolink:ProteinDomain
+      - biolink:ProteinFamily
+      - biolink:Publication
+      - biolink:RegulatoryRegion
+      - biolink:SequenceVariant
+      - biolink:SmallMolecule
+      - biolink:Transcript
+    node_count: 40160474
     original_source:
       - relation_type: prov:hadPrimarySource
         source: biobtree
+      - relation_type: prov:hadPrimarySource
+        source: alphafold
+      - relation_type: prov:hadPrimarySource
+        source: alphamissense
+      - relation_type: prov:hadPrimarySource
+        source: bao
+      - relation_type: prov:hadPrimarySource
+        source: bgee
+      - relation_type: prov:hadPrimarySource
+        source: bindingdb
+      - relation_type: prov:hadPrimarySource
+        source: biogrid
+      - relation_type: prov:hadPrimarySource
+        source: brenda
+      - relation_type: prov:hadPrimarySource
+        source: cellphonedb
+      - relation_type: prov:hadPrimarySource
+        source: cellxgene
+      - relation_type: prov:hadPrimarySource
+        source: chebi
+      - relation_type: prov:hadPrimarySource
+        source: chembl
+      - relation_type: prov:hadPrimarySource
+        source: cl
+      - relation_type: prov:hadPrimarySource
+        source: clinicaltrialsgov
+      - relation_type: prov:hadPrimarySource
+        source: clinvar
+      - relation_type: prov:hadPrimarySource
+        source: collectri
+      - relation_type: prov:hadPrimarySource
+        source: corum
+      - relation_type: prov:hadPrimarySource
+        source: ctd
+      - relation_type: prov:hadPrimarySource
+        source: dbsnp
+      - relation_type: prov:hadPrimarySource
+        source: eco
+      - relation_type: prov:hadPrimarySource
+        source: efo
+      - relation_type: prov:hadPrimarySource
+        source: encode
+      - relation_type: prov:hadPrimarySource
+        source: ensembl
+      - relation_type: prov:hadPrimarySource
+        source: expressionatlas
+      - relation_type: prov:hadPrimarySource
+        source: fantom5
+      - relation_type: prov:hadPrimarySource
+        source: gencc
+      - relation_type: prov:hadPrimarySource
+        source: go
+      - relation_type: prov:hadPrimarySource
+        source: gwascatalog
+      - relation_type: prov:hadPrimarySource
+        source: hgnc
+      - relation_type: prov:hadPrimarySource
+        source: hmdb
+      - relation_type: prov:hadPrimarySource
+        source: hp
+      - relation_type: prov:hadPrimarySource
+        source: intact
+      - relation_type: prov:hadPrimarySource
+        source: interpro
+      - relation_type: prov:hadPrimarySource
+        source: jaspar
+      - relation_type: prov:hadPrimarySource
+        source: lipidmaps
+      - relation_type: prov:hadPrimarySource
+        source: mesh
+      - relation_type: prov:hadPrimarySource
+        source: mirdb
+      - relation_type: prov:hadPrimarySource
+        source: mondo
+      - relation_type: prov:hadPrimarySource
+        source: msigdb
+      - relation_type: prov:hadPrimarySource
+        source: ncbigene
+      - relation_type: prov:hadPrimarySource
+        source: ncbitaxon
+      - relation_type: prov:hadPrimarySource
+        source: orphanet
+      - relation_type: prov:hadPrimarySource
+        source: pdb
+      - relation_type: prov:hadPrimarySource
+        source: pharmgkb
+      - relation_type: prov:hadPrimarySource
+        source: pubchem
+      - relation_type: prov:hadPrimarySource
+        source: reactome
+      - relation_type: prov:hadPrimarySource
+        source: refseq
+      - relation_type: prov:hadPrimarySource
+        source: rhea
+      - relation_type: prov:hadPrimarySource
+        source: rnacentral
+      - relation_type: prov:hadPrimarySource
+        source: signor
+      - relation_type: prov:hadPrimarySource
+        source: string
+      - relation_type: prov:hadPrimarySource
+        source: surechembl
+      - relation_type: prov:hadPrimarySource
+        source: swisslipid
+      - relation_type: prov:hadPrimarySource
+        source: uberon
+      - relation_type: prov:hadPrimarySource
+        source: uniprot
+    predicates:
+      - biolink:actively_involved_in
+      - biolink:affects
+      - biolink:associated_with
+      - biolink:close_match
+      - biolink:derives_from
+      - biolink:directly_physically_interacts_with
+      - biolink:enables
+      - biolink:expressed_in
+      - biolink:gene_associated_with_condition
+      - biolink:gene_product_of
+      - biolink:has_adverse_event
+      - biolink:has_gene_product
+      - biolink:has_part
+      - biolink:has_participant
+      - biolink:has_phenotype
+      - biolink:in_clinical_trials_for
+      - biolink:in_taxon
+      - biolink:interacts_with
+      - biolink:is_sequence_variant_of
+      - biolink:located_in
+      - biolink:member_of
+      - biolink:mentions
+      - biolink:orthologous_to
+      - biolink:paralogous_to
+      - biolink:participates_in
+      - biolink:physically_interacts_with
+      - biolink:related_to
+      - biolink:same_as
+      - biolink:subclass_of
+      - biolink:transcribed_from
+      - biolink:translates_to
+      - biolink:treats_or_applied_or_studied_to_treat
     product_url: https://zenodo.org/records/20816742
   - category: ProgrammingInterface
     description: REST API for searching identifiers and special keywords, mapping between data sources with a chain-query syntax, and retrieving entries across the integrated BioBTree databases.

--- a/resource/biobtree/biobtree.md
+++ b/resource/biobtree/biobtree.md
@@ -18,13 +18,28 @@ domains:
   - clinical
 homepage_url: https://sugi.bio/biobtree/
 id: biobtree
-last_modified_date: '2026-06-15T00:00:00Z'
+last_modified_date: '2026-06-24T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.gnu.org/licenses/agpl-3.0.en.html
   label: AGPL-3.0
 name: BioBTree
 products:
+  - category: GraphProduct
+    compression: gzip
+    description: Human-scoped, Neo4j-ready subgraph of the BioBTree knowledge graph, exported as a biolink-typed KGX graph (~40M nodes / ~132M edges, ~8.3 GB compressed across separate node and edge files). A practical projection of the full graph for human-centric biomedical use. Published on Zenodo.
+    edge_count: 132000000
+    format: kgx
+    id: biobtree.graph.human-subgraph
+    license:
+      id: https://creativecommons.org/licenses/by-nc-sa/4.0/
+      label: CC-BY-NC-SA-4.0
+    name: BioBTree Knowledge Graph - Human Subgraph (KGX)
+    node_count: 40000000
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: biobtree
+    product_url: https://zenodo.org/records/20816742
   - category: ProgrammingInterface
     description: REST API for searching identifiers and special keywords, mapping between data sources with a chain-query syntax, and retrieving entries across the integrated BioBTree databases.
     format: http


### PR DESCRIPTION
Addresses #630 (the BioBTree page already exists; this adds the graph dumps).

## Change

Adds BioBTree's published graph dump as a `GraphProduct`, placed first since it's the headline artifact for a knowledge-graph resource:

| Field | Value |
|---|---|
| Name | BioBTree Knowledge Graph - Human Subgraph (KGX) |
| Category | GraphProduct |
| Format / compression | `kgx` / `gzip` |
| Size | ~40M nodes / ~132M edges, ~8.3 GB compressed |
| License | CC-BY-NC-SA-4.0 |
| URL | https://zenodo.org/records/20816742 (DOI 10.5281/zenodo.20816742) |

Details confirmed against the Zenodo record and the repo's `docs/kg_export` (biolink-typed KGX, separate node/edge TSV+JSONL `.gz` files).

## Complete dump deferred

The ticket also mentions a **complete dump** (~136M nodes / ~1.16B edges). That one is produced by the export feature but I couldn't find it hosted at any downloadable URL (not on Zenodo, the website, or the repo), so it's left out for now rather than pointing at a placeholder. Happy to add it once there's a real download link.

Validated with `make validate-file FILE=resource/biobtree/biobtree.md` (passes clean). The publication-reference cache change is the validator recording biobtree's two existing publications as valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)