### PR TITLE
Speed up the Update Registry Files build

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -33,4 +33,8 @@ jobs:
           git add registry/kgs.jsonld registry/kgs.yml registry/parquet/*.parquet registry/taxon_mapping.yaml
           git add registry/parquet-downloads.html assets/js/duckdb/*
           git add resource/*.md reports/ _config.yml _data/schema.yaml
+          # Persist the URL/reference caches the build just refreshed. Without
+          # this they die with the runner, so every run re-checks every URL from
+          # scratch and the cache TTLs never do anything.
+          git add cache/
           git diff --quiet && git diff --staged --quiet || (git commit -m "Update registry files" && git push)

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -227,7 +227,11 @@ Content
 """
     )
 
-    monkeypatch.setattr(mod, "validate", lambda **_: SimpleNamespace(results=[]))
+    monkeypatch.setattr(
+        mod,
+        "get_schema_validator",
+        lambda: SimpleNamespace(validate=lambda *_: SimpleNamespace(results=[])),
+    )
 
     def fake_validate_publication_references(*args, **kwargs):
         return SimpleNamespace(errors=["publication mismatch"], warnings=["publication warning"])
@@ -271,7 +275,11 @@ Content
 """
     )
 
-    monkeypatch.setattr(mod, "validate", lambda **_: SimpleNamespace(results=[]))
+    monkeypatch.setattr(
+        mod,
+        "get_schema_validator",
+        lambda: SimpleNamespace(validate=lambda *_: SimpleNamespace(results=[])),
+    )
 
     def fake_validate_publication_references(*args, **kwargs):
         return SimpleNamespace(errors=["publication mismatch"], warnings=["publication warning"])
@@ -322,7 +330,11 @@ Content
 """
     )
 
-    monkeypatch.setattr(mod, "validate", lambda **_: SimpleNamespace(results=[]))
+    monkeypatch.setattr(
+        mod,
+        "get_schema_validator",
+        lambda: SimpleNamespace(validate=lambda *_: SimpleNamespace(results=[])),
+    )
 
     def fake_validate_publication_references(*args, **kwargs):
         return SimpleNamespace(

--- a/util/extract-metadata.py
+++ b/util/extract-metadata.py
@@ -14,7 +14,11 @@ import yaml
 
 from copy import deepcopy
 from frontmatter.util import u
-from linkml.validator import validate
+from functools import lru_cache
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml_runtime.linkml_model.meta import SchemaDefinition
+from linkml_runtime.loaders import yaml_loader
 from yaml.parser import ParserError
 from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
@@ -69,6 +73,20 @@ if str(ROOT / "src") not in sys.path:
 # and CI builds, so keep it opt-in.
 PARALLEL_LOADING = os.environ.get("PARALLEL_LOADING", "no").lower() in ("yes", "true", "1")
 PARALLEL_WORKERS = int(os.environ.get("PARALLEL_WORKERS", "10"))
+
+
+@lru_cache(maxsize=1)
+def get_schema_validator():
+    """
+    Build the LinkML validator for the combined schema, once per process.
+
+    This mirrors what `linkml.validator.validate()` does internally, but that
+    helper reloads the schema and re-materializes the JSON Schema on every call.
+    Validating ~1000 resources that way costs ~0.8s each; reusing one validator
+    brings it down to ~0.03s each.
+    """
+    schema = yaml_loader.load(str(SOURCE_SCHEMA_PATH), target_class=SchemaDefinition)
+    return Validator(schema, validation_plugins=[JsonschemaValidationPlugin(closed=True)])
 
 
 def main():
@@ -237,7 +255,7 @@ def validate_markdown(args):
         else:
             continue
 
-        report = validate(instance=obj, schema=str(SOURCE_SCHEMA_PATH), target_class=target_class)
+        report = get_schema_validator().validate(obj, target_class)
         if report.results:
             for result in report.results:
                 if result.severity == "ERROR":


### PR DESCRIPTION
The `Update Registry Files` action has been taking 20–40 minutes. Profiling the two most recent successful runs via the Actions API shows two causes, addressed here in one commit each.

## 1. The LinkML validator was rebuilt once per resource

`util/extract-metadata.py` called `linkml.validator.validate()` inside the per-file loop. That helper is a convenience wrapper around `_get_default_validator()`, which re-reads the 370 KB combined schema from disk and re-materializes the JSON Schema on **every call** — roughly 1000 times per build.

Hoisting the validator into an `lru_cache`d factory, with the same configuration the wrapper applies:

| | per resource | × 1013 resources |
|---|---|---|
| before | 0.775 s | ~785 s |
| after | 0.028 s | ~28 s (+0.2 s setup) |

In CI this step was **659 s of a 23-minute build** (501 s in the 47-minute one) — the largest single item in both.

Behaviour is unchanged: stdout, stderr and exit codes are byte-identical to the previous implementation across a 120-file sample, a sample chosen to produce publication-reference warnings, and a deliberately invalid resource, which still trips the closed-schema `Additional properties are not allowed` check.

## 2. The URL caches were thrown away every run

The build refreshes `cache/url_status_cache.yml`, `cache/quality_url_status_cache.yml` and others as it goes, and they carry TTLs (14 days for the quality dashboard). The commit step never staged `cache/`, so those refreshes died with the runner and the committed copies went stale permanently — `quality_url_status_cache.yml` was last committed 2026-06-27, `url_status_cache.yml` on 2026-06-26.

Past the TTL, every run re-checks every URL live and discards the results. This is what drives the build-time variance, since the cost depends on which remote hosts are hanging that day:

| run | quality-dashboard step |
|---|---|
| 30576011976 | 3 m 41 s |
| 30393020957 | **31 m 56 s** |

All seven files under `cache/` are already tracked, so `git add cache/` stages exactly what the build regenerated.

## Expected effect

Fix 1 saves ~10 minutes on every run. Fix 2 makes the link-checking cost stable rather than occasionally catastrophic.

One caveat: the committed caches are currently stale, so the **first** run after merge still pays for a full re-check. It will commit a fresh cache at the end, and runs after that should settle around 8–10 minutes.

## Testing

- `uv run pytest tests/` — 102 passed, 6 subtests passed.
- Three tests in `tests/test_reference_validation.py` monkeypatched the now-removed `validate` symbol; updated to stub `get_schema_validator` instead.
- `tests/test_integrity.py::test_root_resource_publication_identifiers_use_supported_formats` fails, but it also fails on a clean `main` — it flags `url:`-style publication identifiers in `agro`, `sepio` and `unii`, and is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)