### PR TITLE
Write frontmatter as text, not to a binary handle

### DIFF
--- a/src/kg_registry/ingests/kg-monarch/kg-monarch.py
+++ b/src/kg_registry/ingests/kg-monarch/kg-monarch.py
@@ -39,10 +39,25 @@ NODE_URL = "https://data.monarchinitiative.org/monarch-kg/latest/qc/node_report.
 
 STATE_DIR = ROOT / "build" / "ingests" / "kg-monarch"
 STATE_FILE = STATE_DIR / "state.json"
-RESOURCE_FILE = ROOT / "resource" / "kg-monarch" / "kg-monarch.md"
+RESOURCE_ID = "kg-monarch"
+RESOURCE_FILE = ROOT / "resource" / RESOURCE_ID / f"{RESOURCE_ID}.md"
 
 
 logger = logging.getLogger("kg_registry.ingests.kg_monarch")
+
+
+def _owned_by_resource(product_id: object) -> bool:
+    """Return True if `product_id` belongs to this resource.
+
+    Product IDs are namespaced as `<resource-id>.<suffix>`, so ownership is the
+    segment before the first dot. Compare that whole segment rather than using
+    str.startswith, which would also match a resource whose ID merely begins
+    with this one's. Mirrors util.source_associations.resource_owns_product,
+    which this script cannot import from src/.
+    """
+    if not isinstance(product_id, str) or "." not in product_id:
+        return False
+    return product_id.split(".", 1)[0] == RESOURCE_ID
 
 
 def http_last_modified(url: str) -> Optional[str]:
@@ -302,12 +317,19 @@ def update_resource(
         meta["last_modified_date"] = now_iso
         changed = True
 
-    # Update counts and types on all GraphProduct entries
+    # Update counts and types on the GraphProduct entries this resource owns.
+    # The page also lists products propagated here from every resource that cites
+    # kg-monarch as a source -- epigraphdb.graph among them -- and stamping
+    # Monarch's counts and predicate lists onto those describes them wrongly.
     products = meta.get("products") or []
     if isinstance(products, list):
         new_products = []
         for p in products:
-            if isinstance(p, dict) and p.get("category") == "GraphProduct":
+            if (
+                isinstance(p, dict)
+                and p.get("category") == "GraphProduct"
+                and _owned_by_resource(p.get("id"))
+            ):
                 # Compute whether any updates are needed
                 need_edge = p.get("edge_count") != edge_count
                 need_node = (node_count is not None) and (p.get("node_count") != node_count)
@@ -342,10 +364,10 @@ def update_resource(
 
     if changed:
         post.metadata = meta
-        with open(RESOURCE_FILE, "wb") as fwb:
-            frontmatter.dump(post, fd=fwb, handler=handler)
+        with open(RESOURCE_FILE, "w", encoding="utf-8") as fw:
+            fw.write(frontmatter.dumps(post, handler=handler))
         # Ensure trailing newline for content separation
-        with open(RESOURCE_FILE, "a") as fa:
+        with open(RESOURCE_FILE, "a", encoding="utf-8") as fa:
             fa.write("\n")
 
     return changed

--- a/tests/test_frontmatter_writing.py
+++ b/tests/test_frontmatter_writing.py
@@ -1,0 +1,60 @@
+"""Tests for writing YAML frontmatter back to disk.
+
+python-frontmatter 1.1.0 encoded in `dump` and wrote bytes, so callers opened
+files in binary mode. 1.2.0 changed `dump` to write `str`, which raises
+``TypeError: a bytes-like object is required, not 'str'`` against a binary
+handle -- every write-back path in the repo broke when the lockfile moved to
+1.3.0. These tests pin the behaviour the code now relies on.
+"""
+
+from pathlib import Path
+
+import frontmatter
+import pytest
+
+from util.common import CustomRuamelYAMLHandler, dump_frontmatter_text, save_frontmatter_file
+
+
+POST_TEXT = "---\nid: demo.product\nname: Demo\n---\n\nBody text.\n"
+
+
+@pytest.mark.parametrize("use_handler", [False, True])
+def test_dump_frontmatter_text_returns_str(use_handler):
+    post = frontmatter.loads(POST_TEXT)
+    handler = CustomRuamelYAMLHandler() if use_handler else None
+
+    text = dump_frontmatter_text(post, handler)
+
+    assert isinstance(text, str)
+    # No trailing newline, matching what frontmatter.dump used to write; callers
+    # append one themselves.
+    assert not text.endswith("\n")
+    assert frontmatter.loads(text).metadata["id"] == "demo.product"
+
+
+@pytest.mark.parametrize("use_ruamel", [False, True])
+def test_save_frontmatter_file_round_trips(tmp_path: Path, use_ruamel: bool):
+    target = tmp_path / "demo.md"
+
+    save_frontmatter_file(
+        target,
+        {"id": "demo.product", "name": "Demo", "tags": ["a", "b"]},
+        content="\nBody text.\n",
+        use_ruamel=use_ruamel,
+    )
+
+    reloaded = frontmatter.load(target)
+    assert reloaded.metadata["id"] == "demo.product"
+    assert reloaded.metadata["tags"] == ["a", "b"]
+    assert "Body text." in reloaded.content
+    # Written as text, not bytes: readable without an explicit decode.
+    assert target.read_text(encoding="utf-8").startswith("---")
+
+
+def test_save_frontmatter_file_handles_non_ascii(tmp_path: Path):
+    """UTF-8 is explicit, so the write does not depend on the locale encoding."""
+    target = tmp_path / "demo.md"
+
+    save_frontmatter_file(target, {"id": "demo.product", "name": "Ontología — José"}, content="")
+
+    assert frontmatter.load(target).metadata["name"] == "Ontología — José"

--- a/tests/test_kg_monarch_ingest.py
+++ b/tests/test_kg_monarch_ingest.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import duckdb  # type: ignore
+import frontmatter
 
 
 def _write_parquet_edges(path: Path):
@@ -58,3 +59,96 @@ def test_counts_and_types_from_parquet(tmp_path, kg_monarch_ingest_module):
         "biolink:Disease",
         "biolink:Gene",
     ]
+
+
+RESOURCE_PAGE = """---
+activity_status: active
+category: KnowledgeGraph
+id: kg-monarch
+last_modified_date: '2020-01-01T00:00:00Z'
+layout: resource_detail
+name: Monarch Knowledge Graph
+products:
+- category: GraphProduct
+  description: KGX distribution
+  id: kg-monarch.graph
+  name: KG-Monarch
+- category: GraphProduct
+  description: Propagated here because EpiGraphDB cites kg-monarch as a source
+  id: epigraphdb.graph
+  name: EpiGraphDB Graph
+- category: GraphicalInterface
+  description: Not a graph product
+  id: kg-monarch.web
+  name: Monarch Web
+---
+
+# Monarch Knowledge Graph
+
+Curated body text.
+"""
+
+
+def _prepare_resource(tmp_path, ingest, monkeypatch):
+    resource_file = tmp_path / "kg-monarch.md"
+    resource_file.write_text(RESOURCE_PAGE, encoding="utf-8")
+    monkeypatch.setattr(ingest, "RESOURCE_FILE", resource_file)
+    return resource_file
+
+
+def test_update_resource_writes_without_type_error(tmp_path, kg_monarch_ingest_module, monkeypatch):
+    """The write-back path must not hand a str to a binary file handle."""
+    ingest = kg_monarch_ingest_module
+    resource_file = _prepare_resource(tmp_path, ingest, monkeypatch)
+
+    changed = ingest.update_resource(
+        edge_count=15_807_241,
+        node_count=1_582_279,
+        predicates=["biolink:interacts_with"],
+        node_categories=["biolink:Gene"],
+    )
+
+    assert changed is True
+    post = frontmatter.load(resource_file)
+    assert "Curated body text." in post.content
+    assert post.metadata["last_modified_date"] != "2020-01-01T00:00:00Z"
+
+
+def test_update_resource_only_touches_products_it_owns(
+    tmp_path, kg_monarch_ingest_module, monkeypatch
+):
+    """Products propagated onto the page belong to other resources.
+
+    epigraphdb.graph is listed here only because EpiGraphDB cites kg-monarch as a
+    source. Writing Monarch's counts and predicate lists onto it would describe
+    EpiGraphDB's graph with Monarch's numbers.
+    """
+    ingest = kg_monarch_ingest_module
+    resource_file = _prepare_resource(tmp_path, ingest, monkeypatch)
+
+    ingest.update_resource(
+        edge_count=15_807_241,
+        node_count=1_582_279,
+        predicates=["biolink:interacts_with"],
+        node_categories=["biolink:Gene"],
+    )
+
+    products = {p["id"]: p for p in frontmatter.load(resource_file).metadata["products"]}
+
+    assert products["kg-monarch.graph"]["edge_count"] == 15_807_241
+    assert products["kg-monarch.graph"]["node_count"] == 1_582_279
+    assert products["kg-monarch.graph"]["predicates"] == ["biolink:interacts_with"]
+
+    for field in ("edge_count", "node_count", "predicates", "node_categories"):
+        assert field not in products["epigraphdb.graph"], f"{field} written to a foreign product"
+        assert field not in products["kg-monarch.web"], f"{field} written to a non-GraphProduct"
+
+
+def test_owned_by_resource_rejects_string_prefix_matches(kg_monarch_ingest_module):
+    ingest = kg_monarch_ingest_module
+
+    assert ingest._owned_by_resource("kg-monarch.graph.neo4j")
+    assert not ingest._owned_by_resource("kg-monarch-extras.graph")
+    assert not ingest._owned_by_resource("epigraphdb.graph")
+    assert not ingest._owned_by_resource("kg-monarch")
+    assert not ingest._owned_by_resource(None)

--- a/util/common.py
+++ b/util/common.py
@@ -41,6 +41,7 @@ __all__ = [
     "load_frontmatter_files_parallel",
     "save_frontmatter_file",
     "get_yaml_text",
+    "dump_frontmatter_text",
     "create_id_from_label",
     "get_today_iso",
     "get_separator_for_file",
@@ -178,6 +179,34 @@ def load_frontmatter_files_parallel(
     return results
 
 
+def dump_frontmatter_text(
+    post: "frontmatter.Post",
+    handler: Optional[frontmatter.YAMLHandler] = None,
+) -> str:
+    """
+    Serialize a frontmatter Post to text.
+
+    Use this instead of ``frontmatter.dump(post, fd)``. How ``dump`` treats the
+    file object changed in python-frontmatter 1.2.0: it used to encode the text
+    and write bytes, so callers opened files in binary mode, and it now writes
+    ``str``, which raises ``TypeError: a bytes-like object is required`` against
+    a binary handle. ``dumps`` returns text in every version, so going through it
+    and writing the result works either way.
+
+    The returned text has no trailing newline, matching what ``dump`` wrote.
+
+    Args:
+        post: The frontmatter Post to serialize
+        handler: Optional YAML handler controlling how metadata is emitted
+
+    Returns:
+        The serialized frontmatter document as a string
+    """
+    if handler is None:
+        return frontmatter.dumps(post)
+    return frontmatter.dumps(post, handler=handler)
+
+
 def save_frontmatter_file(
     filepath: pathlib.Path,
     metadata: Dict[str, Any],
@@ -196,13 +225,9 @@ def save_frontmatter_file(
     post = frontmatter.Post(content)
     post.metadata = metadata
 
-    if use_ruamel:
-        handler = CustomRuamelYAMLHandler()
-        with open(filepath, 'wb') as f:
-            frontmatter.dump(post, f, handler=handler)
-    else:
-        with open(filepath, 'wb') as f:
-            frontmatter.dump(post, f)
+    handler = CustomRuamelYAMLHandler() if use_ruamel else None
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write(dump_frontmatter_text(post, handler))
 
 
 def get_yaml_text(filepath: pathlib.Path) -> str:

--- a/util/create_infores_stubs.py
+++ b/util/create_infores_stubs.py
@@ -21,6 +21,11 @@ import yaml
 from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 
+try:
+    from util.common import dump_frontmatter_text
+except ModuleNotFoundError:
+    from common import dump_frontmatter_text
+
 __author__ = "kg-registry-team"
 
 HERE = pathlib.Path(__file__).parent.resolve()
@@ -318,10 +323,10 @@ If this should be a Product, add it to the appropriate parent Resource's `produc
     if not dry_run:
         # Create directory and write file
         resource_dir.mkdir(exist_ok=True, parents=True)
-        with open(resource_file, 'wb') as f:
-            frontmatter.dump(post, fd=f, handler=handler)
+        with open(resource_file, 'w', encoding='utf-8') as f:
+            f.write(dump_frontmatter_text(post, handler))
         # Add trailing newline
-        with open(resource_file, 'a') as f:
+        with open(resource_file, 'a', encoding='utf-8') as f:
             f.write('\n')
 
         print(f"  ✓ Created stub: {resource_file}")

--- a/util/extract-metadata.py
+++ b/util/extract-metadata.py
@@ -23,6 +23,7 @@ from ruamel.yaml.scanner import ScannerError
 from yamllint import config, linter
 
 try:
+    from util.common import dump_frontmatter_text
     from util.source_associations import (
         ensure_direct_product_primary_source,
         iter_source_ids,
@@ -37,6 +38,7 @@ try:
         validate_publication_references,
     )
 except ModuleNotFoundError:
+    from common import dump_frontmatter_text
     from source_associations import (
         ensure_direct_product_primary_source,
         iter_source_ids,
@@ -169,9 +171,10 @@ def prettify(args):
     for file in args.files:
         handler = CustomRuamelYAMLHandler()
         text = frontmatter.load(file, handler=handler)
-        file_obj = open(file, "wb")
-        frontmatter.dump(text, fd=file_obj, handler=handler)
-        file_obj = open(file, "a")
+        file_obj = open(file, "w", encoding="utf-8")
+        file_obj.write(dump_frontmatter_text(text, handler))
+        file_obj.close()
+        file_obj = open(file, "a", encoding="utf-8")
         file_obj.write("\n")
         file_obj.close()
 
@@ -220,10 +223,10 @@ def validate_markdown(args):
         # If modified, write back in-place using ruamel to preserve formatting and quotes
         if obj != original_obj:
             post.metadata = obj
-            with open(fn, "wb") as fwb:
-                frontmatter.dump(post, fd=fwb, handler=handler)
+            with open(fn, "w", encoding="utf-8") as fw:
+                fw.write(dump_frontmatter_text(post, handler))
             # Ensure trailing newline after frontmatter/content
-            with open(fn, "a") as fa:
+            with open(fn, "a", encoding="utf-8") as fa:
                 fa.write("\n")
 
         # If this is the root of the resource, validate against the Resource class
@@ -274,9 +277,9 @@ def validate_markdown(args):
                     if index not in removed_indexes
                 ]
                 post.metadata = obj
-                with open(fn, "wb") as fwb:
-                    frontmatter.dump(post, fd=fwb, handler=handler)
-                with open(fn, "a") as fa:
+                with open(fn, "w", encoding="utf-8") as fw:
+                    fw.write(dump_frontmatter_text(post, handler))
+                with open(fn, "a", encoding="utf-8") as fa:
                     fa.write("\n")
                 warn.append(
                     f"{fn}: removed {len(removed_indexes)} invalid publication reference(s): "

--- a/util/organizations.py
+++ b/util/organizations.py
@@ -24,6 +24,7 @@ from common import (
     ORG_DIR,
     REGISTRY_DIR,
     create_id_from_label,
+    dump_frontmatter_text,
     get_today_iso,
     load_frontmatter_file,
     save_frontmatter_file,
@@ -418,8 +419,8 @@ def update_resource_contacts(
                 if not dry_run:
                     post = frontmatter.Post(content or "")
                     post.metadata = metadata
-                    with open(md_file, 'wb') as f:
-                        frontmatter.dump(post, f)
+                    with open(md_file, 'w', encoding='utf-8') as f:
+                        f.write(dump_frontmatter_text(post))
                 updated += 1
 
     return updated
@@ -558,8 +559,8 @@ def process_resource_organizations(
 
                     post = frontmatter.Post(content or "")
                     post.metadata = metadata
-                    with open(resource_file, 'wb') as f:
-                        frontmatter.dump(post, f)
+                    with open(resource_file, 'w', encoding='utf-8') as f:
+                        f.write(dump_frontmatter_text(post))
 
                     contacts_updated += 1
                     if verbose:

--- a/util/populate_infores_ids.py
+++ b/util/populate_infores_ids.py
@@ -22,11 +22,13 @@ from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 
 try:
+    from util.common import dump_frontmatter_text
     from util.source_associations import (
         ORIGINAL_SOURCE_RELATION,
         merge_source_associations,
     )
 except ModuleNotFoundError:
+    from common import dump_frontmatter_text
     from source_associations import (
         ORIGINAL_SOURCE_RELATION,
         merge_source_associations,
@@ -259,9 +261,9 @@ def update_resource_infores(
     # Write back if modified
     if modified and not dry_run:
         post.metadata = metadata
-        with open(resource_path, 'wb') as f:
-            frontmatter.dump(post, fd=f, handler=handler)
-        with open(resource_path, 'a') as f:
+        with open(resource_path, 'w', encoding='utf-8') as f:
+            f.write(dump_frontmatter_text(post, handler))
+        with open(resource_path, 'a', encoding='utf-8') as f:
             f.write('\n')
 
     return modified, messages


### PR DESCRIPTION
Fixes #670.

## Root cause

python-frontmatter **1.1.0** ended `dump` with:

```python
content = dumps(post, handler, **kwargs)
if hasattr(fd, "write"):
    fd.write(content.encode(encoding))   # bytes
```

Its own docstring used `BytesIO`, so every caller in this repo correctly opened its target with `"wb"`. **1.2.0** changed that line to `fd.write(content)` — a `str` — and `is_writable` accepts anything with a `.write` attribute, so a binary handle now raises:

```
TypeError: a bytes-like object is required, not 'str'
```

`uv.lock` moved python-frontmatter 1.1.0 → 1.3.0 in `1cdd40c` (2026-06-26). That broke **all ten** `frontmatter.dump(post, fd=<binary>)` call sites at once:

| File | Sites |
| --- | --- |
| `src/kg_registry/ingests/kg-monarch/kg-monarch.py` | 1 — the one CI runs, hence #670 |
| `util/extract-metadata.py` | 3 — `prettify`, and two `validate` write-back paths |
| `util/common.py` | 2 — `save_frontmatter_file` |
| `util/organizations.py` | 2 |
| `util/populate_infores_ids.py` | 1 |
| `util/create_infores_stubs.py` | 1 |

It also explains three test failures that had been standing since the bump — the ones I'd been reporting as "pre-existing" on the last three PRs. They are the same `TypeError` at `frontmatter/__init__.py:243`:

- `test_validate_coerces_numeric_strings_and_writes_back`
- `test_invalid_domains_are_removed_and_valid_remain`
- `test_validate_markdown_can_remove_invalid_publications`

## The fix

`dumps` is documented to return text in every version, so `common.dump_frontmatter_text` goes through it and callers write the result to a text handle with an explicit `encoding="utf-8"`. This is correct against 1.1.0 and 1.3.0 alike, so the `python-frontmatter>=1.1.0` floor in `pyproject.toml` still holds and no version pin is needed.

`dumps` returns text with no trailing newline in both versions, matching what `dump` wrote — verified, so the call sites that append `"\n"` separately are unchanged in behaviour.

## A data bug the fix exposed

Once the ingest ran, it turned out to update **every** `GraphProduct` on the page — including products propagated there from resources that cite kg-monarch as a source. The first successful run stamped Monarch's 15,807,241 edges, 1,582,279 nodes, 61 predicates and 19 node categories onto `epigraphdb.graph`, a product **EpiGraphDB owns**:

```
--- kg-monarch page BEFORE ingest      edge_count: None
--- kg-monarch page AFTER ingest       edge_count: 15807241   <-- Monarch's numbers
--- epigraphdb page (owner)            edge_count: None
```

It now updates only products namespaced under `kg-monarch`, using the same whole-first-segment rule as `resource_owns_product` (#671). The script lives under `src/` and cannot import from `util/`, so the check is a small local mirror with a comment pointing at the shared helper.

Fixing the crash without this would have shipped a data regression on the next scheduled run.

## Verification

Ran the ingest against live Monarch data — the exact command and line that failed in the linked CI run:

```
$ uv run python src/kg_registry/ingests/kg-monarch/kg-monarch.py --force
INFO: Monarch counts: edges=15,807,241, nodes=1,582,279
INFO: Distinct predicates: 61
INFO: Distinct node categories: 19
exit=0
```

Same counts as the failing CI run, now completing. It updates the nine `kg-monarch.graph*` products and leaves `epigraphdb.graph` untouched. Also smoke-tested `prettify` on a real resource page and exercised the write pattern each repaired site uses, with and without the ruamel handler, including non-ASCII metadata.

## Testing

Eight new tests (102 passed, up from 91):

- `tests/test_frontmatter_writing.py` (new) — `dump_frontmatter_text` returns `str` with no trailing newline with and without a handler; `save_frontmatter_file` round-trips in both modes and handles non-ASCII without depending on the locale encoding
- `tests/test_kg_monarch_ingest.py` — `update_resource` writes without `TypeError` and preserves the markdown body; it sets counts on the owned product and leaves both `epigraphdb.graph` and a non-`GraphProduct` untouched; `_owned_by_resource` rejects string-prefix matches like `kg-monarch-extras.graph`

Only one failure remains on this branch, `test_root_resource_publication_identifiers_use_supported_formats`. It is unrelated — `agro`, `sepio` and `unii` carry `url:`-prefixed publication identifiers — and fails on `main` too. Worth its own issue.

## One thing to expect

The ingest's ruamel handler indents sequences where the committed `kg-monarch.md` does not, so its first successful write reformats that file (~1750 lines). I confirmed this is cosmetic: markdown body identical, metadata keys identical, and the only value changes are the counts and `last_modified_date` the ingest is meant to set. A subsequent `make all` leaves the new formatting alone, so it is a one-time normalisation rather than a ping-pong. Not included in this PR — CI regenerates the file — but it will show up in the next "Update registry files" commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)