### PR TITLE
Commit the generated artifacts the site actually serves

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -25,16 +25,45 @@ jobs:
           
       - name: Update registry files
         run: uv run make all
-          
+
+      # Runs before the commit: if the derived files disagree with kgs.yml the
+      # build produced an inconsistent registry, and committing half of it would
+      # publish worse data than doing nothing.
+      - name: Check generated artifacts are in sync
+        run: uv run make check-artifacts
+
       - name: Commit and push changes
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git add registry/kgs.jsonld registry/kgs.yml registry/parquet/*.parquet registry/taxon_mapping.yaml
+          # Every generated target of `make all` has to be staged here, or it
+          # dies with the runner and the site serves a stale copy. kgs-summary.json
+          # in particular is what the home page table actually fetches, so leaving
+          # it out silently freezes the resource browser (see registry-data.js).
+          git add registry/kgs.jsonld registry/kgs.yml registry/kgs-summary.json registry/kgs.ttl
+          git add registry/organizations.yml registry/parquet/*.parquet registry/taxon_mapping.yaml
           git add registry/parquet-downloads.html assets/js/duckdb/*
-          git add resource/*.md reports/ _config.yml _data/schema.yaml
+          # resource pages live at resource/<id>/<id>.md, so a top-level *.md
+          # glob matches nothing. Stage the directory to pick up adds, edits and
+          # the product pages the build reaps.
+          git add resource/ reports/ _config.yml _data/schema.yaml
           # Persist the URL/reference caches the build just refreshed. Without
           # this they die with the runner, so every run re-checks every URL from
           # scratch and the cache TTLs never do anything.
           git add cache/
           git diff --quiet && git diff --staged --quiet || (git commit -m "Update registry files" && git push)
+
+      # Deliberately after the push: anything `make all` touched but the step
+      # above does not stage is a file the site will serve a stale copy of. This
+      # fails the job so it gets noticed, but only once the registry update
+      # itself is safely committed. tmp/ is scratch space the build recreates.
+      - name: Check for unstaged build output
+        run: |
+          leftover=$(git status --porcelain -- . ':(exclude)tmp/')
+          if [ -n "$leftover" ]; then
+            echo "::error::'make all' changed files that the commit step does not stage:"
+            echo "$leftover"
+            echo "Add them to the 'git add' list in this workflow, or the site will serve stale copies."
+            exit 1
+          fi
+          echo "No unstaged build output."

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ SCHEMA_DOC_DIR = docs/schema
 SCHEMA_DIR = src/kg_registry/kg_registry_schema
 
 ### Main Tasks
-.PHONY: all pull_and_build test pull clean sync-obo-foundry sync-frink quality-dashboard
+.PHONY: all pull_and_build test pull clean sync-obo-foundry sync-frink quality-dashboard check-artifacts
 
 all: \
 	ingest-kg-monarch \
@@ -217,6 +217,12 @@ registry/kgs-summary.json: registry/kgs.yml
 # Generate Turtle RDF serialization from YAML
 registry/kgs.ttl: registry/kgs.yml
 	$(RUN) python ./util/yaml2ttl.py $< $@.tmp && mv $@.tmp $@
+
+# Verify the derived artifacts agree with registry/kgs.yml. Run after `make all`
+# so a file that failed to regenerate -- or regenerated but never got committed --
+# fails loudly instead of quietly serving stale data to the site.
+check-artifacts:
+	$(RUN) python ./util/check_generated_artifacts.py
 
 ### Validate Configuration Files
 

--- a/tests/test_generated_artifacts_check.py
+++ b/tests/test_generated_artifacts_check.py
@@ -1,0 +1,100 @@
+"""Tests for the generated-artifact sync check.
+
+These exercise the checker against synthetic trees rather than the real
+repository. The repo's own committed summary is expected to be stale between
+registry updates -- it is the update-registry workflow, not CI, that regenerates
+it -- so asserting on the real files here would fail every resource-addition PR.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from util.check_generated_artifacts import REQUIRED_ARTIFACTS, check
+
+
+def _write_tree(root: Path, registry_ids, summary_ids, omit=()):
+    """Lay out a minimal repo with the given resource ids in each artifact."""
+    for artifact in REQUIRED_ARTIFACTS:
+        if artifact in omit:
+            continue
+        path = root / artifact
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("placeholder\n")
+
+    if Path("registry/kgs.yml") not in omit:
+        (root / "registry/kgs.yml").write_text(
+            yaml.safe_dump({"resources": [{"id": i, "name": i} for i in registry_ids]})
+        )
+    if Path("registry/kgs-summary.json") not in omit:
+        (root / "registry/kgs-summary.json").write_text(
+            json.dumps({"resources": [{"id": i, "name": i} for i in summary_ids]})
+        )
+
+
+class TestCheckGeneratedArtifacts(unittest.TestCase):
+    def test_in_sync_tree_has_no_problems(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_tree(root, ["kg-a", "kg-b"], ["kg-a", "kg-b"])
+            self.assertEqual(check(root), [])
+
+    def test_resource_missing_from_summary_is_reported(self):
+        """The exact failure that froze the resource browser."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_tree(root, ["kg-a", "imo-knowledge-graph"], ["kg-a"])
+            problems = check(root)
+            self.assertTrue(problems)
+            joined = "\n".join(problems)
+            self.assertIn("out of sync", joined)
+            self.assertIn("imo-knowledge-graph", joined)
+
+    def test_extra_resource_in_summary_is_reported(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_tree(root, ["kg-a"], ["kg-a", "kg-removed"])
+            joined = "\n".join(check(root))
+            self.assertIn("kg-removed", joined)
+
+    def test_missing_artifact_is_reported(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omit = [Path("registry/kgs.ttl")]
+            _write_tree(root, ["kg-a"], ["kg-a"], omit=omit)
+            joined = "\n".join(check(root))
+            self.assertIn("registry/kgs.ttl is missing", joined)
+
+    def test_missing_registry_yaml_stops_before_comparison(self):
+        """No spurious sync error when there is nothing to compare against."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omit = [Path("registry/kgs.yml")]
+            _write_tree(root, [], ["kg-a"], omit=omit)
+            problems = check(root)
+            self.assertEqual(len(problems), 1)
+            self.assertIn("registry/kgs.yml is missing", problems[0])
+
+    def test_empty_registry_is_reported(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_tree(root, [], [])
+            joined = "\n".join(check(root))
+            self.assertIn("never be empty", joined)
+
+    def test_long_id_lists_are_truncated(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ids = [f"kg-{n:03d}" for n in range(30)]
+            _write_tree(root, ids, [])
+            joined = "\n".join(check(root))
+            self.assertIn("...and 10 more", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/util/check_generated_artifacts.py
+++ b/util/check_generated_artifacts.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Verify that the generated registry artifacts agree with the registry YAML.
+
+`registry/kgs.yml` is the build's source of truth, but the site serves several
+derived files alongside it. If one of those is regenerated and then not
+committed, nothing breaks loudly -- the site just keeps serving the stale copy.
+That is exactly how the home page silently froze: `registry/kgs-summary.json`
+is what the resource browser fetches (see assets/js/registry-data.js), it was
+missing from the `git add` list in .github/workflows/update-registry.yml, and
+the table showed a two-week-old registry while kgs.yml and kgs.jsonld were
+perfectly current.
+
+This runs after `make all` and fails the build if a derived artifact is absent
+or out of sync, so that class of drift cannot go unnoticed again.
+
+Run with: ``python util/check_generated_artifacts.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent.resolve()
+
+REGISTRY_YAML = Path("registry/kgs.yml")
+SUMMARY_JSON = Path("registry/kgs-summary.json")
+
+# Derived files that `make all` produces and the site serves. Every one of
+# these must exist and be staged by the update-registry workflow; add new
+# `make all` targets here as they are introduced.
+REQUIRED_ARTIFACTS = [
+    REGISTRY_YAML,
+    SUMMARY_JSON,
+    Path("registry/kgs.jsonld"),
+    Path("registry/kgs.ttl"),
+    Path("registry/organizations.yml"),
+    Path("registry/taxon_mapping.yaml"),
+    Path("registry/parquet-downloads.html"),
+    Path("_config.yml"),
+]
+
+# How many resources have to be present before an empty/tiny summary is
+# obviously a generation failure rather than a legitimately small registry.
+MIN_EXPECTED_RESOURCES = 1
+
+
+def _resource_ids(resources) -> set[str]:
+    return {r["id"] for r in resources if isinstance(r, dict) and "id" in r}
+
+
+def check(root: Path) -> list[str]:
+    """Return a list of problems; empty means everything is in sync."""
+    problems = []
+
+    missing = [p for p in REQUIRED_ARTIFACTS if not (root / p).is_file()]
+    for path in missing:
+        problems.append(f"{path} is missing -- did `make all` fail partway through?")
+
+    # The rest of the checks need both files, so stop here if either is absent.
+    if (root / REGISTRY_YAML) in {root / p for p in missing}:
+        return problems
+    if (root / SUMMARY_JSON) in {root / p for p in missing}:
+        return problems
+
+    with open(root / REGISTRY_YAML, "r") as stream:
+        registry = yaml.load(stream, Loader=yaml.SafeLoader)
+    with open(root / SUMMARY_JSON, "r") as stream:
+        summary = json.load(stream)
+
+    registry_ids = _resource_ids(registry.get("resources", []))
+    summary_ids = _resource_ids(summary.get("resources", []))
+
+    if len(registry_ids) < MIN_EXPECTED_RESOURCES:
+        problems.append(
+            f"{REGISTRY_YAML} contains {len(registry_ids)} resources; "
+            "the registry should never be empty."
+        )
+
+    only_in_registry = sorted(registry_ids - summary_ids)
+    only_in_summary = sorted(summary_ids - registry_ids)
+
+    if only_in_registry or only_in_summary:
+        problems.append(
+            f"{SUMMARY_JSON} is out of sync with {REGISTRY_YAML} "
+            f"({len(registry_ids)} vs {len(summary_ids)} resources). "
+            f"Regenerate it with `make {SUMMARY_JSON}` and commit the result."
+        )
+    for resource_id in only_in_registry[:20]:
+        problems.append(f"  missing from the summary: {resource_id}")
+    if len(only_in_registry) > 20:
+        problems.append(f"  ...and {len(only_in_registry) - 20} more")
+    for resource_id in only_in_summary[:20]:
+        problems.append(f"  in the summary but not the registry: {resource_id}")
+    if len(only_in_summary) > 20:
+        problems.append(f"  ...and {len(only_in_summary) - 20} more")
+
+    return problems
+
+
+def main() -> int:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=ROOT,
+        help="repository root to check (default: the repo this script lives in)",
+    )
+    args = parser.parse_args()
+
+    problems = check(args.root)
+    if problems:
+        print("Generated registry artifacts are out of sync:", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+
+    print("Generated registry artifacts are in sync.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The problem

The resource browser on the main page hasn't reflected new entries since 2026-07-15. PR #675 added the IMO Health Knowledge Graph, it's correctly in `registry/kgs.yml` and `_config.yml`, and it does not appear in the table.

The registry data is fine. The main page just reads a different file.

Since #662 the home page table no longer loads `kgs.jsonld`. It fetches a slim summary:

```js
// assets/js/registry-data.js
var SUMMARY_URL = base + 'registry/kgs-summary.json';
var FULL_URL    = base + 'registry/kgs.jsonld';   // fallback only
```

`make all` regenerates `registry/kgs-summary.json`, but it was missing from the `git add` list in `update-registry.yml`. So every run built it and then discarded it with the runner. Last-commit dates on `main` before this PR:

| file | last committed |
|---|---|
| `registry/kgs.jsonld` | 2026-07-30 (current) |
| `registry/kgs.yml` | 2026-07-30 (current) |
| `_config.yml` | 2026-07-30 (current) |
| **`registry/kgs-summary.json`** | **2026-07-15** — the commit that introduced it |
| `registry/kgs.ttl` | 2026-06-26 |
| `registry/organizations.yml` | 2026-06-26 |

The committed summary has 1012 resources and no `imo-knowledge-graph`; `kgs.yml` has 1013 and does. IMO is not the only casualty — everything from #667 onward is invisible in the browser.

Two more `make all` targets were unstaged for the same reason: `registry/kgs.ttl` (served by the Turtle download link in `_includes/table_widget.html`) and `registry/organizations.yml`. Separately, `git add resource/*.md` matched **nothing** — resource pages live at `resource/<id>/<id>.md`, one level down.

## The fix

Stage the missing paths, and guard the class of bug rather than just this instance:

- **`util/check_generated_artifacts.py`** verifies every `make all` target exists and that the summary's resource-id set matches `kgs.yml`'s, naming the drifted ids. Exposed as `make check-artifacts`. Against `main` as it stands today it reproduces the bug exactly:

  ```
  registry/kgs-summary.json is out of sync with registry/kgs.yml (1013 vs 1012 resources).
  Regenerate it with `make registry/kgs-summary.json` and commit the result.
    missing from the summary: imo-knowledge-graph
  ```

- Two new workflow steps, deliberately on opposite sides of the commit:
  - **before** the commit — if the derived files disagree with `kgs.yml`, the build produced an inconsistent registry, and committing half of it publishes worse data than doing nothing;
  - **after** the push — fails the job if `make all` touched anything the `git add` list doesn't stage, so a future target can't quietly go uncommitted. After the push so a false positive can't withhold the registry update, which is the failure it exists to prevent.

- **7 tests** covering the checker, including one reproducing the IMO case.

## Merging this does not unstick the site

The fix only takes effect on the next `update-registry` run, and that's triggered by pushes touching `registry/**` or `resource/**`. **Please fire a `workflow_dispatch` after merging** — one run will regenerate and commit the summary, and the browser catches up in a single shot.

## Notes

- `git add resource/` now stages deletions, which is what #673's product-page reaping wants. Flagging it because the broken glob was masking that behavior.
- The tests assert against synthetic trees, not the real repo. Between registry updates the committed summary is legitimately behind — only `update-registry` regenerates it — so a real-file assertion would fail every resource-addition PR.
- Two adjacent problems found while working on this, both out of scope here: CI's test runner sees 18 of the suite's 110 tests (#677), and `tox -e lint` runs `black` in write mode rather than `--check`, so the lint job reformats files and can never fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
