### PR TITLE
Metadata curation: fix data-quality issues on 50 resources

### DIFF
--- a/resource/batman/batman.md
+++ b/resource/batman/batman.md
@@ -1,6 +1,17 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: lidong.bprc@foxmail.com
+  label: Dong Li
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: liuzy1984@163.com
+  label: Zhongyang Liu
 creation_date: '2026-02-18T00:00:00Z'
 description: BATMAN-TCM is a web resource and database for known and predicted interactions
   between traditional Chinese medicine ingredients and target proteins, supporting

--- a/resource/bioportal/bioportal.md
+++ b/resource/bioportal/bioportal.md
@@ -1,6 +1,14 @@
 ---
 activity_status: active
 category: Aggregator
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: support@bioontology.org
+  - contact_type: url
+    value: https://www.bioontology.org/
+  label: National Center for Biomedical Ontology (NCBO), Stanford
 creation_date: '2025-08-20T00:00:00Z'
 description: BioPortal is a comprehensive open repository and portal for biomedical
   ontologies and terminologies, providing search, browsing, mappings, versioned downloads,
@@ -11,6 +19,7 @@ domains:
 - clinical
 - information technology
 - general
+homepage_url: https://bioportal.bioontology.org/
 id: bioportal
 infores_id: bioportal
 last_modified_date: '2025-09-16T00:00:00Z'
@@ -226,6 +235,7 @@ taxon:
 warnings:
 - Some ontologies have distinct licenses; review individual ontology license metadata
   before reuse.
+repository: https://github.com/ncbo
 ---
 # BioPortal
 

--- a/resource/bridge2ai/bridge2ai.md
+++ b/resource/bridge2ai/bridge2ai.md
@@ -90,6 +90,47 @@ products:
     source: orcid
   - relation_type: prov:wasInfluencedBy
     source: bridge2ai
+publications:
+- authors:
+  - Timothy Clark
+  - Harry Caufield
+  - Jillian A Parker
+  - Sadnan Al Manir
+  - Edilberto Amorim
+  - James Eddy
+  - Nayoon Gim
+  - Brian Gow
+  - Wesley Goar
+  - Jan N Hansen
+  - Nomi Harris
+  - Henning Hermjakob
+  - Marcin Joachimiak
+  - Gianna Jordan
+  - In-Hee Lee
+  - Shannon K McWeeney
+  - Camille Nebeker
+  - Milen Nikolov
+  - Sarah J Ratcliffe
+  - Justin Reese
+  - Jamie Shaffer
+  - Nathan Sheffield
+  - Gloria Sheynkman
+  - James Stevenson
+  - Jake Y Chen
+  - Chris Mungall
+  - Alex Wagner
+  - Sek Won Kong
+  - Satrajit S Ghosh
+  - Bhavesh Patel
+  - Andrew Williams
+  - Monica C Munoz-Torres
+  doi: 10.1101/2024.10.23.619844
+  id: https://www.ncbi.nlm.nih.gov/pubmed/39484409
+  journal: bioRxiv
+  preferred: true
+  title: 'AI-readiness for Biomedical Data: Bridge2AI Recommendations'
+  year: '2024'
+repository: https://github.com/bridge2ai
 synonyms:
 - Bridge2AI
 - Bridge to Artificial Intelligence

--- a/resource/cabi-isc/cabi-isc.md
+++ b/resource/cabi-isc/cabi-isc.md
@@ -21,6 +21,9 @@ homepage_url: https://www.cabidigitallibrary.org/product/qi
 id: cabi-isc
 last_modified_date: '2026-07-03T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://www.cabidigitallibrary.org/terms-and-conditions
+  label: CABI Digital Library Terms and Conditions (proprietary / subscription)
 name: CABI Invasive Species Compendium
 products:
 - category: GraphicalInterface

--- a/resource/campbell-biology/campbell-biology.md
+++ b/resource/campbell-biology/campbell-biology.md
@@ -1,7 +1,12 @@
 ---
 activity_status: active
 category: DataSource
-contacts: []
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://www.pearson.com/en-us/subject-catalog/p/campbell-biology/P200000007019
+  label: Pearson Education
 creation_date: '2026-07-03T00:00:00Z'
 description: Campbell Biology (by Reece, Urry, Cain, Wasserman, Minorsky, and Jackson;
   published by Pearson) is a widely used undergraduate introductory biology textbook.
@@ -14,6 +19,9 @@ homepage_url: https://openlibrary.org/isbn/9780134093413
 id: campbell-biology
 last_modified_date: '2026-07-03T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://www.pearson.com/en-us/legal-information/terms-of-use.html
+  label: Pearson — proprietary / all rights reserved
 name: Campbell Biology
 products:
 - category: Product

--- a/resource/ccle/ccle.md
+++ b/resource/ccle/ccle.md
@@ -13,6 +13,9 @@ homepage_url: https://sites.broadinstitute.org/ccle/
 id: ccle
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: CCLE
 products:
 - category: DocumentationProduct

--- a/resource/cellxgene/cellxgene.md
+++ b/resource/cellxgene/cellxgene.md
@@ -20,7 +20,11 @@ homepage_url: https://cellxgene.cziscience.com/
 id: cellxgene
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
 name: CZ CELLxGENE
+repository: https://github.com/chanzuckerberg/single-cell-data-portal
 products:
 - category: GraphicalInterface
   description: Main CZ CELLxGENE Discover portal for browsing public single-cell collections,
@@ -416,6 +420,18 @@ products:
     source: mondo
   - relation_type: prov:wasInfluencedBy
     source: hsapdv
+publications:
+- id: https://doi.org/10.1093/nar/gkae1142
+  authors:
+  - Shibla Abdulla
+  - Brian Aevermann
+  - CZI Cell Science Program
+  doi: 10.1093/nar/gkae1142
+  journal: Nucleic Acids Research
+  preferred: true
+  title: 'CZ CELLxGENE Discover: a single-cell data platform for scalable exploration,
+    analysis and modeling of aggregated data'
+  year: '2025'
 ---
 # CZ CELLxGENE
 

--- a/resource/clinical-data-kp/clinical-data-kp.md
+++ b/resource/clinical-data-kp/clinical-data-kp.md
@@ -26,7 +26,11 @@ homepage_url: https://ncats.nih.gov/research/research-activities/translator/proj
 id: clinical-data-kp
 last_modified_date: '2026-02-20T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by-nc-sa/4.0/
+  label: CC BY-NC-SA 4.0
 name: Clinical Data KP
+repository: https://github.com/WengLab-InformaticsResearch/cohd_api
 products:
   - category: GraphicalInterface
     description: Translator project portal describing clinical data provider activities.
@@ -46,6 +50,20 @@ products:
       - source: clinical-data-kp
         relation_type: prov:hadPrimarySource
     product_url: https://github.com/NCATSTranslator/Translator-All/wiki/Clinical-Data-Provider
+publications:
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/30480666
+    authors:
+      - Casey N. Ta
+      - Michel Dumontier
+      - George Hripcsak
+      - Nicholas P. Tatonetti
+      - Chunhua Weng
+    doi: 10.1038/sdata.2018.273
+    journal: Scientific Data
+    preferred: true
+    title: Columbia Open Health Data, clinical concept prevalence and co-occurrence
+      from electronic health records
+    year: '2018'
 taxon:
   - NCBITaxon:9606
 creation_date: '2025-03-09T00:00:00Z'

--- a/resource/compath/compath.md
+++ b/resource/compath/compath.md
@@ -1,6 +1,17 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: daniel.domingo.fernandez@scai.fraunhofer.de
+  label: Daniel Domingo-Fernández
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://www.scai.fraunhofer.de/
+  label: Fraunhofer SCAI
 creation_date: '2026-01-28T00:00:00Z'
 description: A pathway mapping and harmonization framework for integrating and comparing
   pathway knowledge across multiple pathway databases.
@@ -11,6 +22,9 @@ homepage_url: https://compath.scai.fraunhofer.de/
 id: compath
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://opensource.org/licenses/MIT
+  label: MIT License
 name: ComPath
 products:
 - category: GraphicalInterface
@@ -368,6 +382,7 @@ publications:
   title: 'ComPath: an ecosystem for exploring, analyzing, and curating mappings across
     pathway databases'
   year: '2019'
+repository: https://github.com/ComPath/ComPath
 synonyms:
 - ComPath
 ---

--- a/resource/cpathkg/cpathkg.md
+++ b/resource/cpathkg/cpathkg.md
@@ -16,9 +16,11 @@ contacts:
 description: The C-Path Knowledge Graph project is intended to increase discoverability of rare disease datasets through integration with the Monarch Knowlege Graph.
 domains:
   - biomedical
+homepage_url: https://gitlab.c-path.org/c-pathontology/c-path-knowledge-graph-integration
 id: cpathkg
 layout: resource_detail
 name: C-Path Knowledge Graph
+repository: https://gitlab.c-path.org/c-pathontology/c-path-knowledge-graph-integration
 products:
   - category: ProcessProduct
     description: This repository is a code reference for the C-Path Knowledge Graph project, to increase discoverability of rare disease datasets through integration with the Monarch Knowlege Graph. Note that this is only a reference to scripts and queries associated with this project and is not provided as a runnable project because these workflows depend on an internal data catalog.

--- a/resource/epa-srs/epa-srs.md
+++ b/resource/epa-srs/epa-srs.md
@@ -16,10 +16,14 @@ homepage_url: https://cdxapps.epa.gov/oms-substance-registry-services/about-srs
 id: epa-srs
 last_modified_date: '2026-06-03T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://edg.epa.gov/epa_data_license.html
+  label: EPA Standard Open Data License
 name: EPA Substance Registry Services
 products:
   - category: GraphicalInterface
     description: Public EPA Substance Registry Services search interface for looking up substances tracked or regulated by EPA programs and other sources.
+    format: http
     id: epa-srs.search
     name: EPA SRS Search
     original_source:
@@ -28,6 +32,7 @@ products:
     product_url: https://cdxapps.epa.gov/oms-substance-registry-services/search
   - category: DocumentationProduct
     description: EPA overview page explaining Substance Registry Services as the central EPA system for substance information and program-list membership.
+    format: http
     id: epa-srs.about
     name: About EPA Substance Registry Services
     original_source:
@@ -36,6 +41,7 @@ products:
     product_url: https://cdxapps.epa.gov/oms-substance-registry-services/about-srs
   - category: ProgrammingInterface
     description: EPA SRS widget service for embedding a Substance Registry Services search box in external web pages.
+    format: http
     id: epa-srs.widget
     is_public: true
     name: EPA SRS Widget

--- a/resource/fire/fire.md
+++ b/resource/fire/fire.md
@@ -1,6 +1,17 @@
 ---
 activity_status: inactive
 category: DataSource
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: hum@ccf.org
+  label: Ming Hu
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: biren@ucsd.edu
+  label: Bing Ren
 creation_date: '2026-06-18T00:00:00Z'
 description: FIRE (Frequently Interacting REgions) are genomic regions that participate
   in an unusually high number of local chromatin interactions, identified from high-throughput
@@ -28,6 +39,7 @@ products:
   description: Schmitt et al. (2016) compendium of chromatin contact maps and Frequently
     Interacting REgions, distributed via the PubMed Central article record and its
     supplementary data.
+  format: http
   id: fire.publication
   name: FIRE compendium of chromatin contact maps
   original_source:
@@ -110,6 +122,7 @@ publications:
   title: A Compendium of Chromatin Contact Maps Reveals Spatially Active Regions in
     the Human Genome
   year: '2016'
+repository: https://github.com/yycunc/FIREcaller
 ---
 FIRE (Frequently Interacting REgions) identifies genomic regions that frequently
 take part in local chromatin interactions, called from Hi-C data. Introduced by

--- a/resource/flybase/flybase.md
+++ b/resource/flybase/flybase.md
@@ -1,6 +1,12 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://flybase.org/contact/email
+  label: FlyBase
 creation_date: '2025-09-09T00:00:00Z'
 description: FlyBase is a comprehensive database of genomic and genetic data for Drosophila
   melanogaster (fruit fly) and related species. It provides curated information on
@@ -19,6 +25,9 @@ id: flybase
 infores_id: flybase
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
 name: FlyBase
 products:
 - category: Product

--- a/resource/gene2phenotype/gene2phenotype.md
+++ b/resource/gene2phenotype/gene2phenotype.md
@@ -1,6 +1,17 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: hvf21@cam.ac.uk
+  label: Helen V. Firth
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: seh@ebi.ac.uk
+  label: Sarah E. Hunt
 creation_date: '2026-01-23T00:00:00Z'
 description: A curated gene-disease evidence resource linking genes, variant mechanisms,
   and clinical phenotypes to support rare disease interpretation.
@@ -13,6 +24,9 @@ id: gene2phenotype
 infores_id: gene2phenotype
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://www.ebi.ac.uk/about/terms-of-use/
+  label: EMBL-EBI Terms of Use
 name: Gene2Phenotype
 products:
 - category: GraphicalInterface
@@ -202,6 +216,45 @@ products:
     source: orphanet
   product_file_size: 142045
   product_url: https://github.com/biothings/pending.api/blob/translator-output/plugins/ebi_gene2phenotype/EBIgene2pheno_trapi_edges.jsonl
+publications:
+- id: https://www.ncbi.nlm.nih.gov/pubmed/39506859
+  authors:
+  - T. Michael Yates
+  - Morad Ansari
+  - Louise Thompson
+  - Sarah E. Hunt
+  - Elena Cibrian Uhalte
+  - Rachel J. Hobson
+  - Joseph A. Marsh
+  - Caroline F. Wright
+  - Helen V. Firth
+  doi: 10.1186/s13073-024-01398-1
+  journal: Genome Medicine
+  preferred: true
+  title: Curating genomic disease-gene relationships with Gene2Phenotype (G2P)
+  year: '2024'
+- id: https://www.ncbi.nlm.nih.gov/pubmed/31147538
+  authors:
+  - Anja Thormann
+  - Mihail Halachev
+  - William McLaren
+  - David J. Moore
+  - Victoria Svinti
+  - Archie Campbell
+  - Shona M. Kerr
+  - Marc Tischkowitz
+  - Sarah E. Hunt
+  - Malcolm G. Dunlop
+  - Matthew E. Hurles
+  - Caroline F. Wright
+  - Helen V. Firth
+  - Fiona Cunningham
+  - David R. FitzPatrick
+  doi: 10.1038/s41467-019-10016-3
+  journal: Nature Communications
+  title: Flexible and scalable diagnostic filtering of genomic variants using G2P with
+    Ensembl VEP
+  year: '2019'
 repository: https://github.com/EBI-G2P/gene2phenotype_api
 synonyms:
 - G2P

--- a/resource/geneprof/geneprof.md
+++ b/resource/geneprof/geneprof.md
@@ -21,6 +21,17 @@ products:
       - source: geneprof
         relation_type: prov:hadPrimarySource
     product_url: https://github.com/NCATSTranslator/Translator-All/wiki/GeneProf
+publications:
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/22205509
+    authors:
+      - Florian Halbritter
+      - Harsh J. Vaidya
+      - Simon R. Tomlinson
+    doi: 10.1038/nmeth.1809
+    journal: Nature Methods
+    preferred: true
+    title: 'GeneProf: analysis of high-throughput sequencing experiments'
+    year: '2012'
 ---
 
 # GeneProf

--- a/resource/geoconnex/geoconnex.md
+++ b/resource/geoconnex/geoconnex.md
@@ -11,11 +11,6 @@ contacts:
     value: apadilla@lincolninst.edu
   - contact_type: github
     value: adplincinst
-- category: Individual
-  contact_details:
-  - contact_type: email
-    value: apadilla@lincolninst.edu
-  label: Andrew Padilla
 description: Geoconnex is an open, community-driven knowledge graph linking U.S. hydrologic
   features to enable seamless water data discovery, access, and collaborative monitoring.
 domains:
@@ -23,7 +18,11 @@ domains:
 homepage_url: https://docs.geoconnex.us/about/intro
 id: geoconnex
 layout: resource_detail
+license:
+  id: https://creativecommons.org/publicdomain/zero/1.0/
+  label: CC0 1.0
 name: GEOCONNEX
+repository: https://github.com/internetofwater/geoconnex.us
 products:
 - category: ProgrammingInterface
   description: SPARQL endpoint for GEOCONNEX
@@ -38,6 +37,7 @@ products:
   name: GEOCONNEX TPF
   description: Triple Pattern Fragments endpoint for GEOCONNEX
   category: ProgrammingInterface
+  format: http
   product_url: https://apps.okn.us/ldf/geoconnex
   original_source:
   - source: geoconnex

--- a/resource/icd10cm/icd10cm.md
+++ b/resource/icd10cm/icd10cm.md
@@ -3,6 +3,14 @@ activity_status: active
 category: Ontology
 collection:
 - omop
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: nchsicd10cm@cdc.gov
+  - contact_type: url
+    value: https://www.cdc.gov/nchs/icd/icd-10-cm/index.html
+  label: NCHS ICD-10-CM (National Center for Health Statistics, CDC)
 creation_date: '2025-10-30T00:00:00Z'
 description: ICD-10-CM (International Classification of Diseases, 10th Revision, Clinical
   Modification) is a clinical modification of the WHO's ICD-10 system, providing diagnostic

--- a/resource/immport/immport.md
+++ b/resource/immport/immport.md
@@ -23,6 +23,9 @@ homepage_url: https://immport.niaid.nih.gov/home
 id: immport
 last_modified_date: '2026-07-02T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://docs.immport.org/home/agreement/
+  label: ImmPort User Agreement (custom data use agreement)
 name: ImmPort
 products:
 - category: DataSource
@@ -66,6 +69,29 @@ products:
     source: pdb
   - relation_type: prov:wasInfluencedBy
     source: lincs
+publications:
+- id: https://www.ncbi.nlm.nih.gov/pubmed/29485622
+  authors:
+  - Sanchita Bhattacharya
+  - Patrick Dunn
+  - Cristel G. Thomas
+  - Barry Smith
+  - Henry Schaefer
+  - Jieming Chen
+  - Zicheng Hu
+  - Kelly A. Zalocusky
+  - Ravi D. Shankar
+  - Shai S. Shen-Orr
+  - Elizabeth Thomson
+  - Jeffrey Wiser
+  - Atul J. Butte
+  doi: 10.1038/sdata.2018.15
+  journal: Scientific Data
+  preferred: true
+  title: ImmPort, toward repurposing of open access immunological assay data for translational
+    and clinical research
+  year: '2018'
+repository: https://github.com/ImmPortDB
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/imr/imr.md
+++ b/resource/imr/imr.md
@@ -1,9 +1,11 @@
 ---
 id: imr
 name: Molecule role (INOH Protein name/family name ontology)
-description: Description unavailable.
+description: A structured controlled vocabulary of concrete and generic (abstract)
+  protein names, developed as an INOH pathway-annotation ontology for use in signal-transduction
+  pathway data annotation and integration.
 activity_status: inactive
-homepage_url: http://www.inoh.org
+homepage_url: https://obofoundry.org/ontology/imr.html
 license:
   id: ''
   label: Not specified

--- a/resource/iproclass/iproclass.md
+++ b/resource/iproclass/iproclass.md
@@ -11,6 +11,12 @@ last_modified_date: '2026-02-20T00:00:00Z'
 layout: resource_detail
 name: iProClass
 homepage_url: http://pir.georgetown.edu/iproclass/
+contacts:
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://proteininformationresource.org/
+    label: Protein Information Resource (PIR)
 synonyms:
   - iProClass
   - Integrated Protein Classification
@@ -33,6 +39,30 @@ products:
       - source: iproclass
         relation_type: prov:hadPrimarySource
     product_url: https://proteininformationresource.org/
+publications:
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/12520030
+    authors:
+      - Hongzhan Huang
+      - Winona C. Barker
+      - Yongxing Chen
+      - Cathy H. Wu
+    doi: 10.1093/nar/gkg044
+    journal: Nucleic Acids Research
+    preferred: true
+    title: 'iProClass: an integrated database of protein family, function and structure
+      information'
+    year: '2003'
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/15022647
+    authors:
+      - Cathy H. Wu
+      - Hongzhan Huang
+      - Anastasia Nikolskaya
+      - Zhanghi Hu
+      - Winona C. Barker
+    doi: 10.1016/j.compbiolchem.2003.10.003
+    journal: Computational Biology and Chemistry
+    title: The iProClass integrated database for protein functional analysis
+    year: '2004'
 ---
 
 # iProClass

--- a/resource/kg-ebi-gene2pheno/kg-ebi-gene2pheno.md
+++ b/resource/kg-ebi-gene2pheno/kg-ebi-gene2pheno.md
@@ -14,6 +14,10 @@ contacts:
 description: An ingest of EMBL-EBI's Gene2Phenotype resource, for Translator use (output in Translator standards and NodeNormed, using own custom pipeline)
 domains:
   - biomedical
+homepage_url: https://www.ebi.ac.uk/gene2phenotype/
+license:
+  id: https://www.ebi.ac.uk/about/terms-of-use/
+  label: EMBL-EBI Terms of Use
 id: kg-ebi-gene2pheno
 layout: resource_detail
 name: EBI Gene2Phenotype KG
@@ -73,6 +77,45 @@ products:
       - source: orphanet
         relation_type: prov:wasDerivedFrom
 repository: https://github.com/biothings/pending.api/tree/translator-output/plugins/ebi_gene2phenotype
+publications:
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/39506859
+    authors:
+      - T Michael Yates
+      - Morad Ansari
+      - Louise Thompson
+      - Sarah E Hunt
+      - Elena Cibrian Uhalte
+      - Rachel J Hobson
+      - Joseph A Marsh
+      - Caroline F Wright
+      - Helen V Firth
+    doi: 10.1186/s13073-024-01398-1
+    journal: Genome Medicine
+    preferred: true
+    title: Curating genomic disease-gene relationships with Gene2Phenotype (G2P)
+    year: '2024'
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/31147538
+    authors:
+      - Anja Thormann
+      - Mihail Halachev
+      - William McLaren
+      - David J Moore
+      - Victoria Svinti
+      - Archie Campbell
+      - Shona M Kerr
+      - Marc Tischkowitz
+      - Sarah E Hunt
+      - Malcolm G Dunlop
+      - Matthew E Hurles
+      - Caroline F Wright
+      - Helen V Firth
+      - Fiona Cunningham
+      - David R FitzPatrick
+    doi: 10.1038/s41467-019-10016-3
+    journal: Nature Communications
+    title: Flexible and scalable diagnostic filtering of genomic variants using G2P
+      with Ensembl VEP
+    year: '2019'
 creation_date: '2025-05-07T00:00:00Z'
 last_modified_date: '2026-06-18T00:00:00Z'
 ---

--- a/resource/labeledin/labeledin.md
+++ b/resource/labeledin/labeledin.md
@@ -17,10 +17,14 @@ homepage_url: https://doi.org/10.1016/j.jbi.2014.08.004
 id: labeledin
 last_modified_date: '2026-06-03T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://www.usa.gov/government-works
+  label: U.S. Government Work (public domain)
 name: LabeledIn
 products:
   - category: Product
     description: LabeledIn indication corpus described in the source publication, containing human-reviewed drug-disease treatment relationships with links back to source drug labels.
+    format: http
     id: labeledin.indications
     name: LabeledIn Drug Indication Corpus
     original_source:
@@ -34,6 +38,7 @@ products:
         source: rxnorm
   - category: DocumentationProduct
     description: Publication describing the LabeledIn corpus construction workflow, including drug label selection, automatic disease recognition, and manual indication annotation.
+    format: http
     id: labeledin.publication
     name: LabeledIn Publication
     original_source:

--- a/resource/lipro/lipro.md
+++ b/resource/lipro/lipro.md
@@ -3,6 +3,7 @@ id: lipro
 name: Lipid Ontology
 description: An ontology representation of the LIPIDMAPS nomenclature classification.
 activity_status: inactive
+homepage_url: https://obofoundry.org/ontology/lipro.html
 license:
   id: ''
   label: Not specified
@@ -21,7 +22,18 @@ contacts:
   contact_details:
   - contact_type: email
     value: bakerc@unb.ca
-products: []
+products:
+- id: lipro.owl
+  name: Lipid Ontology OWL product
+  description: OWL-DL edition of the Lipid Ontology (LiPrO), representing the LIPIDMAPS
+    nomenclature classification. Served as an archived mirror via AberOWL; the original
+    OBO PURL no longer resolves.
+  category: OntologyProduct
+  format: owl
+  product_url: http://aber-owl.net/media/ontologies/LIPRO/4/lipro.owl
+  original_source:
+  - source: lipro
+    relation_type: prov:hadPrimarySource
 publications:
 - authors:
   - Chepelev LL

--- a/resource/loggerhead/loggerhead.md
+++ b/resource/loggerhead/loggerhead.md
@@ -1,9 +1,12 @@
 ---
 id: loggerhead
 name: Loggerhead nesting
-description: Description unavailable.
+description: An ontology for loggerhead sea turtle (Caretta caretta) nesting behavior,
+  based on the published ethogram of Hailman and Elowson, demonstrating ontology construction
+  as a technique for coding ethograms into machine-understandable forms. It is obsolete/deprecated
+  in the OBO Foundry.
 activity_status: inactive
-homepage_url: http://www.mesquiteproject.org/ontology/Loggerhead/index.html
+homepage_url: https://obofoundry.org/ontology/loggerhead.html
 license:
   id: ''
   label: Not specified

--- a/resource/maudekg/maudekg.md
+++ b/resource/maudekg/maudekg.md
@@ -4,7 +4,7 @@ name: FDA MAUDE Adverse Event Knowledge Graph
 description: Knowledge graph constructed from FDA MAUDE adverse event reports using
   standardized FDA product codes.
 activity_status: active
-homepage_url: https://github.com/Prabhadeus/Proto-OKN
+homepage_url: https://frink.renci.org/maudekg
 contacts:
 - category: Individual
   contact_details:

--- a/resource/mgi/mgi.md
+++ b/resource/mgi/mgi.md
@@ -20,7 +20,11 @@ id: mgi
 infores_id: mgi
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
 name: Mouse Genome Informatics
+repository: https://github.com/mgijax
 products:
 - category: GraphicalInterface
   description: Main Mouse Genome Informatics portal for accessing mouse genes, alleles,

--- a/resource/mo/mo.md
+++ b/resource/mo/mo.md
@@ -33,13 +33,35 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: mo
-  product_url: http://purl.obolibrary.org/obo/mo.owl
+  product_url: http://web.archive.org/web/20250206194936/https://mged.sourceforge.net/ontologies/MGEDOntology.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-02: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-07-03: HTTP 404 error
-    when accessing file'
-publications: []
+  - 'The original OBO PURL (http://purl.obolibrary.org/obo/mo.owl) no longer resolves
+    (HTTP 404); product_url now points to a Wayback Machine archived snapshot of the
+    MGED Ontology OWL.'
+publications:
+- id: https://www.ncbi.nlm.nih.gov/pubmed/16428806
+  authors:
+  - Whetzel PL
+  - Parkinson H
+  - Causton HC
+  - Fan L
+  - Fostel J
+  - Fragoso G
+  - Game L
+  - Heiskanen M
+  - Morrison N
+  - Rocca-Serra P
+  - Sansone SA
+  - Taylor C
+  - White J
+  - Stoeckert CJ Jr
+  doi: 10.1093/bioinformatics/btl005
+  journal: Bioinformatics
+  preferred: true
+  title: 'The MGED Ontology: a resource for semantics-based description of microarray
+    experiments'
+  year: '2006'
+repository: https://sourceforge.net/projects/mged/
 use_instead:
 - obi
 ---

--- a/resource/nasa-gesdisc-kg/nasa-gesdisc-kg.md
+++ b/resource/nasa-gesdisc-kg/nasa-gesdisc-kg.md
@@ -12,11 +12,6 @@ contacts:
     value: lisa@renci.org
   - contact_type: github
     value: lstillwe
-- category: Individual
-  contact_details:
-  - contact_type: email
-    value: lisa@renci.org
-  label: Lisa Stillwell
 description: The NASA Knowledge Graph Dataset is an expansive graph-based dataset
   designed to integrate and interconnect information about satellite datasets, scientific
   publications, instruments, platforms, projects, data centers, and science keywords.
@@ -30,7 +25,11 @@ domains:
 homepage_url: https://disc.gsfc.nasa.gov
 id: nasa-gesdisc-kg
 layout: resource_detail
+license:
+  id: https://opensource.org/licenses/Apache-2.0
+  label: Apache-2.0
 name: NASA-GESDISC-KG
+repository: https://huggingface.co/datasets/nasa-gesdisc/nasa-eo-knowledge-graph
 products:
 - category: ProgrammingInterface
   description: SPARQL endpoint for NASA-GESDISC-KG
@@ -45,6 +44,7 @@ products:
   name: NASA-GESDISC-KG TPF
   description: Triple Pattern Fragments endpoint for NASA-GESDISC-KG
   category: ProgrammingInterface
+  format: http
   product_url: https://apps.okn.us/ldf/nasa-gesdisc-kg
   original_source:
   - source: nasa-gesdisc-kg
@@ -63,6 +63,21 @@ products:
   - source: nasa-gesdisc
     relation_type: prov:wasDerivedFrom
   product_url: https://frink.renci.org/nasa-gesdisc-kg
+publications:
+- id: doi:10.5334/dsj-2024-001
+  authors:
+  - Irina Gerasimov
+  - Andrey Savtchenko
+  - Jerome Alfred
+  - James Acker
+  - Jennifer Wei
+  - Binita Kc
+  doi: 10.5334/dsj-2024-001
+  journal: Data Science Journal
+  preferred: true
+  title: 'Bridging the Gap: Enhancing Prominence and Provenance of NASA Datasets in
+    Research Publications'
+  year: '2024'
 creation_date: '2025-12-08T00:00:00Z'
 last_modified_date: '2026-07-01T00:00:00Z'
 ---

--- a/resource/nde/nde.md
+++ b/resource/nde/nde.md
@@ -29,6 +29,9 @@ domains:
 homepage_url: https://data.niaid.nih.gov/
 id: nde
 layout: resource_detail
+license:
+  id: https://opensource.org/licenses/Apache-2.0
+  label: Apache-2.0
 name: NIAID Data Ecosystem KG
 products:
 - category: ProgrammingInterface
@@ -44,6 +47,7 @@ products:
   name: NIAID Data Ecosystem KG TPF
   description: Triple Pattern Fragments endpoint for NIAID Data Ecosystem KG
   category: ProgrammingInterface
+  format: http
   product_url: https://apps.okn.us/ldf/nde
   original_source:
   - source: nde
@@ -79,6 +83,37 @@ products:
     source: pdb
   - relation_type: prov:wasInfluencedBy
     source: lincs
+publications:
+- id: https://doi.org/10.48550/arXiv.2509.13524
+  authors:
+  - Ginger Tsueng
+  - Emily Bullen
+  - Candice Czech
+  - Dylan Welzel
+  - Leandro Collares
+  - Jason Lin
+  - Everaldo Rodolpho
+  - Zubair Qazi
+  - Nichollette Acosta
+  - Lisa M. Mayer
+  - Sudha Venkatachari
+  - Zorana Mitrović Vučičević
+  - Poromendro N. Burman
+  - Deepti Jain
+  - Jack DiGiovanna
+  - Maria Giovanni
+  - Asiyah Lin
+  - Wilbert Van Panhuis
+  - Laura D. Hughes
+  - Andrew I. Su
+  - Chunlei Wu
+  doi: 10.48550/arXiv.2509.13524
+  journal: arXiv
+  preferred: true
+  title: 'The NIAID Discovery Portal: A Unified Search Engine for Infectious and Immune-Mediated
+    Disease Datasets'
+  year: '2025'
+repository: https://github.com/NIAID-Data-Ecosystem/nde-crawlers
 taxon:
 - NCBITaxon:9606
 creation_date: '2025-12-08T00:00:00Z'

--- a/resource/nihreporter/nihreporter.md
+++ b/resource/nihreporter/nihreporter.md
@@ -22,6 +22,9 @@ homepage_url: https://reporter.nih.gov/
 id: nihreporter
 last_modified_date: '2025-09-24T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://www.usa.gov/government-works
+  label: U.S. Government Work (public domain)
 name: NIH Reporter
 products:
 - category: GraphicalInterface
@@ -64,6 +67,7 @@ products:
 - category: Product
   description: Database of patents linked to NIH-funded research projects
   id: nihreporter.patents
+  format: csv
   name: NIH-Funded Project Patents
   original_source:
   - relation_type: prov:hadPrimarySource
@@ -72,6 +76,7 @@ products:
 - category: Product
   description: Database of clinical studies linked to NIH-funded research projects
   id: nihreporter.clinicalstudies
+  format: csv
   name: NIH-Funded Project Clinical Studies
   original_source:
   - relation_type: prov:hadPrimarySource
@@ -89,6 +94,7 @@ products:
 - category: Product
   description: Database of publication link tables for NIH-funded research projects
   id: nihreporter.linktables
+  format: csv
   name: NIH-Funded Publications Link Tables
   original_source:
   - relation_type: prov:hadPrimarySource

--- a/resource/offsides/offsides.md
+++ b/resource/offsides/offsides.md
@@ -1,6 +1,19 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://tatonettilab.org/
+  - contact_type: github
+    value: tatonetti-lab
+  label: Tatonetti Lab
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: nicholas.tatonetti@cshs.org
+  label: Nicholas P. Tatonetti
 creation_date: '2025-07-08T00:00:00Z'
 description: OFFSIDES is a database of drug side effects that were found through data
   mining of FDA Adverse Event Reporting System (FAERS) but are not listed on the official
@@ -11,7 +24,11 @@ homepage_url: http://tatonettilab.org/offsides/
 id: offsides
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by-nc-sa/4.0/
+  label: CC-BY-NC-SA-4.0
 name: OFFSIDES
+repository: https://github.com/tatonetti-lab/nsides
 products:
 - category: DocumentationProduct
   description: Tatonetti Lab project page describing OffSIDES and related nSIDES resources.

--- a/resource/osv/osv.md
+++ b/resource/osv/osv.md
@@ -17,6 +17,9 @@ homepage_url: https://osv.dev/
 id: osv
 last_modified_date: '2026-07-03T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://opensource.org/licenses/Apache-2.0
+  label: Apache-2.0
 name: OSV (Open Source Vulnerabilities)
 products:
 - category: GraphicalInterface
@@ -53,6 +56,7 @@ products:
   - relation_type: prov:hadPrimarySource
     source: osv
   product_url: https://purdue-hcss.github.io/nsf-software-supply-chain_security/
+repository: https://github.com/google/osv.dev
 ---
 ## OSV (Open Source Vulnerabilities)
 

--- a/resource/pankbase/pankbase.md
+++ b/resource/pankbase/pankbase.md
@@ -36,11 +36,13 @@ name: PanKBase
 products:
 - category: GraphProduct
   description: Knowledge graph representation of human pancreas and diabetes data
+  format: http
   id: pankbase.graph
   name: PanKGraph
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pankbase
+  product_url: https://pankgraph.org/
 - category: GraphicalInterface
   description: Graphical interface for exploring the PanKGraph
   format: http
@@ -93,7 +95,24 @@ products:
   secondary_source:
   - relation_type: prov:wasInfluencedBy
     source: gene-expression-omnibus
-repository: https://github.com/PanKbase-DB
+publications:
+- authors:
+  - Ha T. H. Vu
+  - Han Sun
+  - Parul Kudtarkar
+  - Seth A. Sharp
+  - PanKbase Consortium
+  - Anna L. Gloyn
+  - Kyle J. Gaulton
+  - Stephen C. J. Parker
+  doi: 10.64898/2026.06.02.729719
+  id: https://www.ncbi.nlm.nih.gov/pubmed/42327171
+  journal: bioRxiv
+  preferred: true
+  title: 'PanKbase Integrated Single-Cell Map: A Comprehensive Atlas of Human Pancreatic
+    Islets'
+  year: '2026'
+repository: https://github.com/PanKbase
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/pao/pao.md
+++ b/resource/pao/pao.md
@@ -13,7 +13,9 @@ contacts:
   label: Pankaj Jaiswal
   orcid: 0000-0002-1005-8383
 creation_date: '2025-09-29T00:00:00Z'
-description: Description unavailable.
+description: Plant Anatomy Ontology, a controlled vocabulary for plant anatomical
+  and morphological structures. It is deprecated and has been superseded by the Plant
+  Ontology (PO).
 domains:
 - anatomy and development
 homepage_url: http://www.plantontology.org
@@ -26,38 +28,64 @@ license:
 name: Plant Anatomy Ontology
 products:
 - category: OntologyProduct
-  description: Plant Anatomy Ontology in OWL format
+  description: OWL edition of the plant anatomy content. The original Plant Anatomy
+    Ontology OBO PURL no longer resolves; product_url now points to the Plant Ontology
+    (PO), which superseded and absorbed the plant anatomy content.
   format: owl
   id: pao.owl
   name: pao.owl
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pao
-  product_url: http://purl.obolibrary.org/obo/pao.owl
+  product_url: http://purl.obolibrary.org/obo/po.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-02: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-22: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-07-03: HTTP 404 error
-    when accessing file'
+  - 'The original PAO OBO PURL (http://purl.obolibrary.org/obo/pao.owl) no longer resolves
+    (HTTP 404); product_url points to the successor Plant Ontology (PO) OWL.'
 - category: OntologyProduct
-  description: Plant Anatomy Ontology in OBO format
+  description: OBO edition of the plant anatomy content. The original Plant Anatomy
+    Ontology OBO PURL no longer resolves; product_url now points to the Plant Ontology
+    (PO), which superseded and absorbed the plant anatomy content.
   format: obo
   id: pao.obo
   name: pao.obo
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pao
-  product_url: http://purl.obolibrary.org/obo/pao.obo
+  product_url: http://purl.obolibrary.org/obo/po.obo
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-02: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-22: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-07-03: HTTP 404 error
-    when accessing file'
-publications: []
+  - 'The original PAO OBO PURL (http://purl.obolibrary.org/obo/pao.obo) no longer resolves
+    (HTTP 404); product_url points to the successor Plant Ontology (PO) OBO.'
+publications:
+- id: https://www.ncbi.nlm.nih.gov/pubmed/23220694
+  authors:
+  - Laurel Cooper
+  - Ramona L. Walls
+  - Justin Elser
+  - Maria A. Gandolfo
+  - Dennis W. Stevenson
+  - Barry Smith
+  - Justin Preece
+  - Balaji Athreya
+  - Christopher J. Mungall
+  - Stefan Rensing
+  - Manuel Hiss
+  - Daniel Lang
+  - Ralf Reski
+  - Tanya Z. Berardini
+  - Donghui Li
+  - Eva Huala
+  - Mary Schaeffer
+  - Naama Menda
+  - Elizabeth Arnaud
+  - Rosemary Shrestha
+  - Yukiko Yamazaki
+  - Pankaj Jaiswal
+  doi: 10.1093/pcp/pcs163
+  journal: Plant and Cell Physiology
+  preferred: true
+  title: The Plant Ontology as a Tool for Comparative Plant Anatomy and Genomic Analyses
+  year: '2013'
+repository: https://github.com/Planteome/plant-ontology
 taxon:
 - NCBITaxon:33090
 ---

--- a/resource/plo/plo.md
+++ b/resource/plo/plo.md
@@ -10,10 +10,11 @@ contacts:
     value: mb4@sanger.ac.uk
   label: Matt Berriman
 creation_date: '2025-09-29T00:00:00Z'
-description: Description unavailable.
+description: A structured controlled vocabulary for the life cycle of the malaria
+  parasite Plasmodium. This ontology is obsolete/deprecated.
 domains:
 - anatomy and development
-homepage_url: http://www.sanger.ac.uk/Users/mb4/PLO/
+homepage_url: https://obofoundry.org/ontology/plo
 id: plo
 last_modified_date: '2026-05-31T00:00:00Z'
 layout: resource_detail

--- a/resource/predict/predict.md
+++ b/resource/predict/predict.md
@@ -1,6 +1,14 @@
 ---
 activity_status: inactive
 category: DataSource
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: roded@tauex.tau.ac.il
+  - contact_type: url
+    value: https://english.tau.ac.il/profile/roded
+  label: Roded Sharan
 creation_date: '2026-06-02T00:00:00Z'
 description: PREDICT is a computational drug-indication inference method and associated
   drug-disease gold-standard dataset introduced by Gottlieb and colleagues for large-scale
@@ -13,6 +21,9 @@ homepage_url: https://www.embopress.org/doi/abs/10.1038/msb.2011.26
 id: predict
 last_modified_date: '2026-06-22T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by-nc-sa/3.0/
+  label: CC BY-NC-SA 3.0
 name: PREDICT
 products:
 - category: DocumentationProduct
@@ -56,7 +67,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: predict
-  product_url: https://www.embopress.org/doi/suppl/10.1038/msb.2011.26
+  product_url: https://pmc.ncbi.nlm.nih.gov/articles/PMC3159979/
   secondary_source:
   - relation_type: prov:used
     source: drugbank
@@ -64,13 +75,6 @@ products:
     source: mesh
   - relation_type: prov:used
     source: omim
-  warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-02: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-06-16: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-07-03: HTTP 404 error
-    when accessing file'
 - category: Product
   description: Curated TSV catalog of drug-disease indications classified as disease-modifying,
     symptomatic, or non-indications

--- a/resource/prodo/prodo.md
+++ b/resource/prodo/prodo.md
@@ -53,6 +53,20 @@ products:
   secondary_source:
   - relation_type: prov:wasInfluencedBy
     source: gene-expression-omnibus
+publications:
+- authors:
+  - David W. Scharp
+  - Jayagowri Arulmoli
+  - Kelly Morgan
+  - Hannah Sunshine
+  - Ergeng Hao
+  doi: 10.21926/obm.transplant.1901052
+  id: https://doi.org/10.21926/obm.transplant.1901052
+  journal: OBM Transplantation
+  preferred: true
+  title: 'Advances in Human Islet Processing: Manufacturing Steps to Achieve Predictable
+    Islet Outcomes from Research Pancreases'
+  year: '2019'
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/ptmd/ptmd.md
+++ b/resource/ptmd/ptmd.md
@@ -1,6 +1,17 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: xueyu@hust.edu.cn
+  label: Yu Xue
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://biocuckoo.cn/
+  label: The CUCKOO Workgroup (BioCuckoo)
 creation_date: '2026-05-29T00:00:00Z'
 description: PTMD 2.0 is a human post-translational modification and disease association
   resource that integrates experimentally supported PTM-disease associations with

--- a/resource/rdp/rdp.md
+++ b/resource/rdp/rdp.md
@@ -6,9 +6,13 @@ description: The Ribosomal Database Project (RDP) provided ribosome-related data
 domains:
   - biological systems
   - genomics
+homepage_url: https://github.com/rdpstaff/RDPTools
 id: rdp
 last_modified_date: '2025-10-15T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://spdx.org/licenses/GPL-2.0.html
+  label: GPL-2.0
 name: Ribosomal Database Project
 products:
   - category: ProcessProduct
@@ -417,6 +421,43 @@ products:
       - source: rnacentral
         relation_type: prov:hadPrimarySource
     product_url: https://rnacentral.org/help/public-database
+publications:
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/24288368
+    authors:
+      - Cole JR
+      - Wang Q
+      - Fish JA
+      - Chai B
+      - McGarrell DM
+      - Sun Y
+      - Brown CT
+      - Porras-Alfaro A
+      - Kuske CR
+      - Tiedje JM
+    doi: 10.1093/nar/gkt1244
+    journal: Nucleic Acids Research
+    preferred: true
+    title: 'Ribosomal Database Project: data and tools for high throughput rRNA analysis'
+    year: '2014'
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/19004872
+    authors:
+      - Cole JR
+      - Wang Q
+      - Cardenas E
+      - Fish J
+      - Chai B
+      - Farris RJ
+      - Kulam-Syed-Mohideen AS
+      - McGarrell DM
+      - Marsh T
+      - Garrity GM
+      - Tiedje JM
+    doi: 10.1093/nar/gkn879
+    journal: Nucleic Acids Research
+    title: 'The Ribosomal Database Project: improved alignments and new tools for rRNA
+      analysis'
+    year: '2009'
+repository: https://github.com/rdpstaff/classifier
 warnings:
   - The RDP website is no longer available. Only stand-alone tools and classifiers remain accessible.
 taxon:

--- a/resource/rediportal/rediportal.md
+++ b/resource/rediportal/rediportal.md
@@ -1,11 +1,24 @@
 ---
 activity_status: active
 category: DataSource
+contacts:
+  - category: Individual
+    contact_details:
+      - contact_type: email
+        value: ernesto.picardi@uniba.it
+    label: Ernesto Picardi
+  - category: Organization
+    contact_details:
+      - contact_type: url
+        value: https://rediportal.cloud.ba.infn.it/atlas/contact.html
+    label: Laboratory of Bioinformatics and Comparative Genomics, University of Bari
+      "Aldo Moro"
 creation_date: '2025-09-09T00:00:00Z'
 description: REDIportal is a specialized database of A-to-I RNA editing events, integrating ~16 million sites from GTEx and TCGA with links to Ensembl, RNAcentral, UniProt, and PRIDE. The portal supports search by genomic position, sample (GTEx/TCGA), dsRNA modules, and gene view, and reports AEI/REI indices and a deep-learning-based reliability score (REDInet).
 domains:
   - genomics
   - biological systems
+homepage_url: https://rediportal.cloud.ba.infn.it/atlas/
 id: rediportal
 last_modified_date: '2025-10-15T00:00:00Z'
 layout: resource_detail
@@ -16,7 +29,7 @@ products:
     format: http
     id: rediportal.portal
     name: REDIportal Web Portal
-    product_url: http://srv00.recas.ba.infn.it/atlas/
+    product_url: https://rediportal.cloud.ba.infn.it/atlas/
     original_source:
       - source: rediportal
         relation_type: prov:hadPrimarySource
@@ -426,6 +439,7 @@ publications:
   preferred: true
   title: 'REDIportal: toward an integrated view of the A-to-I editing'
   year: '2025'
+repository: https://github.com/BioinfoUNIBA/REDItools
 ---
 
 # REDIportal

--- a/resource/securechainkg/securechainkg.md
+++ b/resource/securechainkg/securechainkg.md
@@ -16,7 +16,11 @@ domains:
 homepage_url: https://purdue-hcss.github.io/nsf-software-supply-chain_security/
 id: securechainkg
 layout: resource_detail
+license:
+  id: https://opensource.org/licenses/Apache-2.0
+  label: Apache-2.0
 name: SecureChain KG
+repository: https://github.com/purdue-hcss/SecureChain
 products:
 - category: ProgrammingInterface
   description: SPARQL endpoint for SecureChain KG
@@ -31,6 +35,7 @@ products:
   name: SecureChain KG TPF
   description: Triple Pattern Fragments endpoint for SecureChain KG
   category: ProgrammingInterface
+  format: http
   product_url: https://apps.okn.us/ldf/securechainkg
   original_source:
   - source: securechainkg

--- a/resource/service-kp/service-kp.md
+++ b/resource/service-kp/service-kp.md
@@ -9,10 +9,15 @@ contacts:
 description: A Translator Knowledge Provider
 domains:
   - biomedical
+homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/Service-Provider
 id: service-kp
 last_modified_date: '2026-02-20T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://opensource.org/licenses/Apache-2.0
+  label: Apache-2.0
 name: Service KP
+repository: https://github.com/biothings/biothings.api
 products:
   - category: DocumentationProduct
     description: Team documentation for the Translator Service Provider.
@@ -41,6 +46,28 @@ products:
       - source: service-kp
         relation_type: prov:hadPrimarySource
     product_url: https://github.com/biothings/biothings.api
+publications:
+  - id: https://www.ncbi.nlm.nih.gov/pubmed/35020801
+    authors:
+      - Sebastien Lelong
+      - Xinghua Zhou
+      - Cyrus Afrasiabi
+      - Zhongchao Qian
+      - Marco Alvarado Cano
+      - Ginger Tsueng
+      - Jiwen Xin
+      - Julia Mullen
+      - Yao Yao
+      - Ricardo Avila
+      - Greg Taylor
+      - Andrew I Su
+      - Chunlei Wu
+    doi: 10.1093/bioinformatics/btac017
+    journal: Bioinformatics
+    preferred: true
+    title: 'BioThings SDK: a toolkit for building high-performance data APIs in biomedical
+      research'
+    year: '2022'
 creation_date: '2025-03-09T00:00:00Z'
 ---
 

--- a/resource/sgd/sgd.md
+++ b/resource/sgd/sgd.md
@@ -17,7 +17,11 @@ id: sgd
 infores_id: sgd
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
 name: Saccharomyces Genome Database
+repository: https://github.com/yeastgenome/SGDBackend-Nex2
 products:
 - category: GraphicalInterface
   description: Web portal for searching and browsing ncRNA sequences, structures,

--- a/resource/sudokn/sudokn.md
+++ b/resource/sudokn/sudokn.md
@@ -59,10 +59,23 @@ products:
   name: SUDOKN TPF
   description: Triple Pattern Fragments endpoint for SUDOKN
   category: ProgrammingInterface
+  format: http
   product_url: https://apps.okn.us/ldf/sudokn
   original_source:
   - source: sudokn
     relation_type: prov:hadPrimarySource
+publications:
+- id: https://doi.org/10.1007/978-3-031-71637-9_21
+  authors:
+  - Farhad Ameri
+  - Mukund Shenoy
+  - Ali Hasanzadeh
+  - Sambhav Kapoor
+  doi: 10.1007/978-3-031-71637-9_21
+  journal: Advances in Production Management Systems (APMS 2024), IFIP AICT 732
+  preferred: true
+  title: Open Manufacturing Capability Network Supported by Formal Ontologies
+  year: '2024'
 creation_date: '2025-12-08T00:00:00Z'
 last_modified_date: '2026-07-03T00:00:00Z'
 ---

--- a/resource/translator/translator.md
+++ b/resource/translator/translator.md
@@ -22,6 +22,9 @@ homepage_url: https://kgx-storage.rtx.ai/releases/
 id: translator
 last_modified_date: '2026-04-02T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://opensource.org/license/mit/
+  label: MIT
 name: NCATS Translator Graph Releases
 products:
 - category: GraphProduct
@@ -935,6 +938,23 @@ products:
   - relation_type: prov:hadPrimarySource
     source: translator
   product_url: https://github.com/NCATSTranslator/Translator-All/wiki/Genetics-Knowledge-Provider
+publications:
+- authors:
+  - The Biomedical Data Translator Consortium
+  doi: 10.1111/cts.12591
+  id: https://www.ncbi.nlm.nih.gov/pubmed/30412337
+  journal: Clinical and Translational Science
+  preferred: true
+  title: Toward A Universal Biomedical Data Translator
+  year: '2019'
+- authors:
+  - The Biomedical Data Translator Consortium
+  doi: 10.1111/cts.12592
+  id: https://www.ncbi.nlm.nih.gov/pubmed/30412340
+  journal: Clinical and Translational Science
+  title: 'The Biomedical Data Translator Program: Conception, Culture, and Community'
+  year: '2019'
+repository: https://github.com/NCATSTranslator
 tags:
 - translator
 ---

--- a/resource/try/try.md
+++ b/resource/try/try.md
@@ -1,6 +1,17 @@
 ---
 activity_status: active
 category: Dataset
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: email
+    value: jkattge@bgc-jena.mpg.de
+  label: Jens Kattge
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://www.bgc-jena.mpg.de/
+  label: Max Planck Institute for Biogeochemistry
 creation_date: '2026-01-15T00:00:00Z'
 description: The TRY Plant Trait Database aggregates global plant trait measurements
   contributed by researchers and institutions, widely used for ecological and metabolomic
@@ -12,6 +23,9 @@ id: try
 infores_id: try
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://www.try-db.org/TryWeb/TRY_Intellectual_Property_Guidelines.pdf
+  label: CC BY (TRY Data Intellectual Property Guidelines)
 name: TRY Plant Trait Database
 products:
 - category: Product
@@ -91,6 +105,30 @@ products:
   - relation_type: prov:hadPrimarySource
     source: try
   product_url: https://sib-swiss.github.io/sparql-editor/emi
+publications:
+- id: https://www.ncbi.nlm.nih.gov/pubmed/31891233
+  authors:
+  - Jens Kattge
+  - Gerhard Bönisch
+  - Sandra Díaz
+  - Sandra Lavorel
+  - Iain Colin Prentice
+  doi: 10.1111/gcb.14904
+  journal: Global Change Biology
+  preferred: true
+  title: TRY plant trait database – enhanced coverage and open access
+  year: '2020'
+- id: doi:10.1111/j.1365-2486.2011.02451.x
+  authors:
+  - Jens Kattge
+  - Sandra Díaz
+  - Sandra Lavorel
+  - Iain Colin Prentice
+  - Paul Leadley
+  doi: 10.1111/j.1365-2486.2011.02451.x
+  journal: Global Change Biology
+  title: TRY – a global database of plant traits
+  year: '2011'
 ---
 # TRY Plant Trait Database
 

--- a/resource/usgs/usgs.md
+++ b/resource/usgs/usgs.md
@@ -19,6 +19,9 @@ homepage_url: https://www.usgs.gov/
 id: usgs
 last_modified_date: '2026-07-03T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://www.usa.gov/government-works
+  label: U.S. Government Work (public domain)
 name: U.S. Geological Survey (USGS)
 products:
 - category: GraphicalInterface

--- a/resource/vectology/vectology.md
+++ b/resource/vectology/vectology.md
@@ -21,7 +21,11 @@ homepage_url: http://vectology.mrcieu.ac.uk/
 id: vectology
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
+license:
+  id: https://spdx.org/licenses/GPL-3.0-only
+  label: GPL-3.0
 name: Vectology
+repository: https://github.com/MRCIEU/vectology
 products:
 - category: ProgrammingInterface
   description: Public API providing access to sentence embedding-based similarity
@@ -87,6 +91,18 @@ products:
   - relation_type: prov:hadPrimarySource
     source: mrbase
   product_url: https://docs.epigraphdb.org/graph-database/
+publications:
+- id: https://doi.org/10.1093/bioinformatics/btad169
+  authors:
+  - Yi Liu
+  - Benjamin L Elsworth
+  - Tom R Gaunt
+  doi: 10.1093/bioinformatics/btad169
+  journal: Bioinformatics
+  preferred: true
+  title: Using language models and ontology topology to perform semantic mapping of
+    traits between biomedical datasets
+  year: '2023'
 ---
 ## Overview
 

--- a/resource/web-of-science/web-of-science.md
+++ b/resource/web-of-science/web-of-science.md
@@ -18,6 +18,9 @@ domains:
 homepage_url: https://clarivate.com/academia-government/scientific-and-academic-research/research-discovery-and-referencing/web-of-science/
 id: web-of-science
 last_modified_date: '2026-06-02T00:00:00Z'
+license:
+  id: https://clarivate.com/legal-center/terms-of-business/product-service-terms/
+  label: Clarivate — proprietary / subscription
 layout: resource_detail
 name: Web of Science
 products:

--- a/resource/wipo-tkp/wipo-tkp.md
+++ b/resource/wipo-tkp/wipo-tkp.md
@@ -26,14 +26,15 @@ id: wipo-tkp
 last_modified_date: '2026-06-18T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: WIPO Traditional Knowledge Resources
 products:
 - category: GraphicalInterface
   description: WIPO Traditional Knowledge web portal providing access to TK resources,
     policy materials, and links to traditional knowledge databases relevant to traditional
     and herbal medicine.
+  format: http
   id: wipo-tkp.portal
   name: WIPO Traditional Knowledge Portal
   original_source:


### PR DESCRIPTION
## Summary

General maintenance sweep on the KG-Registry: 50 randomly-selected resource pages (prioritized from the data-quality dashboard's list of resources with 3+ issue types) had their flagged issues fixed across five commits of 10 resources each. Provenance was a priority throughout — every upstream `source:` referenced across all touched resources resolves to an existing registry entry.

Every added value was verified against an authoritative source (Crossref/NCBI/arXiv for publications, GitHub/GitLab for repositories, and the resource's own site/terms for licenses), and every added or changed URL was re-checked live (HTTP 200).

## What was fixed

Across the 50 resources: missing `license`, `repository`, `publications`, `contacts`, and `homepage_url` fields; broken links (dead homepages and product URLs repointed to working canonical/archival/successor URLs); missing product `format` fields; and a few duplicate-contact cleanups.

Resources touched, by commit:
- **Round 1**: bridge2ai, cabi-isc, compath, flybase, kg-ebi-gene2pheno, pankbase, predict, prodo, rediportal, translator
- **Round 2**: batman, campbell-biology, gene2phenotype, geneprof, iproclass, mo, osv, plo, ptmd, try
- **Round 3**: fire, icd10cm, immport, lipro, maudekg, nasa-gesdisc-kg, nde, securechainkg, sudokn, web-of-science
- **Round 4**: bioportal, ccle, epa-srs, geoconnex, labeledin, pao, rdp, service-kp, vectology, wipo-tkp
- **Round 5**: cellxgene, clinical-data-kp, cpathkg, imr, loggerhead, mgi, nihreporter, offsides, sgd, usgs

## Curation principles

- **No fabrication.** Where no verifiable value exists, the field was left absent rather than forced — e.g. commercial products with no public code repo (web-of-science, cabi-isc, ccle), defunct resources with no current contact (rdp, geneprof), US-government databases and portals with no canonical DOI paper (icd10cm, epa-srs, usgs, wipo-tkp), and obsolete ontologies with no successor repo/publication.
- **Honest license classification.** Several licenses that GitHub reports as "NOASSERTION" were confirmed by reading the repo's LICENSE file (e.g. offsides/nsides and clinical-data-kp/cohd_api are genuine CC BY-NC-SA 4.0). Article licenses were not conflated with data/code licenses.
- **Broken links** were repointed to working canonical, successor, or archived URLs where one exists (e.g. pao → Plant Ontology successor OWL/OBO; mo → Wayback snapshot; imr/loggerhead → OBO Foundry pages), and annotated with a `warnings:` note when only an archived copy survives.

## Validation

All 50 files pass JSON-schema validation; all provenance `source:` references resolve to registry entries; all newly added/changed URLs return HTTP 200. The full quality dashboard (`reports/quality-dashboard.json`) was intentionally not regenerated here, since its link-check pass rewrites unrelated entries daily — it can be regenerated separately via `make quality-dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)