### PR TITLE
Add curated data sources to PubChem substance products (#649)

### DIFF
--- a/resource/pubchem/pubchem.md
+++ b/resource/pubchem/pubchem.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://pubchem.ncbi.nlm.nih.gov/
 id: pubchem
 infores_id: pubchem
-last_modified_date: '2026-07-01T00:00:00Z'
+last_modified_date: '2026-07-14T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.ncbi.nlm.nih.gov/home/about/policies/
@@ -56,7 +56,52 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pubchem
+  - relation_type: prov:hadPrimarySource
+    source: bindingdb
+  - relation_type: prov:hadPrimarySource
+    source: chebi
+  - relation_type: prov:hadPrimarySource
+    source: chembl
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
+  - relation_type: prov:hadPrimarySource
+    source: glygen
+  - relation_type: prov:hadPrimarySource
+    source: gtopdb
+  - relation_type: prov:hadPrimarySource
+    source: hmdb
+  - relation_type: prov:hadPrimarySource
+    source: kegg
+  - relation_type: prov:hadPrimarySource
+    source: lipidmaps
   product_url: https://ftp.ncbi.nlm.nih.gov/pubchem/Substance/CURRENT-Full/ASN/
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: clinvar
+  - relation_type: prov:wasInfluencedBy
+    source: dbsnp
+  - relation_type: prov:wasInfluencedBy
+    source: dgidb
+  - relation_type: prov:wasInfluencedBy
+    source: mesh
+  - relation_type: prov:wasInfluencedBy
+    source: ncbigene
+  - relation_type: prov:wasInfluencedBy
+    source: omim
+  - relation_type: prov:wasInfluencedBy
+    source: pharmgkb
+  - relation_type: prov:wasInfluencedBy
+    source: reactome
+  - relation_type: prov:wasInfluencedBy
+    source: unichem
+  - relation_type: prov:wasInfluencedBy
+    source: uniprot
+  - relation_type: prov:wasInfluencedBy
+    source: wikidata
+  - relation_type: prov:wasInfluencedBy
+    source: wikipathways
 - category: Product
   compression: gzip
   description: PubChem substance information in SDF format
@@ -66,7 +111,52 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: pubchem
+  - relation_type: prov:hadPrimarySource
+    source: bindingdb
+  - relation_type: prov:hadPrimarySource
+    source: chebi
+  - relation_type: prov:hadPrimarySource
+    source: chembl
+  - relation_type: prov:hadPrimarySource
+    source: drugbank
+  - relation_type: prov:hadPrimarySource
+    source: drugcentral
+  - relation_type: prov:hadPrimarySource
+    source: glygen
+  - relation_type: prov:hadPrimarySource
+    source: gtopdb
+  - relation_type: prov:hadPrimarySource
+    source: hmdb
+  - relation_type: prov:hadPrimarySource
+    source: kegg
+  - relation_type: prov:hadPrimarySource
+    source: lipidmaps
   product_url: https://ftp.ncbi.nlm.nih.gov/pubchem/Substance/CURRENT-Full/SDF/
+  secondary_source:
+  - relation_type: prov:wasInfluencedBy
+    source: clinvar
+  - relation_type: prov:wasInfluencedBy
+    source: dbsnp
+  - relation_type: prov:wasInfluencedBy
+    source: dgidb
+  - relation_type: prov:wasInfluencedBy
+    source: mesh
+  - relation_type: prov:wasInfluencedBy
+    source: ncbigene
+  - relation_type: prov:wasInfluencedBy
+    source: omim
+  - relation_type: prov:wasInfluencedBy
+    source: pharmgkb
+  - relation_type: prov:wasInfluencedBy
+    source: reactome
+  - relation_type: prov:wasInfluencedBy
+    source: unichem
+  - relation_type: prov:wasInfluencedBy
+    source: uniprot
+  - relation_type: prov:wasInfluencedBy
+    source: wikidata
+  - relation_type: prov:wasInfluencedBy
+    source: wikipathways
 - category: Product
   compression: gzip
   description: PubChem BioAssay data in ASN.1 format


### PR DESCRIPTION
Closes #649

PubChem aggregates data from **>1,000 depositors**, so enumerating all of them is neither practical nor useful. This PR adds the subset of major PubChem data sources that **already exist as resources in this registry**, so the provenance links resolve to real registry entries. They are attached to the two PubChem **Substance** products (`pubchem.substances.asn`, `pubchem.substances.sdf`) — the depositor-level records.

### Sources added
**Chemical substance depositors** — `original_source` (`prov:hadPrimarySource`):
BindingDB, ChEBI, ChEMBL, DrugBank, DrugCentral, GlyGen, Guide to Pharmacology (`gtopdb`), HMDB, KEGG, LIPID MAPS

**Annotation / cross-reference sources** — `secondary_source` (`prov:wasInfluencedBy`):
ClinVar, dbSNP, DGIdb, MeSH, NCBI Gene, OMIM, PharmGKB, Reactome, UniChem, UniProt, Wikidata, WikiPathways

All 22 referenced `source:` ids were verified against the `id:` field of existing registry resources. File validates clean.

> Note: the full PubChem source list (https://pubchem.ncbi.nlm.nih.gov/sources/) was not machine-readable from CI (PUG REST returned `ServerBusy`); the selection above is the set of well-established PubChem contributors that intersect the registry. Easy to extend as more of PubChem's sources are added to the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)