### PR TITLE
Report render exceptions separately from data load failures

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -984,6 +984,34 @@ jQuery(document).ready(function () {
         $('#retry-load').on('click', loadRegistryData);
     }
 
+    // The counterpart to showLoadError for the other failure mode: the data
+    // arrived intact but an exception was thrown while rendering it. Retrying
+    // is pointless here (a deterministic render bug fails identically every
+    // time), so offer a link to the issue tracker instead. See issue #664.
+    function showRenderError(error) {
+        console.error('Error rendering data:', error);
+        $tableDiv.html(
+            `<div class="alert alert-danger" role="alert">
+                <h5 class="alert-heading">
+                    <i class="bi-exclamation-triangle-fill" aria-hidden="true"></i>
+                    Could not display the registry data
+                </h5>
+                <p class="mb-2">
+                    The registry data loaded, but an error occurred while
+                    displaying it. This is a problem with the page or the data,
+                    not with your connection, so retrying will not help.
+                </p>
+                <p class="mb-3"><small>Details: ${error && error.message ? error.message : error}</small></p>
+                <a class="btn btn-outline-danger btn-sm"
+                   href="https://github.com/Knowledge-Graph-Hub/kg-registry/issues"
+                   target="_blank" rel="noopener">
+                    <i class="bi-bug" aria-hidden="true"></i> Report this problem
+                </a>
+            </div>`
+        );
+        setCountsError();
+    }
+
     function loadRegistryData() {
         $tableDiv.html(
             `<div class="loading-indicator" role="status" aria-live="polite">
@@ -992,9 +1020,20 @@ jQuery(document).ready(function () {
             </div>`
         );
 
-        return fetchRegistryData()
-            .then(onRegistryDataLoaded)
-            .catch(showLoadError);
+        // Keep the two failure modes distinct (issue #664): a rejected fetch
+        // is a load failure, but an exception thrown by onRegistryDataLoaded
+        // means the data arrived and only the rendering broke. The
+        // two-argument then() ensures showLoadError never sees render errors.
+        return fetchRegistryData().then(
+            data => {
+                try {
+                    onRegistryDataLoaded(data);
+                } catch (error) {
+                    showRenderError(error);
+                }
+            },
+            showLoadError
+        );
     }
 
     function onRegistryDataLoaded(data) {


### PR DESCRIPTION
Fixes #664.

## Problem

`loadRegistryData()` wrapped both the fetch and the render in a single `.catch(showLoadError)`, so any exception thrown while rendering successfully fetched data — including the deliberate "Registry data is missing its list of resources" guard — was presented to the user as a network load failure, with a Retry button that fails identically every time. This undercut the distinct error state introduced for #660/#661.

## Fix

- `loadRegistryData()` now uses the two-argument `then(onFulfilled, onRejected)` form: a rejected fetch goes to `showLoadError` as before, while `onRegistryDataLoaded` runs inside its own try/catch so render exceptions can no longer reach the load-error handler.
- New `showRenderError()` shows a distinct alert: the data loaded, but an error occurred while displaying it, so retrying will not help. It includes the underlying error message and a "Report this problem" link to the issue tracker instead of a Retry button. Badges get the same `—` error treatment as a load failure.

## Verification

Exercised end-to-end in headless Chromium against the built site, using the reproduction from the issue:

- **Malformed data** (HTTP 200, `category` is a number): shows "Could not display the registry data" with `Details: r.category.toLowerCase is not a function` and the report link; badges read `— resources` / `— KGs`. Previously this showed the load-failure banner.
- **Missing `resources` key** (valid JSON): shows the display error with "Registry data is missing its list of resources".
- **404 on both data URLs**: still shows "Could not load the registry data" with the Retry button.
- **Real summary data**: table renders normally (1012 resources / 153 KGs), no error state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)