### PR TITLE
Deactivate Dragon AI Agent GitHub Mentions workflow

### DIFF
--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -1,14 +1,19 @@
 name: Dragon AI Agent GitHub Mentions
 
+# Temporarily deactivated to reduce noise: the upstream dragon-ai-agent
+# actions keep failing due to configuration we can't easily change here.
+# The automatic mention triggers below are disabled; the workflow only runs
+# when dispatched manually. To re-enable, restore the commented-out triggers.
 on:
-  issues:
-    types: [opened, edited]
-  issue_comment:
-    types: [created, edited]
-  pull_request:
-    types: [opened, edited]
-  pull_request_review_comment:
-    types: [created, edited]
+  workflow_dispatch:
+  # issues:
+  #   types: [opened, edited]
+  # issue_comment:
+  #   types: [created, edited]
+  # pull_request:
+  #   types: [opened, edited]
+  # pull_request_review_comment:
+  #   types: [created, edited]
 
 jobs:
   check-mention:


### PR DESCRIPTION
The **Dragon AI Agent GitHub Mentions** workflow (`.github/workflows/ai-agent.yml`) keeps failing — the upstream `dragon-ai-agent/*` actions depend on configuration we can't easily change here — which creates noise on issues and PRs.

This deactivates it for now by disabling the automatic triggers:
- Removed `issues`, `issue_comment`, `pull_request`, and `pull_request_review_comment` triggers (kept as comments)
- Left only `workflow_dispatch`, so the workflow no longer runs automatically

The job definitions are untouched, so re-enabling is just uncommenting the original triggers. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)