### PR TITLE
Fix broken hetnetpy product link (#643)

### DIFF
--- a/resource/doid/doid.md
+++ b/resource/doid/doid.md
@@ -1237,7 +1237,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/drugbank/drugbank.md
+++ b/resource/drugbank/drugbank.md
@@ -1430,7 +1430,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/drugcentral/drugcentral.md
+++ b/resource/drugcentral/drugcentral.md
@@ -850,7 +850,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/go/go.md
+++ b/resource/go/go.md
@@ -4656,7 +4656,7 @@ products:
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
   format: python
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/hetionet/hetionet.hetnetpy.md
+++ b/resource/hetionet/hetionet.hetnetpy.md
@@ -1,0 +1,36 @@
+---
+category: ProcessProduct
+description: Python package for creating, querying, and operating on hetnets (heterogeneous
+  networks)
+id: hetionet.hetnetpy
+name: hetnetpy
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: hetionet
+- relation_type: prov:hadPrimarySource
+  source: ncbigene
+- relation_type: prov:hadPrimarySource
+  source: drugbank
+- relation_type: prov:hadPrimarySource
+  source: uberon
+- relation_type: prov:hadPrimarySource
+  source: doid
+- relation_type: prov:hadPrimarySource
+  source: mesh
+- relation_type: prov:hadPrimarySource
+  source: sider
+- relation_type: prov:hadPrimarySource
+  source: umls
+- relation_type: prov:hadPrimarySource
+  source: go
+- relation_type: prov:hadPrimarySource
+  source: wikipathways
+- relation_type: prov:hadPrimarySource
+  source: reactome
+- relation_type: prov:hadPrimarySource
+  source: pid
+- relation_type: prov:hadPrimarySource
+  source: drugcentral
+product_url: https://github.com/hetio/hetnetpy
+layout: product_detail
+---

--- a/resource/hetionet/hetionet.md
+++ b/resource/hetionet/hetionet.md
@@ -200,7 +200,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/mesh/mesh.md
+++ b/resource/mesh/mesh.md
@@ -1113,7 +1113,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/ncbigene/ncbigene.md
+++ b/resource/ncbigene/ncbigene.md
@@ -1331,7 +1331,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/pid/pid.md
+++ b/resource/pid/pid.md
@@ -420,7 +420,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/reactome/reactome.md
+++ b/resource/reactome/reactome.md
@@ -4114,7 +4114,7 @@ products:
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
   format: python
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/sider/sider.md
+++ b/resource/sider/sider.md
@@ -1339,7 +1339,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/uberon/uberon.md
+++ b/resource/uberon/uberon.md
@@ -1721,7 +1721,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/umls/umls.md
+++ b/resource/umls/umls.md
@@ -775,7 +775,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/wikipathways/wikipathways.md
+++ b/resource/wikipathways/wikipathways.md
@@ -1652,7 +1652,7 @@ products:
 - category: ProcessProduct
   description: Python package for creating, querying, and operating on hetnets (heterogeneous
     networks)
-  id: hetnetpy
+  id: hetionet.hetnetpy
   name: hetnetpy
   original_source:
   - relation_type: prov:hadPrimarySource


### PR DESCRIPTION
Fixes #643.

## Problem

The `hetnetpy` product (a Python package from the Hetionet project) used the bare id `hetnetpy` with no owning-resource prefix. The site builds product links from the segment before the first `.` in the id and treats it as the owning resource, so it pointed every reference at `resource/hetnetpy/hetnetpy.html` — a resource that doesn't exist (404). No product page was generated either, since pages are only built for product ids that start with their owning resource's id.

Result: broken links from every resource that references hetnetpy (uberon, go, drugcentral, and 10 others).

## Fix

- Rename the product id from `hetnetpy` to `hetionet.hetnetpy` across all 13 resources that reference it. The display `name` stays `hetnetpy`.
- Add the generated product page at `resource/hetionet/hetionet.hetnetpy.md`.

Links now resolve to `resource/hetionet/hetionet.hetnetpy.html`.

## Notes

- Each of the 13 resource edits is a single-line id change; no unrelated churn.
- `make`-style schema validation passes on the affected files.
- No dangling `source: hetnetpy` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)