### PR TITLE
Add 48 BER-relevant resources to the `ber` collection

### DIFF
--- a/resource/agro/agro.md
+++ b/resource/agro/agro.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   label: Marie-Ang lique Laporte

--- a/resource/aop-db/aop-db.md
+++ b/resource/aop-db/aop-db.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Aggregator
 collection:
 - aop
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/aop-wiki/aop-wiki.md
+++ b/resource/aop-wiki/aop-wiki.md
@@ -3,6 +3,7 @@ activity_status: active
 category: DataSource
 collection:
 - aop
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/araport/araport.md
+++ b/resource/araport/araport.md
@@ -1,6 +1,8 @@
 ---
 activity_status: inactive
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/bacdive/bacdive.md
+++ b/resource/bacdive/bacdive.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/bactotraits/bactotraits.md
+++ b/resource/bactotraits/bactotraits.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/bco/bco.md
+++ b/resource/bco/bco.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   label: Ramona Walls

--- a/resource/bv-brc/bv-brc.md
+++ b/resource/bv-brc/bv-brc.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/catalogue-of-life/catalogue-of-life.md
+++ b/resource/catalogue-of-life/catalogue-of-life.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: KnowledgeGraph
+collection:
+- ber
 contacts:
   - category: Organization
     contact_details:

--- a/resource/climatemodelskg/climatemodelskg.md
+++ b/resource/climatemodelskg/climatemodelskg.md
@@ -3,6 +3,7 @@ activity_status: active
 category: KnowledgeGraph
 collection:
 - okn
+- ber
 contacts:
 - category: Individual
   label: Aayush Acharya

--- a/resource/cog/cog.md
+++ b/resource/cog/cog.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 creation_date: '2026-01-30T00:00:00Z'
 description: A resource for orthology-based functional classification of proteins
   into clusters of orthologous groups (COGs) across complete genomes.

--- a/resource/cropland-data-layer/cropland-data-layer.md
+++ b/resource/cropland-data-layer/cropland-data-layer.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/ecocore/ecocore.md
+++ b/resource/ecocore/ecocore.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
   - obo-foundry
+  - ber
 contacts:
   - category: Individual
     label: Pier Luigi Buttigieg

--- a/resource/ecto/ecto.md
+++ b/resource/ecto/ecto.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   contact_details:

--- a/resource/envo/envo.md
+++ b/resource/envo/envo.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   contact_details:

--- a/resource/eo/eo.md
+++ b/resource/eo/eo.md
@@ -3,6 +3,7 @@ activity_status: inactive
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   contact_details:

--- a/resource/epa-aqs/epa-aqs.md
+++ b/resource/epa-aqs/epa-aqs.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/gbif/gbif.md
+++ b/resource/gbif/gbif.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/genophenoenvo-kg/genophenoenvo-kg.md
+++ b/resource/genophenoenvo-kg/genophenoenvo-kg.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: KnowledgeGraph
+collection:
+- ber
 creation_date: '2025-11-22T00:00:00Z'
 description: A knowledge graph integrating plant genomics, phenomics, and environmental data to predict gene expression patterns across multiple species under different environmental conditions, particularly drought stress
 domains:

--- a/resource/gomapman/gomapman.md
+++ b/resource/gomapman/gomapman.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/gtdb/gtdb.md
+++ b/resource/gtdb/gtdb.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/imodulondb/imodulondb.md
+++ b/resource/imodulondb/imodulondb.md
@@ -1,4 +1,6 @@
 ---
+collection:
+- ber
 layout: resource_detail
 activity_status: active
 category: DataSource

--- a/resource/maizegdb/maizegdb.md
+++ b/resource/maizegdb/maizegdb.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/mediadive/mediadive.md
+++ b/resource/mediadive/mediadive.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/metatraits/metatraits.md
+++ b/resource/metatraits/metatraits.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: KnowledgeGraph
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/metpo/metpo.md
+++ b/resource/metpo/metpo.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: Ontology
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/mgmlink/mgmlink.md
+++ b/resource/mgmlink/mgmlink.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: KnowledgeGraph
+collection:
+- ber
 contacts:
   - category: Individual
     contact_details:

--- a/resource/mgnify/mgnify.md
+++ b/resource/mgnify/mgnify.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: Aggregator
+collection:
+- ber
 creation_date: '2025-09-09T00:00:00Z'
 description: MGnify is an active aggregator and analysis platform for microbiome and metagenomic data, providing tools for submission, analysis, visualization, and discovery of microbiome datasets from diverse biomes and environments. It is operated by EMBL-EBI and is an ELIXIR Core Data Resource.
 domains:

--- a/resource/nasa-gesdisc-kg/nasa-gesdisc-kg.md
+++ b/resource/nasa-gesdisc-kg/nasa-gesdisc-kg.md
@@ -3,6 +3,7 @@ activity_status: active
 category: KnowledgeGraph
 collection:
 - okn
+- ber
 contacts:
 - category: Individual
   label: Lisa Stillwell

--- a/resource/ncbitaxon/ncbitaxon.md
+++ b/resource/ncbitaxon/ncbitaxon.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   contact_details:

--- a/resource/noaa-ncei/noaa-ncei.md
+++ b/resource/noaa-ncei/noaa-ncei.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/obis/obis.md
+++ b/resource/obis/obis.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
   - category: Organization
     contact_details:

--- a/resource/ohmi/ohmi.md
+++ b/resource/ohmi/ohmi.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   label: Yongqun Oliver He

--- a/resource/oma/oma.md
+++ b/resource/oma/oma.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/open-tree-of-life/open-tree-of-life.md
+++ b/resource/open-tree-of-life/open-tree-of-life.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
   - category: Organization
     contact_details:

--- a/resource/p3db/p3db.md
+++ b/resource/p3db/p3db.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
   - category: Organization
     contact_details:

--- a/resource/pco/pco.md
+++ b/resource/pco/pco.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
   - obo-foundry
+  - ber
 contacts:
   - category: Individual
     label: Ramona Walls

--- a/resource/phosphat/phosphat.md
+++ b/resource/phosphat/phosphat.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/planteome/planteome.md
+++ b/resource/planteome/planteome.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: Aggregator
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/progenomes/progenomes.md
+++ b/resource/progenomes/progenomes.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/pso/pso.md
+++ b/resource/pso/pso.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
   - obo-foundry
+  - ber
 contacts:
   - category: Individual
     label: Laurel Cooper

--- a/resource/rapdb/rapdb.md
+++ b/resource/rapdb/rapdb.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/sockg/sockg.md
+++ b/resource/sockg/sockg.md
@@ -3,6 +3,7 @@ activity_status: active
 category: KnowledgeGraph
 collection:
 - okn
+- ber
 contacts:
 - category: Individual
   label: Chengkai Li

--- a/resource/ssurgo/ssurgo.md
+++ b/resource/ssurgo/ssurgo.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/tair/tair.md
+++ b/resource/tair/tair.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:

--- a/resource/taxrank/taxrank.md
+++ b/resource/taxrank/taxrank.md
@@ -3,6 +3,7 @@ activity_status: active
 category: Ontology
 collection:
 - obo-foundry
+- ber
 contacts:
 - category: Individual
   label: Jim Balhoff

--- a/resource/tera/tera.md
+++ b/resource/tera/tera.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: KnowledgeGraph
+collection:
+- ber
 contacts:
   - category: Individual
     contact_details:

--- a/resource/usdm/usdm.md
+++ b/resource/usdm/usdm.md
@@ -1,6 +1,8 @@
 ---
 activity_status: active
 category: DataSource
+collection:
+- ber
 contacts:
 - category: Organization
   contact_details:


### PR DESCRIPTION
Tags 48 existing KG-Registry resources into the **`ber`** collection because they fall within the scope of DOE Biological and Environmental Research (BER).

**Change is frontmatter-only**: appends `ber` to the existing `collection` list, or adds a `collection` block where none existed. No other fields touched — **80 insertions, 0 deletions** across 48 files.

### Resources added, by theme

**Plant / agriculture / bioenergy (11):** agro, araport, tair, maizegdb, rapdb, planteome, pso, eo, p3db, phosphat, gomapman

**Microbiology / microbiome (13):** bacdive, bv-brc, bactotraits, gtdb, cog, progenomes, mediadive, metpo, imodulondb, mgnify, metatraits, mgmlink, ohmi

**Environment / earth / ecology / taxonomy (21):** envo, ecto, ecocore, pco, bco, gbif, obis, catalogue-of-life, open-tree-of-life, ncbitaxon, taxrank, oma, genophenoenvo-kg, climatemodelskg, nasa-gesdisc-kg, sockg, ssurgo, cropland-data-layer, usdm, epa-aqs, noaa-ncei

**Environmental exposure / toxicology (3):** aop-wiki, aop-db, tera

🤖 Generated with [Claude Code](https://claude.com/claude-code)