### PR TITLE
Add ERA Knowledge Graph (EU Agency for Railways)

### DIFF
--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -1998,6 +1998,15 @@ entries:
     source_path: resource/eqtlgen/eqtlgen.md
     status: valid
     warnings: []
+  resource/era-kg/era-kg.md#publication[0]#DOI:10.1007/978-3-032-09530-5_23:
+    checked_at: '2026-08-06T17:58:17Z'
+    errors: []
+    fingerprint: f7297ab1b861b997ead9908ec5e45389456d364520bff4584685b58e2c53a68d
+    publication_index: 0
+    reference_id: DOI:10.1007/978-3-032-09530-5_23
+    source_path: resource/era-kg/era-kg.md
+    status: valid
+    warnings: []
   resource/eram/eram.md#publication[0]#DOI:10.1093/nar/gkx1062:
     checked_at: '2026-06-12T20:32:32Z'
     errors: []

--- a/references_cache/DOI_10.1007_978-3-032-09530-5_23.md
+++ b/references_cache/DOI_10.1007_978-3-032-09530-5_23.md
@@ -1,0 +1,24 @@
+---
+reference_id: DOI:10.1007/978-3-032-09530-5_23
+title: "Using Semantic Technologies in the Railway Domain: The Register of Infrastructure (RINF) System"
+authors:
+- Jhon Toledo
+- Daniel Doña
+- Edna Ruckhaus
+- Oscar Corcho
+- Marina Aguado
+- Dragos Patru
+- Ghislain Atemezing
+- Polymnia Vasilopoulou
+journal: Lecture Notes in Computer Science
+year: '2026'
+doi: 10.1007/978-3-032-09530-5_23
+content_type: unavailable
+---
+
+# Using Semantic Technologies in the Railway Domain: The Register of Infrastructure (RINF) System
+**Authors:** Jhon Toledo, Daniel Doña, Edna Ruckhaus, Oscar Corcho, Marina Aguado, Dragos Patru, Ghislain Atemezing, Polymnia Vasilopoulou
+**Journal:** Lecture Notes in Computer Science (2026)
+**DOI:** [10.1007/978-3-032-09530-5_23](https://doi.org/10.1007/978-3-032-09530-5_23)
+
+## Content

--- a/resource/era-kg/era-kg.api.md
+++ b/resource/era-kg/era-kg.api.md
@@ -1,0 +1,19 @@
+---
+category: ProgrammingInterface
+description: SPARQL API path documented with the Agency's data releases as the public
+  query interface to the RINF knowledge graph.
+format: http
+id: era-kg.api
+is_public: true
+name: ERA Knowledge Graph SPARQL API
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://rinf.data.era.europa.eu/api/v1/sparql/rinf
+warnings:
+- Checked on 2026-08-06_ this path returned HTTP 500 with the message "SPARQL upstream
+  returned 500". The GraphDB endpoint at graph.data.era.europa.eu answered the same
+  queries successfully, so this appears to be a fault in the API layer rather than
+  in the graph.
+layout: product_detail
+---

--- a/resource/era-kg/era-kg.documentation.md
+++ b/resource/era-kg/era-kg.documentation.md
@@ -1,0 +1,14 @@
+---
+category: DocumentationProduct
+description: The Agency's ERA Knowledge Graph page, with a catalogue of curated SPARQL
+  queries organized by infrastructure type, covering parameter completeness, infrastructure
+  statistics, and comparisons between member states.
+format: http
+id: era-kg.documentation
+name: ERA Knowledge Graph Documentation and Query Catalogue
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://www.era.europa.eu/domains/registers/era-knowlege-graph_en
+layout: product_detail
+---

--- a/resource/era-kg/era-kg.dump.md
+++ b/resource/era-kg/era-kg.dump.md
@@ -1,0 +1,23 @@
+---
+category: GraphProduct
+description: Periodic full dump of the infrastructure knowledge graph, archived on
+  Zenodo under a versioned series with a concept DOI covering all releases. The most
+  recent release identified is v9.0 of 2026-06-29, a 3.75 GB TriG file (rinfplus.trig);
+  earlier releases were compressed N-Quads. The edge count recorded here is the triple
+  count reported by the live RINF+ repository on 2026-08-06.
+edge_count: 53716816
+id: era-kg.dump
+latest_version: v9.0
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
+name: ERA Knowledge Graph Dump
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://doi.org/10.5281/zenodo.14605743
+warnings:
+- The current release is serialized as TriG, for which the registry format enum has
+  no value, so no format is recorded for this product.
+layout: product_detail
+---

--- a/resource/era-kg/era-kg.graphdb.md
+++ b/resource/era-kg/era-kg.graphdb.md
@@ -1,0 +1,14 @@
+---
+category: GraphicalInterface
+description: GraphDB workbench for the Agency's linked data deployment, exposing the
+  RINF+, ERA ontology, and legislation repositories for interactive exploration and
+  query.
+format: http
+id: era-kg.graphdb
+name: ERA GraphDB Workbench
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://graph.data.era.europa.eu/
+layout: product_detail
+---

--- a/resource/era-kg/era-kg.mappings.md
+++ b/resource/era-kg/era-kg.mappings.md
@@ -1,0 +1,15 @@
+---
+category: ProcessProduct
+description: RML mapping definitions used to generate the ERA Knowledge Graph from
+  the source RINF data supplied by infrastructure managers and national registration
+  entities.
+format: ttl
+id: era-kg.mappings
+name: ERA Knowledge Graph RML Mappings
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://gitlab.com/era-europa-eu/public/interoperable-data-programme/era-ontology/era-kg-mappings
+repository: https://gitlab.com/era-europa-eu/public/interoperable-data-programme/era-ontology/era-kg-mappings
+layout: product_detail
+---

--- a/resource/era-kg/era-kg.md
+++ b/resource/era-kg/era-kg.md
@@ -1,0 +1,235 @@
+---
+activity_status: active
+category: KnowledgeGraph
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: url
+    value: https://www.era.europa.eu/agency/contact-us_en
+  - contact_type: url
+    value: https://rinf.data.era.europa.eu/
+  label: European Union Agency for Railways
+creation_date: '2026-08-06T00:00:00Z'
+description: The ERA Knowledge Graph is the RDF publication of the European Union Agency
+  for Railways' Register of Infrastructure (RINF) and related registers, released as
+  linked open data since 2021. It describes the European railway network as a graph
+  of operational points, sections of line, tracks, tunnels, sidings, and platforms,
+  together with the interoperability parameters attached to them, including load capability,
+  maximum permitted speed, gauging and gradient profiles, braking systems, energy supply
+  and contact line systems, train detection systems, and authorized vehicle types,
+  with geospatial location data organized by EU member state. Source data supplied
+  by infrastructure managers and national registration entities is converted to RDF
+  using RML mappings. The graph is formalized by the ERA Vocabulary (ERA Ontology),
+  which carries roughly 76 classes, 600 properties, 52 annotation properties, and more
+  than 80 SKOS concept schemes for coded parameter values, and is accompanied by SHACL
+  shapes used for validation. Entities are minted in the http://data.europa.eu/949/
+  namespace. The graph is served from a public GraphDB deployment and dumped periodically
+  to Zenodo; the infrastructure repository held roughly 53.7 million triples when checked
+  in August 2026.
+domains:
+- other
+homepage_url: https://www.era.europa.eu/domains/registers/era-knowlege-graph_en
+last_modified_date: '2026-08-06T00:00:00Z'
+layout: resource_detail
+id: era-kg
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
+name: ERA Knowledge Graph
+products:
+- category: ProgrammingInterface
+  description: Public SPARQL endpoint over the RINF+ repository, the infrastructure
+    graph expressed with the ERA Ontology 3.1.x model, served from the Agency's GraphDB
+    deployment. Verified queryable on 2026-08-06, when the repository reported 53,716,816
+    triples. Companion repositories on the same deployment hold the ERA ontology itself
+    (OWL, SKOS, and SHACL) and references to railway legislation.
+  format: http
+  id: era-kg.sparql
+  is_public: true
+  name: ERA Knowledge Graph SPARQL Endpoint (RINF+)
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://graph.data.era.europa.eu/repositories/rinf-plus
+- category: ProgrammingInterface
+  description: SPARQL API path documented with the Agency's data releases as the public
+    query interface to the RINF knowledge graph.
+  format: http
+  id: era-kg.api
+  is_public: true
+  name: ERA Knowledge Graph SPARQL API
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://rinf.data.era.europa.eu/api/v1/sparql/rinf
+  warnings:
+  - 'Checked on 2026-08-06: this path returned HTTP 500 with the message "SPARQL upstream
+    returned 500". The GraphDB endpoint at graph.data.era.europa.eu answered the same
+    queries successfully, so this appears to be a fault in the API layer rather than
+    in the graph.'
+- category: GraphicalInterface
+  description: GraphDB workbench for the Agency's linked data deployment, exposing the
+    RINF+, ERA ontology, and legislation repositories for interactive exploration and
+    query.
+  format: http
+  id: era-kg.graphdb
+  name: ERA GraphDB Workbench
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://graph.data.era.europa.eu/
+- category: GraphicalInterface
+  description: RINF linked data portal, the Agency's entry point for the infrastructure
+    knowledge graph, with documentation of the data model and access paths.
+  format: http
+  id: era-kg.portal
+  name: RINF Linked Data Portal
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://rinf.data.era.europa.eu/
+- category: GraphProduct
+  description: Periodic full dump of the infrastructure knowledge graph, archived on
+    Zenodo under a versioned series with a concept DOI covering all releases. The most
+    recent release identified is v9.0 of 2026-06-29, a 3.75 GB TriG file (rinfplus.trig);
+    earlier releases were compressed N-Quads. The edge count recorded here is the triple
+    count reported by the live RINF+ repository on 2026-08-06.
+  edge_count: 53716816
+  id: era-kg.dump
+  latest_version: v9.0
+  license:
+    id: https://creativecommons.org/licenses/by/4.0/
+    label: CC BY 4.0
+  name: ERA Knowledge Graph Dump
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://doi.org/10.5281/zenodo.14605743
+  warnings:
+  - The current release is serialized as TriG, for which the registry format enum has
+    no value, so no format is recorded for this product.
+- category: OntologyProduct
+  description: The ERA Vocabulary (ERA Ontology), defined by the European Union Agency
+    for Railways to describe European railway infrastructure and the vehicles authorized
+    to operate over it. It carries roughly 76 classes, 600 properties, and 52 annotation
+    properties, along with more than 80 SKOS concept schemes for coded parameter values,
+    and is distributed with SHACL shapes for validating conforming data.
+  format: owl
+  id: era-kg.ontology
+  name: ERA Vocabulary (ERA Ontology)
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://data-interop.era.europa.eu/era-vocabulary/
+  repository: https://gitlab.com/era-europa-eu/public/interoperable-data-programme/era-ontology/era-ontology
+- category: ProcessProduct
+  description: RML mapping definitions used to generate the ERA Knowledge Graph from
+    the source RINF data supplied by infrastructure managers and national registration
+    entities.
+  format: ttl
+  id: era-kg.mappings
+  name: ERA Knowledge Graph RML Mappings
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://gitlab.com/era-europa-eu/public/interoperable-data-programme/era-ontology/era-kg-mappings
+  repository: https://gitlab.com/era-europa-eu/public/interoperable-data-programme/era-ontology/era-kg-mappings
+- category: DocumentationProduct
+  description: The Agency's ERA Knowledge Graph page, with a catalogue of curated SPARQL
+    queries organized by infrastructure type, covering parameter completeness, infrastructure
+    statistics, and comparisons between member states.
+  format: http
+  id: era-kg.documentation
+  name: ERA Knowledge Graph Documentation and Query Catalogue
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: era-kg
+  product_url: https://www.era.europa.eu/domains/registers/era-knowlege-graph_en
+publications:
+- authors:
+  - Toledo J
+  - Doña D
+  - Ruckhaus E
+  - Corcho O
+  - Aguado M
+  - Patru D
+  - Atemezing G
+  - Vasilopoulou P
+  doi: 10.1007/978-3-032-09530-5_23
+  id: doi:10.1007/978-3-032-09530-5_23
+  journal: Lecture Notes in Computer Science
+  preferred: true
+  title: 'Using Semantic Technologies in the Railway Domain: The Register of Infrastructure
+    (RINF) System'
+  year: '2026'
+repository: https://gitlab.com/era-europa-eu/public/interoperable-data-programme/era-ontology
+synonyms:
+- ERA-KG
+- ERA RINF Knowledge Graph
+- EU Rail Knowledge Graph
+warnings:
+- '"ERA" here is the European Union Agency for Railways, not the European Research Area.
+  This graph describes railway infrastructure. For European research projects, organizations,
+  and funding, see the EURIO Knowledge Graph and the EU Knowledge Graph.'
+---
+# ERA Knowledge Graph
+
+## Overview
+
+The ERA Knowledge Graph is the linked open data publication of the European Union
+Agency for Railways' **Register of Infrastructure (RINF)**. RINF collects railway
+infrastructure data from infrastructure managers and national registration entities
+across EU member states; since 2021 the Agency has published that register as RDF,
+converted from the source data with RML mappings and served from a public GraphDB
+deployment.
+
+The graph is part of the Agency's Interoperable Data Programme, whose broader purpose
+is to make the registers underpinning railway interoperability queryable as data
+rather than only as documents.
+
+## Name disambiguation
+
+This resource is frequently confused with the **European Research Area**. It is not
+related: "ERA" here is the Agency, and the graph is about track, not about research
+funding. The registry entries covering European research projects and funding are
+`eurio` (the EURIO Knowledge Graph, CORDIS framework-programme data) and
+`eu-knowledge-graph` (the Commission's Wikibase graph of EU-financed projects).
+
+## Contents
+
+Infrastructure entities include operational points, sections of line, tracks, tunnels,
+sidings, and platforms, with interoperability parameters attached: load capability,
+maximum permitted speed, gauging and gradient profiles, braking systems, energy supply
+and contact line systems, train detection systems, and authorized vehicle types.
+Geospatial locations are included and the data is organized by member state. Entities
+are minted under `http://data.europa.eu/949/`.
+
+The semantics come from the **ERA Vocabulary (ERA Ontology)** — roughly 76 classes,
+600 properties, and 52 annotation properties, plus more than 80 SKOS concept schemes
+for coded parameter values — distributed with SHACL shapes for validation.
+
+## Access
+
+Verified on 2026-08-06:
+
+- The **GraphDB SPARQL endpoint** for the RINF+ repository
+  (`graph.data.era.europa.eu/repositories/rinf-plus`) answers queries and reported
+  **53,716,816 triples**. Sibling repositories on the same deployment hold the ERA
+  ontology (OWL, SKOS, SHACL; ~1.15M triples) and railway legislation references.
+- The **documented API path** (`rinf.data.era.europa.eu/api/v1/sparql/rinf`) returned
+  HTTP 500 with `SPARQL upstream returned 500`. Since the GraphDB endpoint answered
+  the same queries, this looks like an API-layer fault rather than a data problem, and
+  it is recorded as a product warning.
+- **Dumps** are archived on Zenodo as a versioned series under concept DOI
+  [10.5281/zenodo.14605743](https://doi.org/10.5281/zenodo.14605743). The latest
+  release identified is v9.0 (2026-06-29), a 3.75 GB TriG file; earlier releases were
+  compressed N-Quads. All are CC BY 4.0.
+
+## Notes on this entry
+
+`FormatEnum` has no value for TriG, the serialization of the current dump, and no
+`other` fallback either, so that product carries no format and a warning explaining
+why. Adding `trig` to `FormatEnum` would close the gap.
+
+Domains are recorded as `other`: this is transport infrastructure data, and
+`DomainEnum` has no term for it.

--- a/resource/era-kg/era-kg.ontology.md
+++ b/resource/era-kg/era-kg.ontology.md
@@ -1,0 +1,17 @@
+---
+category: OntologyProduct
+description: The ERA Vocabulary (ERA Ontology), defined by the European Union Agency
+  for Railways to describe European railway infrastructure and the vehicles authorized
+  to operate over it. It carries roughly 76 classes, 600 properties, and 52 annotation
+  properties, along with more than 80 SKOS concept schemes for coded parameter values,
+  and is distributed with SHACL shapes for validating conforming data.
+format: owl
+id: era-kg.ontology
+name: ERA Vocabulary (ERA Ontology)
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://data-interop.era.europa.eu/era-vocabulary/
+repository: https://gitlab.com/era-europa-eu/public/interoperable-data-programme/era-ontology/era-ontology
+layout: product_detail
+---

--- a/resource/era-kg/era-kg.portal.md
+++ b/resource/era-kg/era-kg.portal.md
@@ -1,0 +1,13 @@
+---
+category: GraphicalInterface
+description: RINF linked data portal, the Agency's entry point for the infrastructure
+  knowledge graph, with documentation of the data model and access paths.
+format: http
+id: era-kg.portal
+name: RINF Linked Data Portal
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://rinf.data.era.europa.eu/
+layout: product_detail
+---

--- a/resource/era-kg/era-kg.sparql.md
+++ b/resource/era-kg/era-kg.sparql.md
@@ -1,0 +1,17 @@
+---
+category: ProgrammingInterface
+description: Public SPARQL endpoint over the RINF+ repository, the infrastructure
+  graph expressed with the ERA Ontology 3.1.x model, served from the Agency's GraphDB
+  deployment. Verified queryable on 2026-08-06, when the repository reported 53,716,816
+  triples. Companion repositories on the same deployment hold the ERA ontology itself
+  (OWL, SKOS, and SHACL) and references to railway legislation.
+format: http
+id: era-kg.sparql
+is_public: true
+name: ERA Knowledge Graph SPARQL Endpoint (RINF+)
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: era-kg
+product_url: https://graph.data.era.europa.eu/repositories/rinf-plus
+layout: product_detail
+---


### PR DESCRIPTION
Adds a `KnowledgeGraph` entry for the **ERA Knowledge Graph**, the RDF publication of the European Union Agency for Railways' Register of Infrastructure (RINF).

Closes #681

## Verified against the live service, not just the docs

- The **GraphDB SPARQL endpoint** for the RINF+ repository (`graph.data.era.europa.eu/repositories/rinf-plus`) answers queries and reported **53,716,816 triples** on 2026-08-06. Recorded as the primary endpoint and as `edge_count` on the dump product.
- The **documented API path** (`rinf.data.era.europa.eu/api/v1/sparql/rinf`) returned **HTTP 500** (`SPARQL upstream returned 500`). Since GraphDB answered the same queries, this looks like an API-layer fault; listed with a warning rather than dropped or silently presented as working.
- Sibling repositories on the same deployment hold the ERA ontology (OWL/SKOS/SHACL, ~1.15M triples) and legislation references.
- Latest dump is **v9.0, 2026-06-29** — a 3.75 GB TriG file — under concept DOI [10.5281/zenodo.14605743](https://doi.org/10.5281/zenodo.14605743), CC BY 4.0. (The issue cited v5; v9 is current.)

## Two corrections to the issue's research

1. The ERA vocabulary GitHub repo cited in #681 (`Interoperable-data/ERA_vocabulary`) **returns 404** — the ontology lives on GitLab under the `era-ontology` group, which is what the entry uses.
2. The arXiv SHACL-DS paper cited in #681 (`arXiv:2605.10540`) **does not exist** — the arXiv API returns nothing for that ID and nothing for a `SHACL-DS` full-text search. It was a bad search result; it is not cited here. The only publication included is the RINF semantic technologies chapter (doi:10.1007/978-3-032-09530-5_23), with its reference cached and its year corrected to 2026 to match Crossref.

## Schema gap surfaced

`FormatEnum` has no `trig` value **and no `other` fallback**, so the dump product carries no `format` plus a warning explaining why. Adding `trig` to `FormatEnum` is a natural addition for the follow-up schema PR.

## Name collision

A resource-level warning states plainly that "ERA" here is the Agency, not the European Research Area, and points to `eurio` and `eu-knowledge-graph` for the research-funding graphs. The body carries a disambiguation section for the same reason — this misreading is exactly what put the graph on our radar.

`domains` is `other` (transport infrastructure); the follow-up PR will revisit.

Validated with `uv run ./util/extract-metadata.py validate` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)