### PR TITLE
Add COURAGE Knowledge Graph

### DIFF
--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -1162,6 +1162,24 @@ entries:
     source_path: resource/corum/corum.md
     status: valid
     warnings: []
+  resource/courage/courage.md#publication[0]#DOI:10.3390/fi13110277:
+    checked_at: '2026-08-06T17:51:30Z'
+    errors: []
+    fingerprint: cb43643fa38373d87c7d1219f819dbd4e85839deb949140ac1ed7f0285e42c3a
+    publication_index: 0
+    reference_id: DOI:10.3390/fi13110277
+    source_path: resource/courage/courage.md
+    status: valid
+    warnings: []
+  resource/courage/courage.md#publication[1]#DOI:10.1007/978-3-030-36599-8_37:
+    checked_at: '2026-08-06T17:51:31Z'
+    errors: []
+    fingerprint: 5fe1875efd7817e758e0cf560cfb2991c817fe1a70d5dd583a8588776c49acfb
+    publication_index: 1
+    reference_id: DOI:10.1007/978-3-030-36599-8_37
+    source_path: resource/courage/courage.md
+    status: valid
+    warnings: []
   resource/cpathkg/cpathkg.md#publication[0]#DOI:10.1093/jamiaopen/ooaf001:
     checked_at: '2026-06-22T16:25:55Z'
     errors: []

--- a/references_cache/DOI_10.1007_978-3-030-36599-8_37.md
+++ b/references_cache/DOI_10.1007_978-3-030-36599-8_37.md
@@ -1,0 +1,18 @@
+---
+reference_id: DOI:10.1007/978-3-030-36599-8_37
+title: Enriching Wikidata with Cultural Heritage Data from the COURAGE Project
+authors:
+- Ghazal Faraj
+- András Micsik
+journal: Communications in Computer and Information Science
+year: '2019'
+doi: 10.1007/978-3-030-36599-8_37
+content_type: unavailable
+---
+
+# Enriching Wikidata with Cultural Heritage Data from the COURAGE Project
+**Authors:** Ghazal Faraj, András Micsik
+**Journal:** Communications in Computer and Information Science (2019)
+**DOI:** [10.1007/978-3-030-36599-8_37](https://doi.org/10.1007/978-3-030-36599-8_37)
+
+## Content

--- a/references_cache/DOI_10.3390_fi13110277.md
+++ b/references_cache/DOI_10.3390_fi13110277.md
@@ -1,0 +1,20 @@
+---
+reference_id: DOI:10.3390/fi13110277
+title: Representing and Validating Cultural Heritage Knowledge Graphs in CIDOC-CRM Ontology
+authors:
+- Ghazal Faraj
+- András Micsik
+journal: Future Internet
+year: '2021'
+doi: 10.3390/fi13110277
+content_type: abstract_only
+---
+
+# Representing and Validating Cultural Heritage Knowledge Graphs in CIDOC-CRM Ontology
+**Authors:** Ghazal Faraj, András Micsik
+**Journal:** Future Internet (2021)
+**DOI:** [10.3390/fi13110277](https://doi.org/10.3390/fi13110277)
+
+## Content
+
+In order to unify access to multiple heterogeneous sources of cultural heritage data, many datasets were mapped to the CIDOC-CRM ontology. CIDOC-CRM provides a formal structure and definitions for most cultural heritage concepts and their relationships. The COURAGE project includes historic data concerning people, organizations, cultural heritage collections, and collection items covering the period between 1950 and 1990. Therefore, CIDOC-CRM seemed the optimal choice for describing COURAGE entities, improving knowledge sharing, and facilitating the COURAGE dataset unification with other datasets. This paper introduces the results of translating the COURAGE dataset to CIDOC-CRM semantically. This mapping was implemented automatically according to predefined mapping rules. Several SPARQL queries were applied to validate the migration process manually. In addition, multiple SHACL shapes were conducted to validate the data and mapping models.

--- a/resource/courage/courage.md
+++ b/resource/courage/courage.md
@@ -1,0 +1,199 @@
+---
+activity_status: orphaned
+category: KnowledgeGraph
+contacts:
+- category: Individual
+  contact_details:
+  - contact_type: url
+    value: https://sztaki.hun-ren.hu/en/science/services/courage-knowledge-graph
+  label: András Micsik
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://cultural-opposition.eu/
+  label: COURAGE Project Consortium
+creation_date: '2026-08-06T00:00:00Z'
+description: The COURAGE knowledge graph is the linked data registry produced by the
+  COURAGE project (Cultural Opposition - Understanding the Cultural Heritage of Dissent
+  in the Former Socialist Countries). It describes public and private collections documenting
+  cultural opposition under socialism, roughly 1950 to 1990, across the member and
+  candidate states of the European Union that were part of the former socialist bloc.
+  Alongside collections it describes persons, person roles, organizations, groups,
+  events, and featured collection items, covering material such as dissident literature,
+  samizdat and other unofficial publications, underground music scenes, avant-garde
+  art, and religious and civic movements. Content was contributed by researchers from
+  more than fifteen countries, and descriptions are held simultaneously in fifteen
+  languages, which the project cited as a motivation for its RDF-based design. The
+  schema is the COURAGE Ontology, published in OWL; a separate effort re-expressed
+  the dataset in CIDOC-CRM and validated the conversion with SPARQL and SHACL, and
+  another linked COURAGE entities to Wikidata.
+domains:
+- other
+homepage_url: https://cultural-opposition.eu/
+id: courage
+last_modified_date: '2026-08-06T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://opendatacommons.org/licenses/by/1-0/
+  label: ODC-By 1.0
+name: COURAGE Knowledge Graph
+products:
+- category: GraphicalInterface
+  description: The COURAGE registry web interface, providing browsable and searchable
+    access to collections, persons, organizations, groups, events, and featured items,
+    with descriptions available in multiple languages.
+  format: http
+  id: courage.registry
+  name: COURAGE Registry
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: courage
+  product_url: https://cultural-opposition.eu/registry/
+- category: GraphProduct
+  description: Open data release of the COURAGE registry as linked data, covering collections,
+    featured items, groups, organizations, and persons. Published as a Zenodo archive
+    of RDF data, version 1.1 dated 2019-07-12.
+  format: rdfxml
+  id: courage.dump
+  latest_version: '1.1'
+  license:
+    id: https://opendatacommons.org/licenses/by/1-0/
+    label: ODC-By 1.0
+  name: COURAGE Registry Open Dataset
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: courage
+  product_url: https://doi.org/10.5281/zenodo.3333540
+  versions:
+  - '1.0'
+  - '1.1'
+- category: ProgrammingInterface
+  description: SPARQL endpoint over the COURAGE triple store, historically served from
+    the Hungarian Academy of Sciences infrastructure. The project reported that the
+    graph database and SPARQL made it practical to express complex queries over the
+    registry and to manage descriptions in fifteen languages at once.
+  format: http
+  id: courage.sparql
+  is_public: true
+  name: COURAGE SPARQL Endpoint
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: courage
+  product_url: http://courage.btk.mta.hu:3030/courage/query
+  warnings:
+  - 'Checked on 2026-08-06: the documented endpoint path returned HTTP 404. The endpoint
+    may have moved or been retired following the reorganization of the Hungarian Academy
+    of Sciences research network (MTA to HUN-REN). Use the Zenodo data dump instead,
+    or contact SZTAKI for current access.'
+- category: OntologyProduct
+  description: The COURAGE Ontology, the schema of the COURAGE registry, published
+    as an OWL file. It models collections, collection items, persons and their roles,
+    groups, organizations, and events in the domain of cultural opposition.
+  format: owl
+  id: courage.ontology
+  name: COURAGE Ontology
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: courage
+  warnings:
+  - A stable public URL for the OWL file was not located when this entry was created
+    on 2026-08-06. The ontology is described in the project publications and was distributed
+    with the registry.
+- category: DocumentationProduct
+  description: Service page for the COURAGE knowledge graph at HUN-REN SZTAKI, the
+    institute that built and hosted the graph, summarizing its contents and technical
+    basis.
+  format: http
+  id: courage.sztaki-page
+  name: COURAGE Knowledge Graph Service Page (SZTAKI)
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: courage
+  product_url: https://sztaki.hun-ren.hu/en/science/services/courage-knowledge-graph
+publications:
+- authors:
+  - Faraj G
+  - Micsik A
+  doi: 10.3390/fi13110277
+  id: doi:10.3390/fi13110277
+  journal: Future Internet
+  preferred: true
+  title: Representing and Validating Cultural Heritage Knowledge Graphs in CIDOC-CRM
+    Ontology
+  year: '2021'
+- authors:
+  - Faraj G
+  - Micsik A
+  doi: 10.1007/978-3-030-36599-8_37
+  id: doi:10.1007/978-3-030-36599-8_37
+  journal: Communications in Computer and Information Science
+  title: Enriching Wikidata with Cultural Heritage Data from the COURAGE Project
+  year: '2019'
+synonyms:
+- COURAGE
+- COURAGE Registry
+- 'Cultural Opposition: Understanding the Cultural Heritage of Dissent in the Former
+  Socialist Countries'
+warnings:
+- The COURAGE project ran from February 2016 to January 2019 and the graph is no longer
+  actively extended. The registry interface and the archived data dump remain available,
+  but the documented SPARQL endpoint did not respond when checked on 2026-08-06.
+---
+# COURAGE Knowledge Graph
+
+## Overview
+
+COURAGE — *Cultural Opposition: Understanding the Cultural Heritage of Dissent in the
+Former Socialist Countries* — built a registry of the scattered collections that
+document cultural opposition under socialism in Central and Eastern Europe. The
+project ran from February 2016 to January 2019 with twelve partner institutions,
+funded by the European Union's Horizon 2020 programme under grant agreement 692919
+(approximately €2.48M), and was led from the Hungarian Academy of Sciences
+(MTA BTK Research Centre for the Humanities) with the Institute of Philosophy and
+Sociology of the Polish Academy of Sciences (IFIS PAN) among the partners.
+
+The registry is a knowledge graph rather than a document collection: it describes
+collections and the people, groups, organizations, and events around them, linking
+private archives, institutional holdings, and individual estates that had never been
+described together.
+
+## Contents
+
+Entity types in the graph include collections, featured collection items, persons and
+person roles, groups, organizations, and events. Subject matter spans dissident
+literature and samizdat, underground and punk music scenes, avant-garde and
+unofficial art, religious movements, and civic and environmental opposition, roughly
+covering 1950 to 1990.
+
+Content was contributed by researchers in more than fifteen countries, and
+descriptions are maintained in fifteen languages simultaneously. The project reported
+that RDF made this multilingual text management straightforward and that SPARQL was
+what made the relationship-heavy queries over persons, collections, and organizations
+practical.
+
+## Access
+
+- The **registry web interface** at [cultural-opposition.eu/registry](https://cultural-opposition.eu/registry/)
+  remains available.
+- The **open data release** is archived on Zenodo
+  ([10.5281/zenodo.3333540](https://doi.org/10.5281/zenodo.3333540)), version 1.1
+  dated July 2019, under the Open Data Commons Attribution License 1.0.
+- The **SPARQL endpoint** documented by the project did not respond when checked for
+  this entry. The graph was hosted at SZTAKI, and the institutional reorganization of
+  the Hungarian research network (MTA to HUN-REN) is a plausible cause; the dump is
+  the reliable route to the data today.
+
+## Related work
+
+Two follow-on efforts are worth noting, both from SZTAKI:
+
+- A **CIDOC-CRM rendering** of the COURAGE data, with SPARQL and SHACL used to
+  validate the converted dataset — see the *Future Internet* paper below and the
+  [courage-crm repository](https://github.com/dsd-sztaki-hu/courage-crm).
+- An effort to **enrich Wikidata** with COURAGE cultural heritage entities.
+
+## Status
+
+Recorded as `orphaned`: the project has concluded, the graph is not being extended,
+and part of its documented infrastructure is no longer responding, but the registry
+and the archived dump are still usable.


### PR DESCRIPTION
Adds a `KnowledgeGraph` entry for the **COURAGE** registry — linked data describing collections of cultural opposition in the former socialist countries of Europe, roughly 1950–1990.

Closes #680

## What's in the entry

- **Products:** registry web interface, the archived open data release on Zenodo (v1.1, ODC-By 1.0), the historical SPARQL endpoint, the COURAGE Ontology, and the SZTAKI service page.
- **Publications:** the two SZTAKI follow-on papers — the CIDOC-CRM representation/validation paper (*Future Internet* 2021) and the Wikidata enrichment paper (2019). Reference metadata fetched into `references_cache`, so the citation validator passes with no warnings.
- **License:** ODC-By 1.0, taken from the Zenodo release rather than assumed.

## Status: `orphaned`, not `active`

The project ran February 2016 – January 2019 (H2020 grant 692919, 12 partners, led from MTA BTK with IFIS PAN). The registry interface and the Zenodo dump are still available, but:

- the documented SPARQL endpoint (`courage.btk.mta.hu:3030/courage/query`) returned **HTTP 404** when checked on 2026-08-06 — plausibly a casualty of the MTA → HUN-REN reorganization. Recorded as a product warning pointing users to the dump.
- no stable public URL for the COURAGE Ontology OWL file was found; the product is listed with that gap flagged rather than pointed at a guess.

Both are also summarized in a resource-level warning.

## Domain caveat

`domains` is `other` — `DomainEnum` has no cultural heritage or history term. A follow-up PR will add appropriate term(s) and update this entry.

Validated with `uv run ./util/extract-metadata.py validate` (clean, no warnings). Generated artifacts under `registry/` untouched, per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)