### PR TITLE
Count unique Products in the quality dashboard

### DIFF
--- a/README-sitedev.md
+++ b/README-sitedev.md
@@ -130,6 +130,12 @@ Then access the site using the Docker host's IP address rather than localhost, e
 The site includes a data quality dashboard at `/kg-registry/data-quality-dashboard.html`.
 It reads metrics from `reports/quality-dashboard.json`, generated from all Resource pages.
 
+Product metrics count *unique* Products, keyed on product ID. A derived Product is
+propagated onto the page of every Resource it names as a source, so the same Product
+appears on many Resource pages; each one is counted once. A Product counts toward a
+completeness metric (missing `format`, missing `original_source`, missing `product_url`,
+retrieval warnings) if any of its copies shows that issue.
+
 Generate/update the dashboard metrics:
 
 ```shell

--- a/data-quality-dashboard.html
+++ b/data-quality-dashboard.html
@@ -359,7 +359,7 @@ async function loadDashboard() {
             { label: 'Missing format', detailKey: 'products_missing_format_ids', value: data.products.missing_format || 0, color: '#a61e4d' },
             { label: 'Missing original_source', detailKey: 'products_missing_original_source_ids', value: data.products.missing_original_source || 0, color: '#7c3aed' },
             { label: 'Missing product_url', detailKey: 'products_missing_product_url_ids', value: data.products.missing_product_url || 0, color: '#2563eb' },
-            { label: 'Retrieval warning mentions', detailKey: 'retrieval_warning_product_ids', value: data.products.retrieval_warning_mentions || 0, color: '#0f766e' }
+            { label: 'Retrieval warnings', detailKey: 'retrieval_warning_product_ids', value: data.products.with_retrieval_warning || 0, color: '#0f766e' }
         ], productTotal);
 
         const linkTotal = data.links.total_unique_urls || 0;

--- a/tests/test_quality_dashboard.py
+++ b/tests/test_quality_dashboard.py
@@ -103,7 +103,7 @@ def test_build_dashboard_data_counts_and_scoring(quality_dashboard_module):
     assert data["products"]["missing_format"] == 1
     assert data["products"]["missing_original_source"] == 1
     assert data["products"]["missing_product_url"] == 1
-    assert data["products"]["retrieval_warning_mentions"] == 1
+    assert data["products"]["with_retrieval_warning"] == 1
     assert data["citations"]["publication_entries_total"] == 1
     assert data["citations"]["publication_entries_with_issues"] == 1
     assert data["citations"]["resources_without_publications"] == 1
@@ -125,6 +125,135 @@ def test_build_dashboard_data_counts_and_scoring(quality_dashboard_module):
     assert len(top) == 2
     assert top[0]["id"] == "stubres"
     assert top[0]["score"] > top[1]["score"]
+
+
+def test_product_metrics_count_unique_products(quality_dashboard_module):
+    """Products propagated onto source Resource pages are counted only once.
+
+    ``propagate_products`` copies a derived product onto every Resource page
+    listed as one of its sources, so the same product ID appears on several
+    pages. Every product metric must count distinct products.
+    """
+    mod = quality_dashboard_module
+    repo_root = Path(__file__).resolve().parents[1]
+    now = datetime(2026, 2, 16, tzinfo=timezone.utc)
+
+    shared_product = {
+        "id": "agg.download",
+        "category": "GraphProduct",
+        "name": "Aggregated Download",
+        "warnings": [
+            "File was not able to be retrieved when checked on 2026-02-10: timeout"
+        ],
+    }
+    resources = [
+        {
+            "id": "agg",
+            "name": "Aggregator",
+            "products": [dict(shared_product)],
+        },
+        # The propagated copies, as they appear on each cited source's page.
+        {
+            "id": "src1",
+            "name": "Source One",
+            "products": [
+                dict(shared_product),
+                {"id": "src1.graph", "category": "GraphProduct", "name": "Src1 Graph"},
+            ],
+        },
+        {
+            "id": "src2",
+            "name": "Source Two",
+            "products": [dict(shared_product)],
+        },
+    ]
+
+    data = mod.build_dashboard_data(
+        resources,
+        org_index={"ids": set(), "short_ids": set(), "labels": set()},
+        url_results={},
+        citation_reports={},
+        now=now,
+        link_mode="cache-or-unchecked",
+        link_summary={
+            "total_unique_urls": 0,
+            "live_checked_urls": 0,
+            "cache_hits": 0,
+            "healthy_urls": 0,
+            "broken_urls": 0,
+            "unchecked_urls": 0,
+        },
+        cache_path=repo_root / "cache" / "quality_url_status_cache.yml",
+    )
+
+    # Four product entries across the three pages, but only two distinct products.
+    assert data["products"]["total"] == 2
+    assert data["products"]["missing_format"] == 2
+    assert data["products"]["missing_original_source"] == 2
+    assert data["products"]["missing_product_url"] == 2
+    assert data["products"]["with_retrieval_warning"] == 1
+
+    # Every product figure equals the length of the list it drills down into.
+    detail = data["detail_lists"]
+    assert data["products"]["total"] == len(detail["product_total_ids"])
+    assert data["products"]["missing_format"] == len(detail["products_missing_format_ids"])
+    assert data["products"]["missing_original_source"] == len(
+        detail["products_missing_original_source_ids"]
+    )
+    assert data["products"]["missing_product_url"] == len(
+        detail["products_missing_product_url_ids"]
+    )
+    assert data["products"]["with_retrieval_warning"] == len(
+        detail["retrieval_warning_product_ids"]
+    )
+    assert detail["product_total_ids"] == ["agg.download", "src1.graph"]
+
+
+def test_products_without_ids_are_counted_separately(quality_dashboard_module):
+    """Unidentified products fall back to per-resource synthetic IDs, not deduped away."""
+    mod = quality_dashboard_module
+    repo_root = Path(__file__).resolve().parents[1]
+    now = datetime(2026, 2, 16, tzinfo=timezone.utc)
+    resources = [
+        {
+            "id": "res1",
+            "name": "Resource One",
+            "products": [
+                {"category": "GraphProduct", "name": "Unnamed A"},
+                {"category": "GraphProduct", "name": "Unnamed B"},
+            ],
+        },
+        {
+            "id": "res2",
+            "name": "Resource Two",
+            "products": [{"category": "GraphProduct", "name": "Unnamed C"}],
+        },
+    ]
+
+    data = mod.build_dashboard_data(
+        resources,
+        org_index={"ids": set(), "short_ids": set(), "labels": set()},
+        url_results={},
+        citation_reports={},
+        now=now,
+        link_mode="cache-or-unchecked",
+        link_summary={
+            "total_unique_urls": 0,
+            "live_checked_urls": 0,
+            "cache_hits": 0,
+            "healthy_urls": 0,
+            "broken_urls": 0,
+            "unchecked_urls": 0,
+        },
+        cache_path=repo_root / "cache" / "quality_url_status_cache.yml",
+    )
+
+    assert data["products"]["total"] == 3
+    assert data["detail_lists"]["product_total_ids"] == [
+        "res1.product-1",
+        "res1.product-2",
+        "res2.product-1",
+    ]
 
 
 def test_knowledge_graph_evaluation_coverage(quality_dashboard_module):

--- a/util/generate-quality-dashboard.py
+++ b/util/generate-quality-dashboard.py
@@ -828,11 +828,14 @@ def build_dashboard_data(
     contacts_with_org_connection = 0
     contacts_without_org_connection = 0
 
-    total_products = 0
-    products_missing_format = 0
-    products_missing_original_source = 0
-    products_missing_product_url = 0
-    retrieval_warning_count = 0
+    # Product metrics are counted per unique product, not per product entry.
+    # ``propagate_products`` (util/extract-metadata.py) copies a derived product
+    # onto every Resource page listed as one of its sources, so a single product
+    # can appear on dozens of pages and would otherwise be counted once per
+    # appearance. The ``products_*`` / ``*_product_ids`` sets in ``detail_lists``
+    # are keyed on product ID and so are the authoritative counts; the aggregate
+    # figures are derived from them at the end of this function, which also keeps
+    # every dashboard number equal to the length of its own drill-down list.
 
     with_both_dates = 0
     modified_after_creation = 0
@@ -1015,7 +1018,6 @@ def build_dashboard_data(
         for idx, product in enumerate(products):
             if not isinstance(product, dict):
                 continue
-            total_products += 1
             product_id_value = product.get("id")
             if is_non_empty_text(product_id_value):
                 product_id = str(product_id_value)
@@ -1024,7 +1026,6 @@ def build_dashboard_data(
             detail_lists["product_total_ids"].add(product_id)
 
             if not is_non_empty_text(product.get("format")):
-                products_missing_format += 1
                 missing_format_for_resource += 1
                 detail_lists["products_missing_format_ids"].add(product_id)
 
@@ -1035,7 +1036,6 @@ def build_dashboard_data(
                     for source in iter_source_ids(product.get("original_source"))
                 )
                 if not has_source:
-                    products_missing_original_source += 1
                     missing_source_for_resource += 1
                     detail_lists["products_missing_original_source_ids"].add(product_id)
 
@@ -1043,7 +1043,6 @@ def build_dashboard_data(
             if is_non_empty_text(product_url):
                 url_targets.append((resource_id, product_id, str(product_url)))
             else:
-                products_missing_product_url += 1
                 missing_url_for_resource += 1
                 detail_lists["products_missing_product_url_ids"].add(product_id)
 
@@ -1054,7 +1053,6 @@ def build_dashboard_data(
             warning_values = ensure_list(product.get("warnings"))
             for warning in warning_values:
                 if isinstance(warning, str) and WARNING_RETRIEVAL_PATTERN.match(warning):
-                    retrieval_warning_count += 1
                     detail_lists["retrieval_warning_product_ids"].add(product_id)
                     if is_non_empty_text(product_url):
                         warning_url = str(product_url)
@@ -1183,11 +1181,11 @@ def build_dashboard_data(
             "validation_warnings": citation_validation_warnings,
         },
         "products": {
-            "total": total_products,
-            "missing_format": products_missing_format,
-            "missing_original_source": products_missing_original_source,
-            "missing_product_url": products_missing_product_url,
-            "retrieval_warning_mentions": retrieval_warning_count,
+            "total": len(detail_lists["product_total_ids"]),
+            "missing_format": len(detail_lists["products_missing_format_ids"]),
+            "missing_original_source": len(detail_lists["products_missing_original_source_ids"]),
+            "missing_product_url": len(detail_lists["products_missing_product_url_ids"]),
+            "with_retrieval_warning": len(detail_lists["retrieval_warning_product_ids"]),
         },
         "dates": {
             "with_both_dates": with_both_dates,


### PR DESCRIPTION
Fixes #668.

Every product metric on the [data quality dashboard](https://kghub.org/kg-registry/data-quality-dashboard.html) was incremented once per `(resource, product)` pair. Because `propagate_products` copies a derived Product onto the page of every Resource it names as a source, one Product appears on many Resource pages and was counted once per appearance.

| Metric | Before | After |
| --- | --- | --- |
| Products total | 8,405 | **3,841** |
| Missing format | 323 | 233 |
| Missing original_source | 5 | 5 |
| Missing product_url | 85 | 21 |
| Retrieval warnings | 537 (warning strings) | 134 (products) |

The per-product `detail_lists` sets were already keyed on product ID, so the summary cards disagreed with the drill-down lists they link to — the "Products" card read 8,405 while clicking it listed 3,833 IDs. This derives the aggregates from those sets, which fixes the counts and makes each figure equal the length of its own list by construction.

`products.retrieval_warning_mentions` counted warning strings rather than products; it becomes `products.with_retrieval_warning`, and the dashboard bar is relabeled from "Retrieval warning mentions" to "Retrieval warnings".

Of the 879 duplicated product IDs in the registry, exactly one has copies that differ in any field (a `format` difference), so deduplicating by ID is safe. A Product counts toward a completeness metric if any of its copies shows the issue — the union semantics `detail_lists` already used. Products with no `id` keep their synthetic `{resource_id}.product-{n}` fallback and are not merged.

`reports/quality-dashboard.json` is not included here; `make all` regenerates it with live link checks.

## Not addressed

Per-resource issue scoring still counts propagated copies, so a Resource is penalized for products it does not own but which were copied onto its page. That changes the "resources most in need of improvement" ranking and needs a definition of Product ownership, so it is left for a follow-up (noted on #668).

## Testing

- `tests/test_quality_dashboard.py`: two new tests — one for a product propagated across three Resource pages, asserting each metric counts it once and every figure matches its drill-down list; one asserting products without IDs are not merged. 9 passed.
- Full suite: 78 passed, 4 failed — the same 4 failures occur on `main` without these changes (`test_integrity`, `test_reference_validation`, `test_validate_domain_sanitization`, `test_validate_string_coercion`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)