### PR TITLE
Update NLM-CKN with current repos, products, and processes (#648)

### DIFF
--- a/resource/nlm-ckn/nlm-ckn.graph.md
+++ b/resource/nlm-ckn/nlm-ckn.graph.md
@@ -16,7 +16,7 @@ original_source:
   source: cellxgene
 - relation_type: prov:hadPrimarySource
   source: pubmed
-product_url: https://github.com/NIH-NLM/cell-kn-mvp
+product_url: https://nlm-ckn.org
 secondary_source:
 - relation_type: prov:wasInfluencedBy
   source: cl

--- a/resource/nlm-ckn/nlm-ckn.md
+++ b/resource/nlm-ckn/nlm-ckn.md
@@ -36,8 +36,9 @@ domains:
   - biological systems
   - biomedical
   - phenotype
+homepage_url: https://nlm-ckn.org
 id: nlm-ckn
-last_modified_date: '2026-07-01T00:00:00Z'
+last_modified_date: '2026-07-14T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -67,20 +68,63 @@ products:
         relation_type: prov:wasInfluencedBy
       - source: hsapdv
         relation_type: prov:wasInfluencedBy
-    product_url: https://github.com/NIH-NLM/cell-kn-mvp
+    product_url: https://nlm-ckn.org
+  - category: GraphicalInterface
+    description: The NLM-CKN web application, a Django and React interface that loads a pre-built ArangoDB dataset produced by the ETL pipeline and lets researchers query, visualize, and explore the cell knowledge graph.
+    id: nlm-ckn.ui
+    name: nlm-ckn-ui
+    format: http
+    original_source:
+      - source: nlm-ckn
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/NIH-NLM/nlm-ckn-ui
   - category: DataModelProduct
-    description: Data model for cell phenotypes and biological entities they relate to.
+    description: LinkML data model (schema) for cell phenotypes and the biological entities they relate to, defining the node and edge types used in the NLM-CKN knowledge graph.
     id: nlm-ckn.schema
     name: nlm-ckn-schema
     original_source:
       - source: nlm-ckn
         relation_type: prov:hadPrimarySource
-    product_file_size: 4262
-    product_url: https://github.com/NIH-NLM/cell-kn-schema/blob/main/ckn-schema.yaml
-repository: https://github.com/NIH-NLM/cell-kn-mvp
+    product_file_size: 75158
+    product_url: https://github.com/NIH-NLM/nlm-ckn-schema/blob/main/ckn-schema.yaml
+  - category: ProcessProduct
+    description: The NLM-CKN ETL pipeline, which produces the knowledge graph as an ArangoDB archive from single-cell genomics results and source ontologies. It combines a data processing pipeline (DataFetcher, DataTransformer, TupleWriters, ResultsGraphBuilder) with an ontology processing pipeline (OntologyDownloader, OntologyGraphBuilder), then selects a relevant induced subgraph.
+    id: nlm-ckn.etl
+    name: nlm-ckn-etl
+    original_source:
+      - source: nlm-ckn
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/NIH-NLM/nlm-ckn-etl
+  - category: ProcessProduct
+    description: The cellxgene-harvester package, which harvests, filters, and counts normal cells from the CELLxGENE Census using ontology-based filtering (UBERON tissue, PATO/MONDO disease, HsapDv age) to produce per-organ input datasets for the quality-control workflow.
+    id: nlm-ckn.harvester
+    name: cellxgene-harvester
+    original_source:
+      - source: nlm-ckn
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/NIH-NLM/cellxgene-harvester
+  - category: ProcessProduct
+    description: The scsilhouette Python package, part of the NLM-CKN quality-control workflow. Together with NSForest F-scores it computes silhouette and summary quality metrics that characterize the single-cell clusters used in the knowledgebase.
+    id: nlm-ckn.scsilhouette
+    name: scsilhouette
+    original_source:
+      - source: nlm-ckn
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/NIH-NLM/scsilhouette
+  - category: ProcessProduct
+    description: The sc-nsforest-qc-nf Nextflow workflow, which runs the scsilhouette package and the JCVI NSForest method over each harvested dataset to produce marker genes, F-scores, and silhouette quality metrics consumed downstream by the ETL pipeline.
+    id: nlm-ckn.nsforest-qc
+    name: sc-nsforest-qc-nf
+    original_source:
+      - source: nlm-ckn
+        relation_type: prov:hadPrimarySource
+    product_url: https://github.com/NIH-NLM/sc-nsforest-qc-nf
+repository: https://github.com/NIH-NLM/nlm-ckn
 ---
 
 A knowledge graph that contains knowledge about cellular phenotypes (cell types and cell states) that has been gathered through single cell technologies and related experiments. NLM-CKN is populated using validated computational analysis pipelines and natural language processing of scientific literature and integrated with other public sources of relevant knowledge about genes, anatomical structures, diseases, and drugs.
+
+The NLM-CKN infrastructure spans several coordinated repositories: the [cellxgene-harvester](https://github.com/NIH-NLM/cellxgene-harvester) selects and filters single-cell datasets from the CELLxGENE Census; the [sc-nsforest-qc-nf](https://github.com/NIH-NLM/sc-nsforest-qc-nf) Nextflow workflow (using [scsilhouette](https://github.com/NIH-NLM/scsilhouette) and NSForest) generates marker genes and quality metrics; the [NLM-CKN ETL](https://github.com/NIH-NLM/nlm-ckn-etl) pipeline builds the ArangoDB knowledge graph from those results and source ontologies (following the [NLM-CKN schema](https://github.com/NIH-NLM/nlm-ckn-schema)); and the [NLM-CKN UI](https://github.com/NIH-NLM/nlm-ckn-ui) serves it at [nlm-ckn.org](https://nlm-ckn.org).
 
 ## Automated Evaluation
 

--- a/resource/nlm-ckn/nlm-ckn.schema.md
+++ b/resource/nlm-ckn/nlm-ckn.schema.md
@@ -1,12 +1,12 @@
 ---
 category: DataModelProduct
-description: Data model for cell phenotypes and biological entities they relate to.
+description: LinkML data model (schema) for cell phenotypes and the biological entities they relate to, defining the node and edge types used in the NLM-CKN knowledge graph.
 id: nlm-ckn.schema
 name: nlm-ckn-schema
 original_source:
   - source: nlm-ckn
     relation_type: prov:hadPrimarySource
-product_file_size: 4262
-product_url: https://github.com/NIH-NLM/cell-kn-schema/blob/main/ckn-schema.yaml
+product_file_size: 75158
+product_url: https://github.com/NIH-NLM/nlm-ckn-schema/blob/main/ckn-schema.yaml
 layout: product_detail
 ---


### PR DESCRIPTION
Closes #648

Updates NLM-CKN to reflect the current [NIH-NLM/nlm-ckn](https://github.com/NIH-NLM/nlm-ckn) umbrella repository and its ecosystem, replacing references to the retired `cell-kn-mvp`/`cell-kn-schema` repos.

### Changes
- `repository` → `NIH-NLM/nlm-ckn`; `homepage_url` → `https://nlm-ckn.org`; refreshed `last_modified_date`
- Refreshed `nlm-ckn.schema` to the `nlm-ckn-schema` repo (file size 4262 → 75158 bytes, LinkML)
- Pointed the served graph product at `https://nlm-ckn.org`
- **Added current products / processes:**
  - `nlm-ckn.ui` — Django/React web UI (`nlm-ckn-ui`)
  - `nlm-ckn.etl` — ETL pipeline producing the ArangoDB graph (`nlm-ckn-etl`)
  - `nlm-ckn.harvester` — CELLxGENE Census harvester (`cellxgene-harvester`)
  - `nlm-ckn.scsilhouette` — QC metrics package (`scsilhouette`)
  - `nlm-ckn.nsforest-qc` — Nextflow QC workflow (`sc-nsforest-qc-nf`)
- Updated companion product-detail pages (`nlm-ckn.graph.md`, `nlm-ckn.schema.md`) and expanded the description with the infrastructure overview

Source: [NIH-NLM/nlm-ckn README](https://github.com/NIH-NLM/nlm-ckn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)