### PR TITLE
Add EU Knowledge Graph

### DIFF
--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -2007,6 +2007,15 @@ entries:
     source_path: resource/eram/eram.md
     status: valid
     warnings: []
+  resource/eu-knowledge-graph/eu-knowledge-graph.md#publication[0]#DOI:10.1007/978-3-030-88361-4_37:
+    checked_at: '2026-08-06T18:08:16Z'
+    errors: []
+    fingerprint: b26ed960616e9867f89a304c218051dcc2d577f9d83d94b7ce5921584c8764ee
+    publication_index: 0
+    reference_id: DOI:10.1007/978-3-030-88361-4_37
+    source_path: resource/eu-knowledge-graph/eu-knowledge-graph.md
+    status: valid
+    warnings: []
   resource/eupath/eupath.md#publication[0]#DOI:10.5281/zenodo.6685957:
     checked_at: '2026-06-12T20:32:32Z'
     errors: []

--- a/references_cache/DOI_10.1007_978-3-030-88361-4_37.md
+++ b/references_cache/DOI_10.1007_978-3-030-88361-4_37.md
@@ -1,0 +1,19 @@
+---
+reference_id: DOI:10.1007/978-3-030-88361-4_37
+title: "Wikibase as an Infrastructure for Knowledge Graphs: The EU Knowledge Graph"
+authors:
+- Dennis Diefenbach
+- Max De Wilde
+- Samantha Alipio
+journal: Lecture Notes in Computer Science
+year: '2021'
+doi: 10.1007/978-3-030-88361-4_37
+content_type: unavailable
+---
+
+# Wikibase as an Infrastructure for Knowledge Graphs: The EU Knowledge Graph
+**Authors:** Dennis Diefenbach, Max De Wilde, Samantha Alipio
+**Journal:** Lecture Notes in Computer Science (2021)
+**DOI:** [10.1007/978-3-030-88361-4_37](https://doi.org/10.1007/978-3-030-88361-4_37)
+
+## Content

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.api.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.api.md
@@ -1,0 +1,15 @@
+---
+category: ProgrammingInterface
+description: MediaWiki and Wikibase action API of the EU Knowledge Graph instance,
+  supporting entity retrieval, search, and change tracking. Verified responding on
+  2026-08-06.
+format: json
+id: eu-knowledge-graph.api
+is_public: true
+name: EU Knowledge Graph Wikibase API
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://linkedopendata.eu/w/api.php
+layout: product_detail
+---

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.exports.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.exports.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+description: Data exports of the EU Knowledge Graph, advertised on the instance's
+  main page as available from data.linkedopendata.eu.
+id: eu-knowledge-graph.exports
+name: EU Knowledge Graph Data Exports
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://data.linkedopendata.eu
+warnings:
+- Checked on 2026-08-06_ the export host returned HTTP 404 for its root and for the
+  common Wikibase dump paths that were probed, so no dump file could be located or
+  its format determined. The SPARQL endpoint and the Wikibase API were both working
+  at the same time, so this appears specific to the export host.
+layout: product_detail
+---

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.kohesio.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.kohesio.md
@@ -1,0 +1,15 @@
+---
+category: GraphicalInterface
+description: Kohesio, the main public-facing application built on the EU Knowledge
+  Graph. It presents EU cohesion policy projects and their beneficiaries to the public,
+  with map and search based discovery. Kohesio won the European Ombudsman's 2023 award
+  for good administration in the open administration category.
+format: http
+id: eu-knowledge-graph.kohesio
+name: Kohesio
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://kohesio.ec.europa.eu/
+layout: product_detail
+---

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.md
@@ -1,0 +1,216 @@
+---
+activity_status: active
+category: KnowledgeGraph
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: CNECT-ECDORIS@ec.europa.eu
+  - contact_type: url
+    value: https://linkedopendata.eu/
+  label: European Commission - Directorate-General for Communications Networks, Content
+    and Technology (DG CONNECT)
+creation_date: '2026-08-06T00:00:00Z'
+description: The EU Knowledge Graph is a Wikibase-based knowledge graph of structured
+  information about the European Union, deployed and maintained at the European Commission.
+  It describes EU institutions, countries and their capitals, and Commission Directorates-General,
+  and it carries the large project datasets that are its main content, namely 2,111,428
+  projects financed by the European Union recorded through the Kohesio cohesion policy
+  project,
+  and 678,448 beneficiaries of those projects, roughly ten percent of which are linked
+  to Wikidata so that Wikidata statements complement the Commission's own data. It also
+  holds the 2021 Nomenclature of Territorial Units for Statistics (NUTS 2021) used by
+  Eurostat, the multilingual European Science Vocabulary (EuroSciVoc) representing fields
+  of science, and even Commission facilities such as buildings, canteens, cafeterias,
+  and parkings. When queried on 2026-08-06 the query service reported 889,454,967 triples.
+  The stated goal is to make EU project spending visible and navigable for citizens
+  with no technical background; Kohesio is the main public application built on the graph.
+  Because it runs on Wikibase, the graph supports multilingual labels, statement-level
+  provenance, and curation by authorized editors, who sign in through EU Login and request
+  editor rights.
+domains:
+- general
+homepage_url: https://linkedopendata.eu/wiki/The_EU_Knowledge_Graph
+id: eu-knowledge-graph
+last_modified_date: '2026-08-06T00:00:00Z'
+layout: resource_detail
+name: EU Knowledge Graph
+products:
+- category: ProgrammingInterface
+  description: Public SPARQL endpoint of the EU Knowledge Graph query service. Verified
+    queryable on 2026-08-06, when it reported 889,454,967 triples.
+  format: http
+  id: eu-knowledge-graph.sparql
+  is_public: true
+  name: EU Knowledge Graph SPARQL Endpoint
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://query.linkedopendata.eu/sparql
+- category: GraphicalInterface
+  description: Query service interface for the EU Knowledge Graph, in the style of the
+    Wikidata Query Service, providing an editor and result views over the SPARQL endpoint.
+  format: http
+  id: eu-knowledge-graph.query-service
+  name: EU Knowledge Graph Query Service
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://query.linkedopendata.eu/
+- category: GraphicalInterface
+  description: The Wikibase instance itself, where items and statements can be browsed
+    and, for authorized editors signed in through EU Login, edited. The instance reported
+    3,801,954 pages and more than 48 million edits on 2026-08-06, with edits from Commission
+    services taking place the same day.
+  format: http
+  id: eu-knowledge-graph.wikibase
+  name: EU Knowledge Graph Wikibase
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://linkedopendata.eu/
+- category: ProgrammingInterface
+  description: MediaWiki and Wikibase action API of the EU Knowledge Graph instance,
+    supporting entity retrieval, search, and change tracking. Verified responding on
+    2026-08-06.
+  format: json
+  id: eu-knowledge-graph.api
+  is_public: true
+  name: EU Knowledge Graph Wikibase API
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://linkedopendata.eu/w/api.php
+- category: GraphicalInterface
+  description: Kohesio, the main public-facing application built on the EU Knowledge
+    Graph. It presents EU cohesion policy projects and their beneficiaries to the public,
+    with map and search based discovery. Kohesio won the European Ombudsman's 2023 award
+    for good administration in the open administration category.
+  format: http
+  id: eu-knowledge-graph.kohesio
+  name: Kohesio
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://kohesio.ec.europa.eu/
+- category: GraphicalInterface
+  description: Question answering service over the EU Knowledge Graph, allowing natural
+    language questions to be posed against the graph.
+  format: http
+  id: eu-knowledge-graph.qa
+  name: EU Knowledge Graph Question Answering Service
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://qa.linkedopendata.eu
+- category: GraphProduct
+  description: Data exports of the EU Knowledge Graph, advertised on the instance's main
+    page as available from data.linkedopendata.eu.
+  id: eu-knowledge-graph.exports
+  name: EU Knowledge Graph Data Exports
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://data.linkedopendata.eu
+  warnings:
+  - 'Checked on 2026-08-06: the export host returned HTTP 404 for its root and for the
+    common Wikibase dump paths that were probed, so no dump file could be located or
+    its format determined. The SPARQL endpoint and the Wikibase API were both working
+    at the same time, so this appears specific to the export host.'
+- category: ProcessProduct
+  description: Wikibase configuration of the EU Knowledge Graph, published by the Commission's
+    DORIS team, along with the issue tracker used for feature requests and bug reports.
+  id: eu-knowledge-graph.wikibase-config
+  name: EU Knowledge Graph Wikibase Configuration
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: eu-knowledge-graph
+  product_url: https://github.com/ec-doris/EuKnowledgeGraph
+  repository: https://github.com/ec-doris/EuKnowledgeGraph
+  warnings:
+  - The repository was archived on GitHub in May 2026 and is read-only. The knowledge
+    graph itself remains actively edited.
+publications:
+- authors:
+  - Diefenbach D
+  - De Wilde M
+  - Alipio S
+  doi: 10.1007/978-3-030-88361-4_37
+  id: doi:10.1007/978-3-030-88361-4_37
+  journal: Lecture Notes in Computer Science
+  preferred: true
+  title: 'Wikibase as an Infrastructure for Knowledge Graphs: The EU Knowledge Graph'
+  year: '2021'
+synonyms:
+- EU KG
+- EuKnowledgeGraph
+- Linked Open Data EU
+warnings:
+- No license is declared for the graph. The Wikibase instance returns empty rights information
+  through its API and no license statement was located on the instance or its export
+  host, as checked on 2026-08-06. Wikibase deployments commonly place statement data
+  under CC0, but that should not be assumed here.
+---
+# EU Knowledge Graph
+
+## Overview
+
+The EU Knowledge Graph is the European Commission's Wikibase deployment for structured
+data about the European Union. Its stated purpose is public legibility: making the
+projects the EU finances visible and navigable to citizens with no technical background.
+The public-facing product of that goal is **Kohesio**, the cohesion policy project
+explorer, which won the European Ombudsman's 2023 award for good administration in the
+open administration category.
+
+It is maintained by DG CONNECT, and edits come from Commission services directly — the
+instance was being edited by DG REGIO on the day this entry was written.
+
+## Contents
+
+From the instance's own description, confirmed against the live query service on
+2026-08-06 (**889,454,967 triples** total):
+
+- **2,111,428 projects** financed by the European Union, recorded through Kohesio.
+- **678,448 beneficiaries** of those projects, roughly 10% of them linked back to
+  Wikidata so that Wikidata statements complement the Commission's data.
+- EU **institutions**, world and EU **countries**, their **capitals**, and Commission
+  **Directorates-General**.
+- **NUTS 2021**, the Nomenclature of Territorial Units for Statistics used by Eurostat.
+- **EuroSciVoc**, the multilingual European Science Vocabulary of scientific fields.
+- Commission **facilities** — buildings, canteens, cafeterias, and parkings.
+
+The Wikibase instance reported 3,801,954 pages and more than 48 million edits.
+
+## Access
+
+- **SPARQL endpoint:** `https://query.linkedopendata.eu/sparql`, with a Wikidata-style
+  query interface at [query.linkedopendata.eu](https://query.linkedopendata.eu/).
+- **Wikibase API:** `https://linkedopendata.eu/w/api.php` — verified responding.
+- **Question answering service:** [qa.linkedopendata.eu](https://qa.linkedopendata.eu).
+- **Editing:** authorized editors sign in through EU Login and request editor rights;
+  an OpenRefine integration is documented on the instance.
+- **Data exports** are advertised at `data.linkedopendata.eu`, but that host returned
+  HTTP 404 for its root and for the common Wikibase dump paths when checked. The
+  endpoint and API were both working at the same time, so this looks specific to the
+  export host. Recorded as a product warning.
+
+## Two things this entry deliberately does not claim
+
+1. **A license.** The Wikibase instance returns empty rights information through its
+   API, and no license statement was found on the instance or its export host. Wikibase
+   deployments often use CC0 for statement data; that is not evidence, so it is not
+   recorded.
+2. **A dump format.** Since no export file could be located, the exports product
+   carries no `format` value rather than a guessed one.
+
+## Relationship to other registry entries
+
+Distinct from `eurio`, the EURIO Knowledge Graph: EURIO is CORDIS research framework
+programme data published by the Publications Office as RDF dumps and a Virtuoso
+endpoint, while this graph is cohesion policy and general EU data on Wikibase. Both
+are also distinct from `era-kg`, the EU Agency for Railways graph, which despite the
+similar-sounding name is about railway infrastructure.
+
+An earlier round of research put this graph at roughly 1.83M projects and 644k
+beneficiaries, figures traceable to the 2021 ISWC paper. The counts above are current
+as of 2026-08-06 and supersede them.

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.qa.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.qa.md
@@ -1,0 +1,13 @@
+---
+category: GraphicalInterface
+description: Question answering service over the EU Knowledge Graph, allowing natural
+  language questions to be posed against the graph.
+format: http
+id: eu-knowledge-graph.qa
+name: EU Knowledge Graph Question Answering Service
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://qa.linkedopendata.eu
+layout: product_detail
+---

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.query-service.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.query-service.md
@@ -1,0 +1,13 @@
+---
+category: GraphicalInterface
+description: Query service interface for the EU Knowledge Graph, in the style of the
+  Wikidata Query Service, providing an editor and result views over the SPARQL endpoint.
+format: http
+id: eu-knowledge-graph.query-service
+name: EU Knowledge Graph Query Service
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://query.linkedopendata.eu/
+layout: product_detail
+---

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.sparql.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.sparql.md
@@ -1,0 +1,14 @@
+---
+category: ProgrammingInterface
+description: Public SPARQL endpoint of the EU Knowledge Graph query service. Verified
+  queryable on 2026-08-06, when it reported 889,454,967 triples.
+format: http
+id: eu-knowledge-graph.sparql
+is_public: true
+name: EU Knowledge Graph SPARQL Endpoint
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://query.linkedopendata.eu/sparql
+layout: product_detail
+---

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.wikibase-config.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.wikibase-config.md
@@ -1,0 +1,16 @@
+---
+category: ProcessProduct
+description: Wikibase configuration of the EU Knowledge Graph, published by the Commission's
+  DORIS team, along with the issue tracker used for feature requests and bug reports.
+id: eu-knowledge-graph.wikibase-config
+name: EU Knowledge Graph Wikibase Configuration
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://github.com/ec-doris/EuKnowledgeGraph
+repository: https://github.com/ec-doris/EuKnowledgeGraph
+warnings:
+- The repository was archived on GitHub in May 2026 and is read-only. The knowledge
+  graph itself remains actively edited.
+layout: product_detail
+---

--- a/resource/eu-knowledge-graph/eu-knowledge-graph.wikibase.md
+++ b/resource/eu-knowledge-graph/eu-knowledge-graph.wikibase.md
@@ -1,0 +1,15 @@
+---
+category: GraphicalInterface
+description: The Wikibase instance itself, where items and statements can be browsed
+  and, for authorized editors signed in through EU Login, edited. The instance reported
+  3,801,954 pages and more than 48 million edits on 2026-08-06, with edits from Commission
+  services taking place the same day.
+format: http
+id: eu-knowledge-graph.wikibase
+name: EU Knowledge Graph Wikibase
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eu-knowledge-graph
+product_url: https://linkedopendata.eu/
+layout: product_detail
+---


### PR DESCRIPTION
Adds a `KnowledgeGraph` entry for the **EU Knowledge Graph**, the European Commission's Wikibase deployment for structured EU data, with Kohesio as its public application.

Closes #683

## The issue's numbers were stale; these are live

#683 flagged that `linkedopendata.eu` blocks automated requests and that its figures (from the 2021 ISWC paper) needed a manual pass. Done — the block is user-agent based, so the instance is readable after all. Read from the live service on 2026-08-06:

| | |
| --- | --- |
| Triples (query service) | **889,454,967** |
| Kohesio projects | **2,111,428** (issue said ~1.83M) |
| Beneficiaries | **678,448**, ~10% linked to Wikidata (issue said ~644k) |
| Wikibase pages / edits | 3,801,954 / 48M+ |

Also present and not previously recorded: **NUTS 2021**, **EuroSciVoc**, EU institutions, countries and capitals, Commission DGs, and Commission facilities (buildings, canteens, cafeterias, parkings).

**Status is `active`, confirmed by behavior not inference:** the instance was being edited by DG REGIO the same day, via the recent-changes API.

## Products

SPARQL endpoint (verified), query service UI, Wikibase instance, Wikibase action API (verified), Kohesio, question answering service at `qa.linkedopendata.eu` (the `dev.qa` host from #683 is dead; the non-dev host is live), data exports, and the Wikibase configuration repo — flagged as **archived on GitHub in May 2026**, with a note that the graph itself is still actively edited.

## Two things the entry declines to claim

1. **License.** The Wikibase API returns *empty* rights information and no license statement was found on the instance or export host. Wikibase deployments often use CC0; that isn't evidence, so no license is recorded — just a warning.
2. **Dump format.** The advertised export host `data.linkedopendata.eu` returned **404** for its root and for every common Wikibase dump path probed, while the endpoint and API worked. The exports product therefore carries no `format` and a warning explaining the check.

## Relationship notes

The body distinguishes this from `eurio` (CORDIS framework-programme data, RDF dumps + Virtuoso, Publications Office) and from `era-kg` (railways, despite the name). `domains` is `general`; the follow-up schema PR will revisit.

Validated with `uv run ./util/extract-metadata.py validate` (clean). Publication reference cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)