### PR TITLE
Disambiguate BiomarkerKB KG (biomarkerkg) from BiomarkerKB (biomarker)

### DIFF
--- a/resource/biomarkerkg/biomarkerkg.md
+++ b/resource/biomarkerkg/biomarkerkg.md
@@ -14,16 +14,20 @@ contacts:
   - contact_type: email
     value: avi.maayan@mssm.edu
   label: MaayanLab
-description: The BiomarkerKB knowledge graph is a structured network that connects
-  biomarkers to diseases, drugs, biological entities, and evidence from the scientific
-  literature.
+description: BiomarkerKB KG (BKG) is a knowledge-graph representation of biomarker
+  data that connects biomarkers to diseases, drugs, biological entities, and evidence
+  from the scientific literature. It is built from BiomarkerKB (registry id `biomarker`)
+  biomarker data together with reference ontologies, and is deployed as an OKN/FRINK
+  knowledge graph. Note that this resource (id `biomarkerkg`) is the knowledge graph,
+  which is distinct from the similarly named source knowledgebase BiomarkerKB (id
+  `biomarker`); the near-identical names are a common source of confusion.
 domains:
 - biomedical
 - biological systems
-homepage_url: https://biomarkerkb.org/home/
+homepage_url: https://frink.renci.org/registry/kg/biomarkerkg
 id: biomarkerkg
 layout: resource_detail
-name: BiomarkerKB KG
+name: BiomarkerKB KG (BKG)
 products:
 - category: GraphicalInterface
   description: Web interface to explore and query the Biomarker Knowledge Graph
@@ -55,6 +59,8 @@ products:
   name: BKG Biomarker Nodes
   original_source:
   - source: biomarkerkg
+    relation_type: prov:hadPrimarySource
+  - source: biomarker
     relation_type: prov:hadPrimarySource
   - source: glygen
     relation_type: prov:hadPrimarySource
@@ -197,11 +203,13 @@ products:
     relation_type: prov:hadPrimarySource
 repository: https://github.com/MaayanLab/BiomarkerKG
 creation_date: '2025-05-04T00:00:00Z'
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-07-15T00:00:00Z'
 collection:
 - okn
 ---
 The Biomarker Knowledge Graph (BKG) is a comprehensive resource that integrates biomarker data across multiple dimensions including anatomical structures, compounds, conditions, roles, and variants. This knowledge graph serves as a centralized platform for biomarker research, enabling researchers to explore complex relationships between biomarkers and various biological and clinical entities.
+
+> **Disambiguation:** This resource (`biomarkerkg`), also titled "BiomarkerKB KG", is the knowledge-graph representation and is built from data curated by the **BiomarkerKB** knowledgebase (`biomarker`). It should not be confused with that source knowledgebase, despite the near-identical names. The OKN/FRINK SPARQL and Triple Pattern Fragments endpoints listed here (labeled "BiomarkerKB KG") serve this knowledge graph — whose underlying biomarker data originates from BiomarkerKB.
 
 BKG supports biomarker discovery, validation, and application by connecting heterogeneous biomedical data sources into a unified graph structure. The platform includes an interactive explorer tool for visualization and analysis of biomarker relationships, as well as downloadable datasets for integration with other bioinformatics workflows.
 


### PR DESCRIPTION
While updating `biomarker` (#647 / #651), it became clear the registry has two very similarly named resources that are easily conflated:

- **`biomarker`** — *BiomarkerKB*, the source knowledgebase (GWU / GlyGen / clinical-biomarkers, biomarkerkb.org)
- **`biomarkerkg`** — *BiomarkerKB KG (BKG)*, a knowledge-graph representation built from BiomarkerKB data (MaayanLab / OKN-FRINK)

### Changes to `biomarkerkg`
- **Fixed the conflated homepage.** `homepage_url` pointed to `https://biomarkerkb.org/home/` — which is **BiomarkerKB's** (`biomarker`) homepage, not this KG's. Changed to the KG's own OKN/FRINK registry page. *(The intended BKG Explorer at `bkg.dev.maayanlab.cloud` is currently unreachable, so I used the live OKN page; happy to switch if you prefer another.)*
- **Rewrote the description** and added a body disambiguation note explaining this is the KG derived from BiomarkerKB, distinct from the source knowledgebase.
- **Clarified the display name** to `BiomarkerKB KG (BKG)`.
- **Recorded `biomarker` as a source** of the BKG Biomarker Nodes product to make the derivation explicit.
- Refreshed `last_modified_date`.

A matching disambiguation note on the `biomarker` side is included in **#651** (issue #647's "general updates").

### FRINK endpoint investigation (the question you raised)
I queried the live endpoint at `https://apps.okn.us/biomarkerkg/sparql`:
- Its `dcterms:source` values are **BiomarkerKB's own curation sources** — OpenTargets, CIViC, ClinVar, OncoMX, EDRN, GWAS Catalog, Metabolomics Workbench, SenNet, CGI, etc. (version `v0.0.3`, updated Jul 2026).
- The OKN registry lists the endpoint's contact as **Jeet Vora (GWU)**, a BiomarkerKB author, and titles it **"BiomarkerKB KG"** with homepage `biomarkerkb.org`.

**Conclusion:** the FRINK endpoints serve the **knowledge graph built from BiomarkerKB** — i.e., in registry terms they belong to `biomarkerkg` (the KG), and their *content* originates from `biomarker`. So your instinct was right that they trace back to BiomarkerKB; they're best modeled as `biomarkerkg`'s endpoints with BiomarkerKB recorded as the upstream source (done here). They are **not** a separate product of the `biomarker` knowledgebase. If you'd rather these endpoints live under `biomarker` directly, that's a quick follow-up — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)