### PR TITLE
Add KG-Bioportal as an aggregator and sync its KGX transforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,13 @@ SCHEMA_DOC_DIR = docs/schema
 SCHEMA_DIR = src/kg_registry/kg_registry_schema
 
 ### Main Tasks
-.PHONY: all pull_and_build test pull clean sync-obo-foundry sync-frink quality-dashboard check-artifacts
+.PHONY: all pull_and_build test pull clean sync-obo-foundry sync-frink sync-kg-bioportal quality-dashboard check-artifacts
 
 all: \
 	ingest-kg-monarch \
 	sync-frink \
 	sync-obo-foundry \
+	sync-kg-bioportal \
 	_config.yml \
 	registry/kgs.jsonld \
 	registry/kgs-summary.json \
@@ -123,6 +124,22 @@ sync-obo-foundry-test:
 sync-obo-foundry:
 	$(RUN) python util/sync_obo_foundry.py --verbose
 
+# Add KG-Bioportal KGX transform products to matching KG-Registry resources.
+# This does not create resources -- see docs/kg-bioportal-sync.md.
+.PHONY: sync-kg-bioportal sync-kg-bioportal-dry-run sync-kg-bioportal-test
+
+# Dry run to see what would be synced
+sync-kg-bioportal-dry-run:
+	$(RUN) python util/sync_kg_bioportal.py --dry-run --verbose
+
+# Test sync with a limited number of manifest entries
+sync-kg-bioportal-test:
+	$(RUN) python util/sync_kg_bioportal.py --limit 50 --verbose
+
+# Full sync of KG-Bioportal transforms
+sync-kg-bioportal:
+	$(RUN) python util/sync_kg_bioportal.py --verbose
+
 # Sync Translator release metadata to KG-Registry
 .PHONY: sync-translator sync-translator-dry-run
 
@@ -147,7 +164,7 @@ clean-schema:
 	rm -Rf src/kg_registry/kg_registry_schema/datamodel/*.py src/kg_registry/kg_registry_schema/*.json src/kg_registry/kg_registry_schema/schema/kg_registry_schema_all.yaml
 
 clean-cache:
-	rm -f cache/obo_foundry_cache.yml cache/frink_registry_cache.yaml cache/url_status_cache.yml cache/quality_url_status_cache.yml cache/publication_reference_validation.yml cache/kgregistry-infores.sssom.tsv cache/infores_catalog.yaml
+	rm -f cache/obo_foundry_cache.yml cache/frink_registry_cache.yaml cache/kg_bioportal_cache.yaml cache/url_status_cache.yml cache/quality_url_status_cache.yml cache/publication_reference_validation.yml cache/kgregistry-infores.sssom.tsv cache/infores_catalog.yaml
 	@echo "✅ Cleared cache files"
 
 ### Directories:
@@ -231,7 +248,7 @@ check-artifacts:
 # Validation uses parallel execution by default (5-10x faster)
 # Set PARALLEL_VALIDATION=no to use sequential validation
 RESULTS = reports/metadata-violations.tsv reports/metadata-grid.csv
-reports/metadata-grid.csv: tmp/unsorted-resources-with-sizes.yml sync-frink sync-obo-foundry | extract-metadata reports
+reports/metadata-grid.csv: tmp/unsorted-resources-with-sizes.yml sync-frink sync-obo-foundry sync-kg-bioportal | extract-metadata reports
 	./util/validate-metadata.py $< $(RESULTS)
 
 # generate an HTML output of the metadata grid

--- a/cache/kg_bioportal_cache.yaml
+++ b/cache/kg_bioportal_cache.yaml
@@ -1,0 +1,12818 @@
+ontologies:
+- id: ABA-AMB
+  status: OK
+  reason: ''
+  name: Allen Brain Atlas (ABA) Adult Mouse Brain Ontology
+  version: '1'
+  nodecount: 916
+  edgecount: 3441
+  submission_id: '1'
+  source_bytes: 692674
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ABA-AMB.tar.gz
+- id: ABD
+  status: OK
+  reason: ''
+  name: Anthology of Biosurveillance Diseases
+  version: NA
+  nodecount: 1447
+  edgecount: 2637
+  submission_id: '4'
+  source_bytes: 816897
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ABD.tar.gz
+- id: ACESO
+  status: OK
+  reason: ''
+  name: Adverse Childhood Experiences Ontology
+  version: Light
+  nodecount: 412
+  edgecount: 331
+  submission_id: '2'
+  source_bytes: 165636
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ACESO.tar.gz
+- id: ACGT-MO
+  status: OK
+  reason: ''
+  name: Cancer Research and Management ACGT Master Ontology
+  version: '1.1'
+  nodecount: 2072
+  edgecount: 4736
+  submission_id: '2'
+  source_bytes: 847408
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ACGT-MO.tar.gz
+- id: ACVD_ONTOLOGY
+  status: OK
+  reason: ''
+  name: Atherosclerotic Cerebrovascular Disease Ontology
+  version: '2.0'
+  nodecount: 1737
+  edgecount: 1911
+  submission_id: '4'
+  source_bytes: 4208234
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ACVD_ONTOLOGY.tar.gz
+- id: AD-CDO
+  status: OK
+  reason: ''
+  name: Alzheimer's Disease Common Data Element Ontology for Clinical Trials
+  version: NA
+  nodecount: 302
+  edgecount: 302
+  submission_id: '2'
+  source_bytes: 287260
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AD-CDO.tar.gz
+- id: AD-DROP
+  status: OK
+  reason: ''
+  name: Alzheimer Disease Relevance Ontology by Process
+  version: alpha
+  nodecount: 98
+  edgecount: 24
+  submission_id: '1'
+  source_bytes: 128750
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AD-DROP.tar.gz
+- id: ADALAB
+  status: OK
+  reason: ''
+  name: AdaLab ontology
+  version: 0.9.2
+  nodecount: 43
+  edgecount: 22
+  submission_id: '10'
+  source_bytes: 14555
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ADALAB.tar.gz
+- id: ADALAB-META
+  status: Failed
+  reason: not_downloadable
+  name: AdaLab-meta ontology
+  version: 0.9.2
+  nodecount: 0
+  edgecount: 0
+  submission_id: '12'
+  source_bytes: 0
+- id: ADAR
+  status: OK
+  reason: ''
+  name: Autism DSM-ADI-R ontology
+  version: '1.1'
+  nodecount: 3263
+  edgecount: 4970
+  submission_id: '1'
+  source_bytes: 7684828
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ADAR.tar.gz
+- id: ADCAD
+  status: OK
+  reason: ''
+  name: Arctic Data Center Academic Disciplines Ontology
+  version: Version 1.0.0
+  nodecount: 201
+  edgecount: 192
+  submission_id: '1'
+  source_bytes: 13048
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ADCAD.tar.gz
+- id: ADHER_INTCARE_EN
+  status: Failed
+  reason: transform_error
+  name: Adherence and Integrated Care
+  version: English 051319
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 224135
+- id: ADHER_INTCARE_SP
+  status: Failed
+  reason: transform_error
+  name: Adherence and Integrated Care in Spanish
+  version: Spanish 052319
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 465827
+- id: ADICAP
+  status: OK
+  reason: ''
+  name: "Association pour le D\xE9veloppement de l'Informatique en Cytologie et Anatomie\
+    \ Pathologique"
+  version: 10-2024
+  nodecount: 9695
+  edgecount: 14014
+  submission_id: '1'
+  source_bytes: 4347516
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ADICAP.tar.gz
+- id: ADMF
+  status: Failed
+  reason: not_downloadable
+  name: alzhaimer dessiese main factors
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: ADMIN
+  status: Failed
+  reason: not_downloadable
+  name: Nurse Administrator
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: ADMO
+  status: OK
+  reason: ''
+  name: Alzheimer Disease Map Ontology
+  version: beta
+  nodecount: 11152
+  edgecount: 30706
+  submission_id: '4'
+  source_bytes: 10088789
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ADMO.tar.gz
+- id: ADO
+  status: OK
+  reason: ''
+  name: Alzheimer's Disease Ontology
+  version: 2.0.1
+  nodecount: 2729
+  edgecount: 6185
+  submission_id: '4'
+  source_bytes: 5491455
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ADO.tar.gz
+- id: ADW
+  status: OK
+  reason: ''
+  name: Animal Natural History and Life History Ontology
+  version: 10/11/04
+  nodecount: 445
+  edgecount: 463
+  submission_id: '2'
+  source_bytes: 149094
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ADW.tar.gz
+- id: AEO
+  status: OK
+  reason: ''
+  name: Anatomical Entity Ontology
+  version: NA
+  nodecount: 461
+  edgecount: 728
+  submission_id: '8'
+  source_bytes: 484985
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AEO.tar.gz
+- id: AERO
+  status: OK
+  reason: ''
+  name: Adverse Event Reporting Ontology
+  version: unknown
+  nodecount: 261
+  edgecount: 1047
+  submission_id: '45'
+  source_bytes: 277186
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/AERO.tar.gz
+- id: AFO
+  status: OK
+  reason: ''
+  name: Allotrope Merged Ontology Suite
+  version: REC/2026/06
+  nodecount: 4854
+  edgecount: 11298
+  submission_id: '45'
+  source_bytes: 4366204
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AFO.tar.gz
+- id: AFPO
+  status: Failed
+  reason: transform_error
+  name: African Population Ontology
+  version: '2024-03-21'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 1369705
+- id: AGRO
+  status: OK
+  reason: ''
+  name: AGRonomy Ontology
+  version: NA
+  nodecount: 5102
+  edgecount: 8691
+  submission_id: '6'
+  source_bytes: 7501012
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/AGRO.tar.gz
+- id: AGROCYMAC
+  status: OK
+  reason: ''
+  name: Control y Monitoreo de afecciones en los cultivos
+  version: NA
+  nodecount: 175
+  edgecount: 55
+  submission_id: '2'
+  source_bytes: 165795
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AGROCYMAC.tar.gz
+- id: AGROMOP
+  status: OK
+  reason: ''
+  name: Control de Cacao
+  version: '1.1'
+  nodecount: 75
+  edgecount: 45
+  submission_id: '1'
+  source_bytes: 60399
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AGROMOP.tar.gz
+- id: AHOL
+  status: OK
+  reason: ''
+  name: Animal Health Ontology for Livestock
+  version: '1.0'
+  nodecount: 374
+  edgecount: 1062
+  submission_id: '1'
+  source_bytes: 413275
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AHOL.tar.gz
+- id: AHSO
+  status: OK
+  reason: ''
+  name: Animal Health Surveillance Ontology
+  version: 0.1.0
+  nodecount: 86
+  edgecount: 146
+  submission_id: '1'
+  source_bytes: 42017
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AHSO.tar.gz
+- id: AI
+  status: OK
+  reason: ''
+  name: Artificial Intelligence
+  version: '2024-08-14'
+  nodecount: 467
+  edgecount: 981
+  submission_id: '1'
+  source_bytes: 529927
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AI.tar.gz
+- id: AI-RHEUM
+  status: OK
+  reason: ''
+  name: Artificial Intelligence Rheumatology Consultant System Ontology
+  version: AIR93
+  nodecount: 814
+  edgecount: 1324
+  submission_id: '1'
+  source_bytes: 408735
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AI-RHEUM.tar.gz
+- id: AIDENTIFYAGE
+  status: OK
+  reason: ''
+  name: AIdentifyAGE
+  version: v1.0.9-beta
+  nodecount: 520
+  edgecount: 500
+  submission_id: '11'
+  source_bytes: 435484
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/AIDENTIFYAGE.tar.gz
+- id: AIO
+  status: OK
+  reason: ''
+  name: Artificial Intelligence Ontology
+  version: '2026-07-22'
+  nodecount: 474
+  edgecount: 990
+  submission_id: '25'
+  source_bytes: 531541
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AIO.tar.gz
+- id: AISM
+  status: OK
+  reason: ''
+  name: Ontology for the Anatomy of the Insect SkeletoMuscular system
+  version: '2023-04-14'
+  nodecount: 8584
+  edgecount: 31372
+  submission_id: '6'
+  source_bytes: 26765928
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AISM.tar.gz
+- id: ALLERGIDOC
+  status: OK
+  reason: ''
+  name: Allergy Ontology
+  version: '3.0'
+  nodecount: 1177
+  edgecount: 1134
+  submission_id: '9'
+  source_bytes: 435152
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ALLERGIDOC.tar.gz
+- id: ALLERGYDETECTOR
+  status: OK
+  reason: ''
+  name: Allergy Detector II
+  version: 0.0.1
+  nodecount: 197
+  edgecount: 17
+  submission_id: '1'
+  source_bytes: 103962
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ALLERGYDETECTOR.tar.gz
+- id: ALTPROTON
+  status: OK
+  reason: ''
+  name: An Ontology for integration and interoperability of multi-aspect data of Protein
+    food production chains
+  version: The Ontology was revised after the reviews from the reviewers of Journal
+    of Scientific Data.
+  nodecount: 549
+  edgecount: 671
+  submission_id: '4'
+  source_bytes: 484726
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ALTPROTON.tar.gz
+- id: AMINO-ACID
+  status: OK
+  reason: ''
+  name: Amino Acid Ontology
+  version: "version 1.2, copyright The University of\n\t\t\tManchester, Nick Drummond,\
+    \ Georgina Moulton, Robert Stevens, Phil Lord"
+  nodecount: 54
+  edgecount: 371
+  submission_id: '2'
+  source_bytes: 99405
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AMINO-ACID.tar.gz
+- id: AMPHX
+  status: OK
+  reason: ''
+  name: The Amphioxus Development and Anatomy Ontology
+  version: NA
+  nodecount: 418
+  edgecount: 1721
+  submission_id: '5'
+  source_bytes: 589457
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AMPHX.tar.gz
+- id: ANCO
+  status: OK
+  reason: ''
+  name: ANC Ontology
+  version: 1.0.0
+  nodecount: 37
+  edgecount: 38
+  submission_id: '1'
+  source_bytes: 4603
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ANCO.tar.gz
+- id: AO
+  status: OK
+  reason: ''
+  name: Asthma Ontology
+  version: '1.3'
+  nodecount: 297
+  edgecount: 283
+  submission_id: '2'
+  source_bytes: 108464
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AO.tar.gz
+- id: APACOMPUTER
+  status: OK
+  reason: ''
+  name: Computer Cluster
+  version: NA
+  nodecount: 115
+  edgecount: 107
+  submission_id: '1'
+  source_bytes: 21065
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APACOMPUTER.tar.gz
+- id: APADISORDERS
+  status: OK
+  reason: ''
+  name: Disorders cluster
+  version: NA
+  nodecount: 823
+  edgecount: 815
+  submission_id: '1'
+  source_bytes: 149904
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APADISORDERS.tar.gz
+- id: APAEDUCLUSTER
+  status: OK
+  reason: ''
+  name: Educational Cluster
+  version: NA
+  nodecount: 510
+  edgecount: 501
+  submission_id: '1'
+  source_bytes: 93299
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APAEDUCLUSTER.tar.gz
+- id: APANEUROCLUSTER
+  status: OK
+  reason: ''
+  name: APA Neuro Cluster
+  version: NA
+  nodecount: 502
+  edgecount: 495
+  submission_id: '1'
+  source_bytes: 88110
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APANEUROCLUSTER.tar.gz
+- id: APAOCUEMPLOY
+  status: OK
+  reason: ''
+  name: APA Occupational and Employment cluster
+  version: NA
+  nodecount: 449
+  edgecount: 444
+  submission_id: '1'
+  source_bytes: 83979
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APAOCUEMPLOY.tar.gz
+- id: APASTATISTICAL
+  status: OK
+  reason: ''
+  name: APA Statistical Cluster
+  version: NA
+  nodecount: 141
+  edgecount: 138
+  submission_id: '1'
+  source_bytes: 27405
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APASTATISTICAL.tar.gz
+- id: APATANDT
+  status: OK
+  reason: ''
+  name: APA Tests and Testing cluster
+  version: NA
+  nodecount: 209
+  edgecount: 199
+  submission_id: '1'
+  source_bytes: 39320
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APATANDT.tar.gz
+- id: APATREATMENT
+  status: OK
+  reason: ''
+  name: APA Treatment Cluster
+  version: NA
+  nodecount: 481
+  edgecount: 472
+  submission_id: '1'
+  source_bytes: 85615
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/APATREATMENT.tar.gz
+- id: APO
+  status: OK
+  reason: ''
+  name: Ascomycete Phenotype Ontology
+  version: '2026-06-16'
+  nodecount: 656
+  edgecount: 2042
+  submission_id: '53'
+  source_bytes: 106057
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/APO.tar.gz
+- id: APOLLO-SV
+  status: OK
+  reason: ''
+  name: Apollo Structured Vocabulary
+  version: '2026-07-19'
+  nodecount: 2334
+  edgecount: 3597
+  submission_id: '67'
+  source_bytes: 2644704
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/APOLLO-SV.tar.gz
+- id: APRO
+  status: OK
+  reason: ''
+  name: Ancient Poet Resource Ontology
+  version: NA
+  nodecount: 104
+  edgecount: 180
+  submission_id: '1'
+  source_bytes: 18918
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/APRO.tar.gz
+- id: ARCRC
+  status: Failed
+  reason: transform_error
+  name: Arctic Report Card
+  version: 0.12.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 86347
+- id: ARO
+  status: OK
+  reason: ''
+  name: Antibiotic Resistance Ontology
+  version: NA
+  nodecount: 8608
+  edgecount: 14883
+  submission_id: '22'
+  source_bytes: 18291054
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ARO.tar.gz
+- id: ASDF
+  status: OK
+  reason: ''
+  name: testiiii1
+  version: NA
+  nodecount: 916
+  edgecount: 3441
+  submission_id: '1'
+  source_bytes: 692674
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ASDF.tar.gz
+- id: ASDPTO
+  status: OK
+  reason: ''
+  name: Autism Spectrum Disorder Phenotype Ontology
+  version: '1'
+  nodecount: 570
+  edgecount: 580
+  submission_id: '1'
+  source_bytes: 184780
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ASDPTO.tar.gz
+- id: ASPECT
+  status: OK
+  reason: ''
+  name: 'ASPECT: wind energy vAriableS, ParametErs and ConsTants'
+  version: 0.1.0
+  nodecount: 188
+  edgecount: 587
+  submission_id: '3'
+  source_bytes: 73751
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ASPECT.tar.gz
+- id: ASSAYNODE
+  status: OK
+  reason: ''
+  name: Assaynode
+  version: '1.0'
+  nodecount: 60
+  edgecount: 96
+  submission_id: '2'
+  source_bytes: 35700
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ASSAYNODE.tar.gz
+- id: ATC
+  status: OK
+  reason: ''
+  name: Anatomical Therapeutic Chemical Classification
+  version: '2025_02_10'
+  nodecount: 7033
+  edgecount: 7023
+  submission_id: '25'
+  source_bytes: 3817393
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATC.tar.gz
+- id: ATO
+  status: OK
+  reason: ''
+  name: Amphibian Taxonomy Ontology
+  version: See Remote Site
+  nodecount: 6147
+  edgecount: 12163
+  submission_id: '2'
+  source_bytes: 1070331
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATO.tar.gz
+- id: ATOL
+  status: OK
+  reason: ''
+  name: Animal Trait Ontology for Livestock
+  version: '6.0'
+  nodecount: 2377
+  edgecount: 2436
+  submission_id: '2'
+  source_bytes: 6308179
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATOL.tar.gz
+- id: ATOM
+  status: OK
+  reason: ''
+  name: Atlas Ontology Model
+  version: '2023-04-27'
+  nodecount: 168
+  edgecount: 196
+  submission_id: '1'
+  source_bytes: 36201
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATOM.tar.gz
+- id: AURA
+  status: OK
+  reason: ''
+  name: KB_Bio_101
+  version: '1.0'
+  nodecount: 28396
+  edgecount: 55725
+  submission_id: '1'
+  source_bytes: 16754258
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AURA.tar.gz
+- id: BAO
+  status: OK
+  reason: ''
+  name: BioAssay Ontology
+  version: 2.8.19
+  nodecount: 6088
+  edgecount: 7517
+  submission_id: '68'
+  source_bytes: 1668222
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BAO.tar.gz
+- id: BAO-GPCR
+  status: OK
+  reason: ''
+  name: G Protein-Coupled Receptor BioAssays Ontology
+  version: '1.1'
+  nodecount: 970
+  edgecount: 1062
+  submission_id: '23'
+  source_bytes: 896788
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BAO-GPCR.tar.gz
+- id: BBO
+  status: OK
+  reason: ''
+  name: Biomedical Burden Ontology
+  version: '2025-09-27'
+  nodecount: 139
+  edgecount: 91
+  submission_id: '3'
+  source_bytes: 116751
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/BBO.tar.gz
+- id: BCGO
+  status: OK
+  reason: ''
+  name: Breast Cancer Grading Ontology
+  version: '1.5'
+  nodecount: 364
+  edgecount: 356
+  submission_id: '2'
+  source_bytes: 224436
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/BCGO.tar.gz
+- id: BCI-O
+  status: OK
+  reason: ''
+  name: Brain-Computer Interaction (BCI) Ontology
+  version: 0.9.6
+  nodecount: 455
+  edgecount: 739
+  submission_id: '6'
+  source_bytes: 506248
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCI-O.tar.gz
+- id: BCIO
+  status: OK
+  reason: ''
+  name: Behaviour Change Intervention Ontology
+  version: NA
+  nodecount: 2698
+  edgecount: 2933
+  submission_id: '1'
+  source_bytes: 2030103
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCIO.tar.gz
+- id: BCLION
+  status: OK
+  reason: ''
+  name: Breast Cancer Lifestyle Ontology
+  version: '1.0'
+  nodecount: 31
+  edgecount: 33
+  submission_id: '1'
+  source_bytes: 8013
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCLION.tar.gz
+- id: BCMO
+  status: Failed
+  reason: not_downloadable
+  name: 'Breast Cancer-Microbiome Ontology '
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: BCO
+  status: OK
+  reason: ''
+  name: Biological Collections Ontology
+  version: '2021-11-14'
+  nodecount: 860
+  edgecount: 1287
+  submission_id: '11'
+  source_bytes: 899384
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCO.tar.gz
+- id: BCON
+  status: OK
+  reason: ''
+  name: Breast Cancer Ontology
+  version: '1.0'
+  nodecount: 67
+  edgecount: 65
+  submission_id: '2'
+  source_bytes: 18075
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCON.tar.gz
+- id: BCS7
+  status: Failed
+  reason: transform_error
+  name: Breast Cancer Staging - 7th Edition
+  version: version 0.1
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 3587
+- id: BCS8
+  status: Failed
+  reason: transform_error
+  name: Breast Cancer Staging - 8th Edition
+  version: version 0.1
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 155178
+- id: BCSR-ONTO
+  status: OK
+  reason: ''
+  name: Breast cancer screening recommendation ontology
+  version: '2.1'
+  nodecount: 297
+  edgecount: 173
+  submission_id: '3'
+  source_bytes: 164573
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCSR-ONTO.tar.gz
+- id: BCTEO
+  status: OK
+  reason: ''
+  name: Bone and Cartilage Tissue Engineering Ontology
+  version: releases/2013-08
+  nodecount: 268
+  edgecount: 458
+  submission_id: '4'
+  source_bytes: 84411
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCTEO.tar.gz
+- id: BCTT
+  status: OK
+  reason: ''
+  name: Behaviour Change Technique Taxonomy
+  version: '0.4'
+  nodecount: 113
+  edgecount: 109
+  submission_id: '6'
+  source_bytes: 36327
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCTT.tar.gz
+- id: BDO
+  status: OK
+  reason: ''
+  name: Bone Dysplasia Ontology
+  version: '1.5'
+  nodecount: 4094
+  edgecount: 2964
+  submission_id: '9'
+  source_bytes: 2691874
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/BDO.tar.gz
+- id: BDPM
+  status: Failed
+  reason: transform_error
+  name: "Base de Donn\xE9es Publique des M\xE9dicaments"
+  version: '2025-03-04'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 87596168
+- id: BE
+  status: OK
+  reason: ''
+  name: Bioentities
+  version: '1.0'
+  nodecount: 452
+  edgecount: 409
+  submission_id: '5'
+  source_bytes: 147230
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BE.tar.gz
+- id: BERO
+  status: Skipped
+  reason: too_large
+  name: Biological and Environmental Research Ontology
+  version: '2022-12-23'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 920322423
+- id: BERVO
+  status: OK
+  reason: ''
+  name: The Biological and Environmental Research Variable Ontology
+  version: '2026-05-20'
+  nodecount: 2770
+  edgecount: 14694
+  submission_id: '6'
+  source_bytes: 3551917
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BERVO.tar.gz
+- id: BFLC
+  status: Failed
+  reason: not_downloadable
+  name: LC BIBFRAME 2.0 Vocabulary Extension
+  version: 1.2.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 0
+- id: BFO
+  status: OK
+  reason: ''
+  name: Basic Formal Ontology
+  version: '2.0'
+  nodecount: 75
+  edgecount: 115
+  submission_id: '2'
+  source_bytes: 161921
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BFO.tar.gz
+- id: BFPO
+  status: OK
+  reason: ''
+  name: Bioreactor Fermentation Process Ontology
+  version: NA
+  nodecount: 225
+  edgecount: 410
+  submission_id: '2'
+  source_bytes: 156112
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BFPO.tar.gz
+- id: BHN
+  status: OK
+  reason: ''
+  name: Biologie Hors Nomenclature
+  version: '3.2'
+  nodecount: 2540
+  edgecount: 2542
+  submission_id: '1'
+  source_bytes: 1050834
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BHN.tar.gz
+- id: BHO
+  status: OK
+  reason: ''
+  name: Bleeding History Phenotype Ontology
+  version: '0.4'
+  nodecount: 666
+  edgecount: 1809
+  submission_id: '3'
+  source_bytes: 422959
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BHO.tar.gz
+- id: BIBFRAME
+  status: Failed
+  reason: not_downloadable
+  name: BIBFRAME 2.0
+  version: "\n   2.2.0\n  "
+  nodecount: 0
+  edgecount: 0
+  submission_id: '11'
+  source_bytes: 0
+- id: BIBLIOTEK-O
+  status: OK
+  reason: ''
+  name: The Biblioteko Ontology
+  version: Version 1.1.0
+  nodecount: 351
+  edgecount: 337
+  submission_id: '3'
+  source_bytes: 242969
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIBLIOTEK-O.tar.gz
+- id: BIFO
+  status: OK
+  reason: ''
+  name: Biofilm Ontology
+  version: NA
+  nodecount: 115
+  edgecount: 134
+  submission_id: '1'
+  source_bytes: 57384
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIFO.tar.gz
+- id: BIM
+  status: OK
+  reason: ''
+  name: Biomedical Image Ontology
+  version: '1.3'
+  nodecount: 237
+  edgecount: 200
+  submission_id: '6'
+  source_bytes: 66400
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIM.tar.gz
+- id: BIN
+  status: OK
+  reason: ''
+  name: Body in Numbers project terminology
+  version: '1.1'
+  nodecount: 195
+  edgecount: 355
+  submission_id: '2'
+  source_bytes: 236889
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIN.tar.gz
+- id: BIODIVTHES
+  status: OK
+  reason: ''
+  name: Biodiversity Thesaurus
+  version: '2.1'
+  nodecount: 2115
+  edgecount: 5860
+  submission_id: '1'
+  source_bytes: 2098409
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIODIVTHES.tar.gz
+- id: BIOLINK
+  status: OK
+  reason: ''
+  name: Biolink Model
+  version: 4.4.3
+  nodecount: 329
+  edgecount: 812
+  submission_id: '82'
+  source_bytes: 949846
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIOLINK.tar.gz
+- id: BIOMO
+  status: OK
+  reason: ''
+  name: Biological Observation Matrix Ontology
+  version: '0.0.1
+
+    '
+  nodecount: 44
+  edgecount: 63
+  submission_id: '1'
+  source_bytes: 20061
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIOMO.tar.gz
+- id: BIOMODELS
+  status: OK
+  reason: ''
+  name: BioModels Ontology
+  version: '21'
+  nodecount: 257551
+  edgecount: 452200
+  submission_id: '3'
+  source_bytes: 12624480
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIOMODELS.tar.gz
+- id: BIOPAX
+  status: OK
+  reason: ''
+  name: BioPAX Level 3 ontology
+  version: v1.0
+  nodecount: 171
+  edgecount: 500
+  submission_id: '1'
+  source_bytes: 124035
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIOPAX.tar.gz
+- id: BIOTOP
+  status: OK
+  reason: ''
+  name: BioTop
+  version: v2012-04-24
+  nodecount: 576
+  edgecount: 807
+  submission_id: '4'
+  source_bytes: 316209
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIOTOP.tar.gz
+- id: BIPOM
+  status: OK
+  reason: ''
+  name: Biological interlocked Process Ontology for metabolism
+  version: Core
+  nodecount: 272
+  edgecount: 449
+  submission_id: '3'
+  source_bytes: 589921
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIPOM.tar.gz
+- id: BIPON
+  status: OK
+  reason: ''
+  name: Bacterial interlocked Process ONtology
+  version: 2017-11-08-bis
+  nodecount: 2721
+  edgecount: 4228
+  submission_id: '3'
+  source_bytes: 3707496
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIPON.tar.gz
+- id: BIRNLEX
+  status: OK
+  reason: ''
+  name: Biomedical Informatics Research Network Project Lexicon
+  version: 1.3.1
+  nodecount: 3590
+  edgecount: 3572
+  submission_id: '1'
+  source_bytes: 4228397
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIRNLEX.tar.gz
+- id: BIRTHONTO
+  status: OK
+  reason: ''
+  name: 'BirthOnto: Birth Data Analysis'
+  version: '1.1'
+  nodecount: 801
+  edgecount: 510
+  submission_id: '1'
+  source_bytes: 12763340
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIRTHONTO.tar.gz
+- id: BKO
+  status: OK
+  reason: ''
+  name: Bricks ontology
+  version: 13:07:2018 10:45
+  nodecount: 729
+  edgecount: 5055
+  submission_id: '1'
+  source_bytes: 727693
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BKO.tar.gz
+- id: BLLM
+  status: Failed
+  reason: no_submission
+  name: Large Language Model Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: BMONT
+  status: OK
+  reason: ''
+  name: The Biomarker Ontology
+  version: 'Version Release: 0.5.8'
+  nodecount: 1222
+  edgecount: 2215
+  submission_id: '2'
+  source_bytes: 1190342
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BMONT.tar.gz
+- id: BMS-LM
+  status: OK
+  reason: ''
+  name: BioMedical Study Lifecycle Management
+  version: Version 1.1
+  nodecount: 160
+  edgecount: 183
+  submission_id: '1'
+  source_bytes: 110399
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/BMS-LM.tar.gz
+- id: BMT
+  status: OK
+  reason: ''
+  name: Biomedical Topics
+  version: '1.4'
+  nodecount: 358
+  edgecount: 1163
+  submission_id: '1'
+  source_bytes: 273033
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BMT.tar.gz
+- id: BNO
+  status: OK
+  reason: ''
+  name: Bionutrition Ontology
+  version: '0.2'
+  nodecount: 105
+  edgecount: 100
+  submission_id: '2'
+  source_bytes: 24376
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BNO.tar.gz
+- id: BOF
+  status: OK
+  reason: ''
+  name: Biodiversity Ontology
+  version: '1.2'
+  nodecount: 656
+  edgecount: 558
+  submission_id: '2'
+  source_bytes: 423057
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BOF.tar.gz
+- id: BOSHI
+  status: Failed
+  reason: no_submission
+  name: boshra
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: BP
+  status: OK
+  reason: ''
+  name: BioPAX Ontology of Biological Pathways
+  version: Level3 v1.0
+  nodecount: 171
+  edgecount: 289
+  submission_id: '1'
+  source_bytes: 145557
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BP.tar.gz
+- id: BP-METADATA
+  status: OK
+  reason: ''
+  name: BioPortal Metadata Ontology
+  version: 0.9.5
+  nodecount: 151
+  edgecount: 157
+  submission_id: '6'
+  source_bytes: 61243
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/BP-METADATA.tar.gz
+- id: BPFORMS
+  status: Failed
+  reason: not_downloadable
+  name: Ontology of chemically concrete, composable DNA, RNA, and protein residue
+    and crosslinks
+  version: 0.0.9
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: BPT
+  status: OK
+  reason: ''
+  name: Biological Pathway Taxonomy
+  version: synonymes2022
+  nodecount: 3882
+  edgecount: 10535
+  submission_id: '2'
+  source_bytes: 8625925
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BPT.tar.gz
+- id: BRAIN-COF
+  status: OK
+  reason: ''
+  name: Computational Ontology Framework for Brain Profiles
+  version: '3'
+  nodecount: 145
+  edgecount: 160
+  submission_id: '2'
+  source_bytes: 122499
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BRAIN-COF.tar.gz
+- id: BRCT
+  status: OK
+  reason: ''
+  name: Brain Region & Cell Type terminology
+  version: '3.0'
+  nodecount: 1667
+  edgecount: 1694
+  submission_id: '1'
+  source_bytes: 2074311
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/BRCT.tar.gz
+- id: BRIDG
+  status: OK
+  reason: ''
+  name: Biomedical Research Integrated Domain Group Model
+  version: '3.2'
+  nodecount: 8829
+  edgecount: 21806
+  submission_id: '1'
+  source_bytes: 6324793
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BRIDG.tar.gz
+- id: BRO
+  status: OK
+  reason: ''
+  name: Biomedical Resource Ontology
+  version: 3.2.1
+  nodecount: 536
+  edgecount: 559
+  submission_id: '14'
+  source_bytes: 363255
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BRO.tar.gz
+- id: BRSO
+  status: OK
+  reason: ''
+  name: Biological Resource Schema Ontology
+  version: '0.02'
+  nodecount: 37
+  edgecount: 17
+  submission_id: '1'
+  source_bytes: 7934
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BRSO.tar.gz
+- id: BSAO
+  status: OK
+  reason: ''
+  name: Botryllus schlosseri anatomy and development ontology
+  version: Version 1
+  nodecount: 120
+  edgecount: 348
+  submission_id: '1'
+  source_bytes: 26974
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BSAO.tar.gz
+- id: BSPO
+  status: OK
+  reason: ''
+  name: Spatial Ontology
+  version: '2023-05-27'
+  nodecount: 505
+  edgecount: 905
+  submission_id: '32'
+  source_bytes: 589018
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BSPO.tar.gz
+- id: BT
+  status: OK
+  reason: ''
+  name: BioTop Ontology
+  version: 'Last modification
+
+    Apr 24, 2012 by Stefan Schulz'
+  nodecount: 576
+  edgecount: 807
+  submission_id: '12'
+  source_bytes: 472989
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BT.tar.gz
+- id: BT-ONTOLOGY
+  status: OK
+  reason: ''
+  name: BrainTeaser Ontology (BTO)
+  version: '2.0'
+  nodecount: 1867
+  edgecount: 2143
+  submission_id: '3'
+  source_bytes: 1850754
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BT-ONTOLOGY.tar.gz
+- id: BTO
+  status: OK
+  reason: ''
+  name: BRENDA Tissue and Enzyme Source Ontology
+  version: releases/2021-10-26
+  nodecount: 6612
+  edgecount: 7657
+  submission_id: '67'
+  source_bytes: 2107454
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BTO.tar.gz
+- id: BTO-BFO
+  status: OK
+  reason: ''
+  name: Brinell Test Ontology-BFO
+  version: 5.0.4 (BFO, IOF. MSEO)
+  nodecount: 134
+  edgecount: 62
+  submission_id: '4'
+  source_bytes: 37589
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BTO-BFO.tar.gz
+- id: BTO-EMMO
+  status: OK
+  reason: ''
+  name: Brinell Test Ontology-EMMO
+  version: 3.0.4 (EMMO, CHAMEO, MT)
+  nodecount: 165
+  edgecount: 64
+  submission_id: '3'
+  source_bytes: 40824
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BTO-EMMO.tar.gz
+- id: BTO-PROVO
+  status: Failed
+  reason: transform_error
+  name: Brinell Test Ontology-PROVO
+  version: 4.0.4 (PROV, PMDco)
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 33463
+- id: BTO_ONTOLOGY
+  status: OK
+  reason: ''
+  name: Brain Tumour Ontology
+  version: '1'
+  nodecount: 211
+  edgecount: 81
+  submission_id: '1'
+  source_bytes: 154400
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BTO_ONTOLOGY.tar.gz
+- id: C19M
+  status: Failed
+  reason: no_submission
+  name: COVID-19
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: CABRO
+  status: OK
+  reason: ''
+  name: Computer Assisted Brain Injury Rehabilitation Ontology
+  version: '0.5'
+  nodecount: 77
+  edgecount: 95
+  submission_id: '1'
+  source_bytes: 38714
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CABRO.tar.gz
+- id: CANCO
+  status: OK
+  reason: ''
+  name: Cancer Chemoprevention Ontology
+  version: '0.3'
+  nodecount: 207
+  edgecount: 259
+  submission_id: '3'
+  source_bytes: 79101
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CANCO.tar.gz
+- id: CANONT
+  status: OK
+  reason: ''
+  name: 'Upper-Level Cancer Ontology '
+  version: unknown
+  nodecount: 70
+  edgecount: 51
+  submission_id: '1'
+  source_bytes: 11917
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CANONT.tar.gz
+- id: CAO
+  status: OK
+  reason: ''
+  name: Clusters of Orthologous Groups (COG) Analysis Ontology
+  version: '1.4'
+  nodecount: 301
+  edgecount: 414
+  submission_id: '3'
+  source_bytes: 273954
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CAO.tar.gz
+- id: CARELEX
+  status: OK
+  reason: ''
+  name: Content Archive Resource Exchange Lexicon
+  version: '1.02'
+  nodecount: 416
+  edgecount: 338
+  submission_id: '46'
+  source_bytes: 762594
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CARELEX.tar.gz
+- id: CARESSES
+  status: OK
+  reason: ''
+  name: CARESSES Ontology
+  version: '1.0'
+  nodecount: 218
+  edgecount: 626
+  submission_id: '1'
+  source_bytes: 100043
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CARESSES.tar.gz
+- id: CARO
+  status: OK
+  reason: ''
+  name: Common Anatomy Reference Ontology
+  version: '2023-03-15'
+  nodecount: 8891
+  edgecount: 10155
+  submission_id: '16'
+  source_bytes: 9696885
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CARO.tar.gz
+- id: CAROLIO
+  status: OK
+  reason: ''
+  name: Caroli's Disease and Syndrome Ontology
+  version: '2.2'
+  nodecount: 118
+  edgecount: 170
+  submission_id: '1'
+  source_bytes: 210756
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CAROLIO.tar.gz
+- id: CARRE
+  status: OK
+  reason: ''
+  name: CARRE Risk Factor ontology
+  version: '0.2'
+  nodecount: 306
+  edgecount: 377
+  submission_id: '3'
+  source_bytes: 300429
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CARRE.tar.gz
+- id: CASE-BASE-ONTO
+  status: OK
+  reason: ''
+  name: Case-base ontology for gastric dystemperament in Persian medicine
+  version: '1.0'
+  nodecount: 238
+  edgecount: 207
+  submission_id: '1'
+  source_bytes: 107717
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CASE-BASE-ONTO.tar.gz
+- id: CATALOG-THEMES
+  status: Failed
+  reason: transform_error
+  name: Catalog Themes
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 1207
+- id: CBCTX
+  status: OK
+  reason: ''
+  name: CalendarBench Context
+  version: 2026.05.26
+  nodecount: 590
+  edgecount: 574
+  submission_id: '1'
+  source_bytes: 274854
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CBCTX.tar.gz
+- id: CBHT
+  status: OK
+  reason: ''
+  name: CalendarBench Health Tasks
+  version: 2026.05.19
+  nodecount: 444
+  edgecount: 113
+  submission_id: '1'
+  source_bytes: 801525
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CBHT.tar.gz
+- id: CBO
+  status: OK
+  reason: ''
+  name: Cell Behavior Ontology
+  version: "Version 1.1.2 added license info.\nVersion 1.1.1 added fuding sources.\n\
+    Version 1.1.0 added classes for OMERO-Tiff files similar to those for VTK files\
+    \ \nVersion 1.0.0 is the initial release of the Cell Behavior Ontology (CBO).\
+    \ \nVersion 1.0.1 added Journal citation for the Cell Behavior Ontology (CBO).\
+    \ \nVersion 1.0.2 corrected a few annotations that had \"snap:process\" that should\
+    \ be \"span:process\".\nVersion 1.0.3 corrected/changed class \"SpacialExclusive\"\
+    \ to \"SpatialExclusive\" and property \"has_Quality\" to \"has_quality\"."
+  nodecount: 326
+  edgecount: 279
+  submission_id: '25'
+  source_bytes: 418289
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CBO.tar.gz
+- id: CCF
+  status: OK
+  reason: ''
+  name: Human Reference Atlas Common Coordinate Framework Ontology
+  version: 3.0.0
+  nodecount: 140
+  edgecount: 23
+  submission_id: '16'
+  source_bytes: 32607
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CCF.tar.gz
+- id: CCO
+  status: Skipped
+  reason: too_large
+  name: Cell Cycle Ontology
+  version: '2.10'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 256083060
+- id: CCON
+  status: OK
+  reason: ''
+  name: Cerrado concepts and plant community dynamics
+  version: 0.9.3
+  nodecount: 272
+  edgecount: 272
+  submission_id: '8'
+  source_bytes: 146562
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CCON.tar.gz
+- id: CCONT
+  status: OK
+  reason: ''
+  name: Cell Culture Ontology
+  version: '1.1'
+  nodecount: 307
+  edgecount: 279
+  submission_id: '3'
+  source_bytes: 112549
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CCONT.tar.gz
+- id: CCTOO
+  status: OK
+  reason: ''
+  name: 'Cancer Care: Treatment Outcome Ontology'
+  version: releases/2018-05-11
+  nodecount: 1153
+  edgecount: 4532
+  submission_id: '2'
+  source_bytes: 1187282
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CCTOO.tar.gz
+- id: CDAO
+  status: OK
+  reason: ''
+  name: Comparative Data Analysis Ontology
+  version: $Revision$
+  nodecount: 238
+  edgecount: 346
+  submission_id: '7'
+  source_bytes: 110550
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDAO.tar.gz
+- id: CDMONTO
+  status: OK
+  reason: ''
+  name: Common Diabetes Medications Ontology
+  version: NA
+  nodecount: 423
+  edgecount: 385
+  submission_id: '2'
+  source_bytes: 169328
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDMONTO.tar.gz
+- id: CDNO
+  status: OK
+  reason: ''
+  name: Compositional Dietary Nutrition Ontology
+  version: NA
+  nodecount: 3507
+  edgecount: 5886
+  submission_id: '21'
+  source_bytes: 11010558
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDNO.tar.gz
+- id: CDO
+  status: Failed
+  reason: transform_error
+  name: Chinese Diabetes Mellitus Ontology
+  version: '3.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 11900382
+- id: CDOH
+  status: OK
+  reason: ''
+  name: Commercial determinant of Health Ontology
+  version: v1
+  nodecount: 356
+  edgecount: 380
+  submission_id: '1'
+  source_bytes: 156762
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDOH.tar.gz
+- id: CDPEO
+  status: OK
+  reason: ''
+  name: Chronic Disease Patient Education Ontology
+  version: 1.0.0
+  nodecount: 195
+  edgecount: 303
+  submission_id: '1'
+  source_bytes: 668722
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDPEO.tar.gz
+- id: CDSSONTOBRIEF
+  status: OK
+  reason: ''
+  name: Clinical Decision Support System Ontology-Brief Version
+  version: NA
+  nodecount: 232
+  edgecount: 228
+  submission_id: '1'
+  source_bytes: 71338
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDSSONTOBRIEF.tar.gz
+- id: CEDARPC
+  status: Failed
+  reason: not_downloadable
+  name: CEDAR Provisional Classes
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 0
+- id: CEDARVS
+  status: OK
+  reason: ''
+  name: CEDAR Value Sets
+  version: 0.2.2
+  nodecount: 35
+  edgecount: 40
+  submission_id: '4'
+  source_bytes: 21023
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CEDARVS.tar.gz
+- id: CEPH
+  status: OK
+  reason: ''
+  name: Cephalopod Ontology
+  version: NA
+  nodecount: 484
+  edgecount: 583
+  submission_id: '1'
+  source_bytes: 651688
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CEPH.tar.gz
+- id: CHD
+  status: OK
+  reason: ''
+  name: Congenital Heart Defects Ontology
+  version: '1.1'
+  nodecount: 1024
+  edgecount: 1870
+  submission_id: '5'
+  source_bytes: 317218
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHD.tar.gz
+- id: CHEAR
+  status: OK
+  reason: ''
+  name: Children's Health Exposure Analysis Resource
+  version: '2.8'
+  nodecount: 1239
+  edgecount: 1017
+  submission_id: '15'
+  source_bytes: 542560
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/CHEAR.tar.gz
+- id: CHEBI
+  status: Skipped
+  reason: too_large
+  name: Chemical Entities of Biological Interest Ontology
+  version: '253'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '220'
+  source_bytes: 270957056
+- id: CHEMBIO
+  status: OK
+  reason: ''
+  name: 'Systems Chemical Biology and Chemogenomics Ontology '
+  version: '1.1'
+  nodecount: 233
+  edgecount: 415
+  submission_id: '10'
+  source_bytes: 155787
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHEMBIO.tar.gz
+- id: CHEMINF
+  status: OK
+  reason: ''
+  name: Chemical Information Ontology
+  version: 2.1.0
+  nodecount: 625
+  edgecount: 639
+  submission_id: '53'
+  source_bytes: 263845
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHEMINF.tar.gz
+- id: CHEMROF
+  status: OK
+  reason: ''
+  name: CHEMROF
+  version: 0.0.1
+  nodecount: 757
+  edgecount: 1729
+  submission_id: '11'
+  source_bytes: 297115
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHEMROF.tar.gz
+- id: CHIRO
+  status: OK
+  reason: ''
+  name: CHEBI Integrated Role Ontology
+  version: NA
+  nodecount: 429
+  edgecount: 466
+  submission_id: '2'
+  source_bytes: 241541
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHIRO.tar.gz
+- id: CHMO
+  status: OK
+  reason: ''
+  name: Chemical Methods Ontology
+  version: '2026-05-28'
+  nodecount: 3656
+  edgecount: 4437
+  submission_id: '30'
+  source_bytes: 5719112
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHMO.tar.gz
+- id: CHO
+  status: OK
+  reason: ''
+  name: ChemoOnto
+  version: "Version: 1.0.1\nDate: Dec 12, 2024\nAuthor: Alice Rogier, Inria Paris,\
+    \ CRC (Inserm, Univ. Paris-Cit\xE9)\nLicence: MIT License"
+  nodecount: 61
+  edgecount: 95
+  submission_id: '1'
+  source_bytes: 20095
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHO.tar.gz
+- id: CHR
+  status: OK
+  reason: ''
+  name: Monochrom
+  version: '2025-10-15'
+  nodecount: 3115
+  edgecount: 5154
+  submission_id: '4'
+  source_bytes: 2219807
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHR.tar.gz
+- id: CHRO
+  status: OK
+  reason: ''
+  name: Chromatin Regulator Ontology
+  version: '2023-08-18'
+  nodecount: 1693
+  edgecount: 4722
+  submission_id: '2'
+  source_bytes: 4251812
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHRO.tar.gz
+- id: CIDO
+  status: OK
+  reason: ''
+  name: Coronavirus Infectious Disease Ontology
+  version: '2024-02-16'
+  nodecount: 32946
+  edgecount: 104133
+  submission_id: '42'
+  source_bytes: 46951577
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIDO.tar.gz
+- id: CIDOC-CRM
+  status: OK
+  reason: ''
+  name: CIDOC Conceptual Reference Model
+  version: v6.2
+  nodecount: 374
+  edgecount: 829
+  submission_id: '2'
+  source_bytes: 351991
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIDOC-CRM.tar.gz
+- id: CIINTEADO
+  status: OK
+  reason: ''
+  name: Ciona intestinalis Anatomy and Development Ontology
+  version: Version 1
+  nodecount: 899
+  edgecount: 4735
+  submission_id: '2'
+  source_bytes: 353359
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIINTEADO.tar.gz
+- id: CIO
+  status: OK
+  reason: ''
+  name: Confidence Information Ontology
+  version: NA
+  nodecount: 64
+  edgecount: 129
+  submission_id: '1'
+  source_bytes: 124125
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIO.tar.gz
+- id: CISAVIADO
+  status: OK
+  reason: ''
+  name: 'Ciona savignyi Anatomy and Development Ontology '
+  version: NA
+  nodecount: 899
+  edgecount: 4735
+  submission_id: '2'
+  source_bytes: 353359
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CISAVIADO.tar.gz
+- id: CKDO
+  status: OK
+  reason: ''
+  name: Chronic Kidney Disease Ontology
+  version: v1.0
+  nodecount: 281
+  edgecount: 272
+  submission_id: '1'
+  source_bytes: 99189
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CKDO.tar.gz
+- id: CL
+  status: OK
+  reason: ''
+  name: Cell Ontology
+  version: '2026-06-08'
+  nodecount: 20178
+  edgecount: 85215
+  submission_id: '129'
+  source_bytes: 66012941
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CL.tar.gz
+- id: CLAO
+  status: OK
+  reason: ''
+  name: Collembola Anatomy Ontology
+  version: '2021-09-27'
+  nodecount: 1565
+  edgecount: 2653
+  submission_id: '2'
+  source_bytes: 1754601
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLAO.tar.gz
+- id: CLO
+  status: OK
+  reason: ''
+  name: Cell Line Ontology
+  version: '2026-06-19'
+  nodecount: 48410
+  edgecount: 69409
+  submission_id: '67'
+  source_bytes: 37965858
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLO.tar.gz
+- id: CLYH
+  status: OK
+  reason: ''
+  name: Clytia hemisphaerica Development and Anatomy Ontology
+  version: NA
+  nodecount: 279
+  edgecount: 746
+  submission_id: '4'
+  source_bytes: 301349
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLYH.tar.gz
+- id: CMDO
+  status: OK
+  reason: ''
+  name: Clinical MetaData Ontology
+  version: 1.1.4
+  nodecount: 348
+  edgecount: 191
+  submission_id: '10'
+  source_bytes: 457973
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CMDO.tar.gz
+- id: CMO
+  status: OK
+  reason: ''
+  name: Clinical Measurement Ontology
+  version: '2026-07-25'
+  nodecount: 4186
+  edgecount: 5013
+  submission_id: '197'
+  source_bytes: 2597983
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CMO.tar.gz
+- id: CMPO
+  status: OK
+  reason: ''
+  name: Cellular microscopy phenotype ontology
+  version: '1.3'
+  nodecount: 11256
+  edgecount: 14977
+  submission_id: '14'
+  source_bytes: 4209923
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CMPO.tar.gz
+- id: CMR-QA
+  status: OK
+  reason: ''
+  name: Cardiovascular Magnetic Resonance Quality Assessment Ontology
+  version: 0.4.5
+  nodecount: 164
+  edgecount: 209
+  submission_id: '1'
+  source_bytes: 105313
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CMR-QA.tar.gz
+- id: CN
+  status: OK
+  reason: ''
+  name: computer network
+  version: NA
+  nodecount: 596
+  edgecount: 1184
+  submission_id: '1'
+  source_bytes: 390520
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CN.tar.gz
+- id: CNO
+  status: OK
+  reason: ''
+  name: Computational Neuroscience Ontology
+  version: version 0.5
+  nodecount: 256
+  edgecount: 272
+  submission_id: '8'
+  source_bytes: 162896
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/CNO.tar.gz
+- id: CO
+  status: Failed
+  reason: no_submission
+  name: Crop Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: CO-WHEAT
+  status: OK
+  reason: ''
+  name: 'Wheat Trait Ontology '
+  version: 08.11.2010
+  nodecount: 193
+  edgecount: 175
+  submission_id: '1'
+  source_bytes: 49979
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CO-WHEAT.tar.gz
+- id: COB
+  status: OK
+  reason: ''
+  name: Core Ontology for Biology and Biomedicine
+  version: '2025-12-15'
+  nodecount: 126
+  edgecount: 106
+  submission_id: '21'
+  source_bytes: 57691
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COB.tar.gz
+- id: COCHRANE
+  status: OK
+  reason: ''
+  name: Cochrane Core Vocabulary Ontology
+  version: 2.0.1
+  nodecount: 56
+  edgecount: 84
+  submission_id: '1'
+  source_bytes: 18296
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COCHRANE.tar.gz
+- id: CODO
+  status: OK
+  reason: ''
+  name: 'CODO: an Ontology for collection and analysis of COviD-19 data'
+  version: '1.5'
+  nodecount: 1538
+  edgecount: 1268
+  submission_id: '6'
+  source_bytes: 1034788
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CODO.tar.gz
+- id: COG
+  status: OK
+  reason: ''
+  name: Common Ontology of Genome
+  version: NA
+  nodecount: 164
+  edgecount: 134
+  submission_id: '1'
+  source_bytes: 71409
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COG.tar.gz
+- id: COGAT
+  status: OK
+  reason: ''
+  name: Cognitive Atlas Ontology
+  version: '0.4'
+  nodecount: 4068
+  edgecount: 931
+  submission_id: '8'
+  source_bytes: 2706390
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COGAT.tar.gz
+- id: COGITO
+  status: OK
+  reason: ''
+  name: Cognitive Task Ontology
+  version: 1.1.0
+  nodecount: 1339
+  edgecount: 10966
+  submission_id: '3'
+  source_bytes: 3185994
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/COGITO.tar.gz
+- id: COGMEMO
+  status: OK
+  reason: ''
+  name: Thesaurus of the Cognitive Psychology of Human Memory
+  version: '2.6'
+  nodecount: 3042
+  edgecount: 11373
+  submission_id: '1'
+  source_bytes: 5232120
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COGMEMO.tar.gz
+- id: COGPO
+  status: OK
+  reason: ''
+  name: Cognitive Paradigm Ontology
+  version: '1'
+  nodecount: 226
+  edgecount: 254
+  submission_id: '1'
+  source_bytes: 209798
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/COGPO.tar.gz
+- id: COHSI2STUDY
+  status: OK
+  reason: ''
+  name: cohsi2study
+  version: 0.2.8
+  nodecount: 111
+  edgecount: 248
+  submission_id: '27'
+  source_bytes: 21694
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COHSI2STUDY.tar.gz
+- id: COHSI2TERMSWEEKX
+  status: OK
+  reason: ''
+  name: cohsi2termsweekx
+  version: NA
+  nodecount: 78
+  edgecount: 95
+  submission_id: '1'
+  source_bytes: 11687
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COHSI2TERMSWEEKX.tar.gz
+- id: COID
+  status: OK
+  reason: ''
+  name: Combined Ontology for Inflammatory Diseases
+  version: 1.0.0
+  nodecount: 1201
+  edgecount: 2071
+  submission_id: '1'
+  source_bytes: 923924
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COID.tar.gz
+- id: COKPME
+  status: OK
+  reason: ''
+  name: 'COKPME - COVID19 Ontology for analyzing the Karnataka Private Medical Establishments
+    Data  '
+  version: '1.0'
+  nodecount: 112
+  edgecount: 93
+  submission_id: '1'
+  source_bytes: 51706
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/COKPME.tar.gz
+- id: COLAO
+  status: OK
+  reason: ''
+  name: Coleoptera Anatomy Ontology
+  version: '2024-06-21'
+  nodecount: 1319
+  edgecount: 2691
+  submission_id: '8'
+  source_bytes: 3238163
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COLAO.tar.gz
+- id: COMET
+  status: OK
+  reason: ''
+  name: LinkML Common Metadata Elements and Terms
+  version: NA
+  nodecount: 446
+  edgecount: 813
+  submission_id: '5'
+  source_bytes: 164986
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COMET.tar.gz
+- id: COMO
+  status: OK
+  reason: ''
+  name: Context and Measurement Ontology
+  version: '2025-08-13'
+  nodecount: 553
+  edgecount: 550
+  submission_id: '8'
+  source_bytes: 163495
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COMO.tar.gz
+- id: COMODI
+  status: OK
+  reason: ''
+  name: COMODI
+  version: NA
+  nodecount: 79
+  edgecount: 80
+  submission_id: '6'
+  source_bytes: 36019
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COMODI.tar.gz
+- id: CONDOR
+  status: OK
+  reason: ''
+  name: Liver Cancer Ontology Diagnosis Treatment
+  version: '0.1'
+  nodecount: 70
+  edgecount: 75
+  submission_id: '1'
+  source_bytes: 40912
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CONDOR.tar.gz
+- id: CONTSONTO
+  status: OK
+  reason: ''
+  name: Continuity of care
+  version: Version 2.1 (2026)
+  nodecount: 563
+  edgecount: 709
+  submission_id: '7'
+  source_bytes: 306687
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CONTSONTO.tar.gz
+- id: COPDO
+  status: OK
+  reason: ''
+  name: COPD Ontology
+  version: '1'
+  nodecount: 116
+  edgecount: 109
+  submission_id: '1'
+  source_bytes: 37331
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COPDO.tar.gz
+- id: COPPER
+  status: OK
+  reason: ''
+  name: COntextualised and Personalised Physical activity and Exercise Recommendations
+  version: '2025-10-07'
+  nodecount: 833
+  edgecount: 594
+  submission_id: '5'
+  source_bytes: 735274
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COPPER.tar.gz
+- id: COSTART
+  status: OK
+  reason: ''
+  name: Coding Symbols for a Thesaurus of Adverse Reaction Terms
+  version: CSP2006
+  nodecount: 1713
+  edgecount: 2968
+  submission_id: '1'
+  source_bytes: 1048478
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COSTART.tar.gz
+- id: COVID-19
+  status: OK
+  reason: ''
+  name: COVID-19 Ontology
+  version: 'Version Release: 1.0.0'
+  nodecount: 2942
+  edgecount: 7150
+  submission_id: '4'
+  source_bytes: 4358555
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COVID-19.tar.gz
+- id: COVID-19-ONT-PM
+  status: OK
+  reason: ''
+  name: COVID-19OntologyInPatternMedicine
+  version: '007'
+  nodecount: 318
+  edgecount: 541
+  submission_id: '9'
+  source_bytes: 217451
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COVID-19-ONT-PM.tar.gz
+- id: COVID19
+  status: OK
+  reason: ''
+  name: COVID-19 Surveillance Ontology
+  version: V1.0
+  nodecount: 39
+  edgecount: 28
+  submission_id: '3'
+  source_bytes: 30166
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COVID19.tar.gz
+- id: COVID19-IBO
+  status: OK
+  reason: ''
+  name: Covid19 Impact on Banking Ontology
+  version: '1.5'
+  nodecount: 240
+  edgecount: 333
+  submission_id: '6'
+  source_bytes: 90995
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COVID19-IBO.tar.gz
+- id: COVIDCRFRAPID
+  status: OK
+  reason: ''
+  name: WHO COVID-19 Rapid Version CRF semantic data model
+  version: 1.1.4
+  nodecount: 529
+  edgecount: 731
+  submission_id: '12'
+  source_bytes: 408321
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/COVIDCRFRAPID.tar.gz
+- id: CPRO
+  status: OK
+  reason: ''
+  name: Computer-Based Patient Record Ontology
+  version: 'Last modification: July 31th, 2011 Chimezie Ogbuji'
+  nodecount: 162
+  edgecount: 200
+  submission_id: '3'
+  source_bytes: 113282
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/CPRO.tar.gz
+- id: CPT
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: CPTAC
+  status: OK
+  reason: ''
+  name: CPTAC Proteomics Pipeline Infrastructure Ontology
+  version: alpha 1.1
+  nodecount: 451
+  edgecount: 1031
+  submission_id: '3'
+  source_bytes: 540882
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CPTAC.tar.gz
+- id: CRENO
+  status: OK
+  reason: ''
+  name: Culture, Race, Ethnicity and Nationality Ontology
+  version: '0.6'
+  nodecount: 638
+  edgecount: 837
+  submission_id: '2'
+  source_bytes: 517607
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CRENO.tar.gz
+- id: CRISP
+  status: OK
+  reason: ''
+  name: Computer Retrieval of Information on Scientific Projects Thesaurus
+  version: CSP2006
+  nodecount: 9050
+  edgecount: 22967
+  submission_id: '1'
+  source_bytes: 11167756
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CRISP.tar.gz
+- id: CRO
+  status: OK
+  reason: ''
+  name: Contributor Role Ontology
+  version: v2019-08-16
+  nodecount: 138
+  edgecount: 237
+  submission_id: '4'
+  source_bytes: 111351
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CRO.tar.gz
+- id: CRYOEM
+  status: OK
+  reason: ''
+  name: Cryo Electron Microscopy
+  version: '2021-03-09'
+  nodecount: 133
+  edgecount: 196
+  submission_id: '4'
+  source_bytes: 55659
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CRYOEM.tar.gz
+- id: CS
+  status: Failed
+  reason: not_downloadable
+  name: Coping Strategies for Adverse Drug Events Ontology
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: CSEO
+  status: OK
+  reason: ''
+  name: Cigarette Smoke Exposure Ontology
+  version: '1.0'
+  nodecount: 20203
+  edgecount: 26523
+  submission_id: '2'
+  source_bytes: 22231399
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CSEO.tar.gz
+- id: CSO
+  status: OK
+  reason: ''
+  name: Clinical Study Ontology
+  version: NA
+  nodecount: 38
+  edgecount: 36
+  submission_id: '1'
+  source_bytes: 12627
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CSO.tar.gz
+- id: CSSO
+  status: OK
+  reason: ''
+  name: Clinical Signs and Symptoms Ontology
+  version: Version 0.6
+  nodecount: 314
+  edgecount: 304
+  submission_id: '6'
+  source_bytes: 307520
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CSSO.tar.gz
+- id: CST
+  status: Failed
+  reason: not_downloadable
+  name: Cancer Staging Terms
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: CSTD
+  status: OK
+  reason: ''
+  name: Clinical smell and taste disorders
+  version: '1'
+  nodecount: 618
+  edgecount: 112
+  submission_id: '1'
+  source_bytes: 150741
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CSTD.tar.gz
+- id: CTCAE
+  status: OK
+  reason: ''
+  name: Common Terminology Criteria for Adverse Events
+  version: '5.0'
+  nodecount: 4059
+  edgecount: 4048
+  submission_id: '3'
+  source_bytes: 14439241
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTCAE.tar.gz
+- id: CTENO
+  status: OK
+  reason: ''
+  name: Ctenophore Ontology
+  version: NA
+  nodecount: 680
+  edgecount: 950
+  submission_id: '1'
+  source_bytes: 289634
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTENO.tar.gz
+- id: CTGO
+  status: OK
+  reason: ''
+  name: Clinical Trials Gov Ontology
+  version: '1.0'
+  nodecount: 412
+  edgecount: 783
+  submission_id: '1'
+  source_bytes: 108266
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTGO.tar.gz
+- id: CTO
+  status: OK
+  reason: ''
+  name: Clinical Trials Ontology
+  version: 'Version Release: 1.0.0'
+  nodecount: 447
+  edgecount: 904
+  submission_id: '1'
+  source_bytes: 589036
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTO.tar.gz
+- id: CTO-NDD
+  status: OK
+  reason: ''
+  name: Clinical Trials Ontology - Neurodegenerative Diseases
+  version: '0.6'
+  nodecount: 381
+  edgecount: 376
+  submission_id: '1'
+  source_bytes: 596384
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTO-NDD.tar.gz
+- id: CTONT
+  status: OK
+  reason: ''
+  name: Epoch Clinical Trial Ontology
+  version: "<table border=\"1\">\n      <tr>\n        <td>\n          <b><i>Version</i></b>\n\
+    \        </td>\n        <td>\n          0.97\n        </td>\n      </tr>\n   \
+    \   <tr>\n        <td>\n          <b><i>Date</i></b>\n        </td>\n        <td>\n\
+    \          3/2/2007<br>\n        </td>\n      </tr>\n    </table>\n    <br>"
+  nodecount: 108
+  edgecount: 139
+  submission_id: '1'
+  source_bytes: 66194
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/CTONT.tar.gz
+- id: CTU_BEREADY_GEM
+  status: OK
+  reason: ''
+  name: CTU Bern BEReady Gemeinden
+  version: gem_onto_1level_v0_01
+  nodecount: 349
+  edgecount: 1017
+  submission_id: '3'
+  source_bytes: 117327
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTU_BEREADY_GEM.tar.gz
+- id: CTX
+  status: Failed
+  reason: transform_error
+  name: Cerebrotendinous Xanthomatosis Ontology
+  version: vtemp2
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 116415
+- id: CU-VO
+  status: OK
+  reason: ''
+  name: Venom Ontology
+  version: '1.0'
+  nodecount: 7360
+  edgecount: 33
+  submission_id: '1'
+  source_bytes: 7358241
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CU-VO.tar.gz
+- id: CVAO
+  status: OK
+  reason: ''
+  name: STO
+  version: '2017-11-01'
+  nodecount: 1839
+  edgecount: 4006
+  submission_id: '2'
+  source_bytes: 2541188
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CVAO.tar.gz
+- id: CVDO
+  status: OK
+  reason: ''
+  name: Cardiovascular Disease Ontology
+  version: '2024-05-17'
+  nodecount: 1023
+  edgecount: 1865
+  submission_id: '5'
+  source_bytes: 1339226
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CVDO.tar.gz
+- id: CWD
+  status: OK
+  reason: ''
+  name: Consumer Wearable Device
+  version: NA
+  nodecount: 47
+  edgecount: 43
+  submission_id: '1'
+  source_bytes: 20353
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CWD.tar.gz
+- id: CXSO
+  status: OK
+  reason: ''
+  name: Cathexis Somatic Ontology
+  version: '1.1'
+  nodecount: 186
+  edgecount: 54
+  submission_id: '2'
+  source_bytes: 47383
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CXSO.tar.gz
+- id: CYTO
+  status: OK
+  reason: ''
+  name: CYTOKINE
+  version: Cytokines
+  nodecount: 326
+  edgecount: 317
+  submission_id: '27'
+  source_bytes: 512717
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CYTO.tar.gz
+- id: D3O
+  status: OK
+  reason: ''
+  name: DSMZ Digital Diversity Ontology
+  version: '1.1'
+  nodecount: 443
+  edgecount: 412
+  submission_id: '3'
+  source_bytes: 315395
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/D3O.tar.gz
+- id: DATACITE
+  status: OK
+  reason: ''
+  name: SPAR DataCite Ontology
+  version: 1.3.1
+  nodecount: 156
+  edgecount: 166
+  submission_id: '4'
+  source_bytes: 130173
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DATACITE.tar.gz
+- id: DATACITE-VOCAB
+  status: OK
+  reason: ''
+  name: DATACITE V4.4
+  version: 0.1.0
+  nodecount: 149
+  edgecount: 394
+  submission_id: '5'
+  source_bytes: 25984
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DATACITE-VOCAB.tar.gz
+- id: DATAHUB
+  status: OK
+  reason: ''
+  name: RADx Data Hub Ontology
+  version: 0.9.3
+  nodecount: 135
+  edgecount: 99
+  submission_id: '4'
+  source_bytes: 86937
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DATAHUB.tar.gz
+- id: DBM
+  status: OK
+  reason: ''
+  name: DBM Ontology
+  version: '1.1'
+  nodecount: 47
+  edgecount: 58
+  submission_id: '1'
+  source_bytes: 8072
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DBM.tar.gz
+- id: DC
+  status: OK
+  reason: ''
+  name: Dublin Core
+  version: NA
+  nodecount: 38
+  edgecount: 37
+  submission_id: '3'
+  source_bytes: 17461
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DC.tar.gz
+- id: DCAT
+  status: OK
+  reason: ''
+  name: Data Catalog Vocabulary
+  version: NA
+  nodecount: 51
+  edgecount: 64
+  submission_id: '2'
+  source_bytes: 29396
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCAT.tar.gz
+- id: DCAT-FDC
+  status: OK
+  reason: ''
+  name: Data Catalog Vocabulary (DCAT)
+  version: "Toto je aktualizovan\xE1 kopie slovn\xEDku DCAT verze 2.0, p\u0159evzat\xE1\
+    \ z https://www.w3.org/ns/dcat.ttl"
+  nodecount: 219
+  edgecount: 342
+  submission_id: '1'
+  source_bytes: 165748
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCAT-FDC.tar.gz
+- id: DCAT3
+  status: OK
+  reason: ''
+  name: DCAT3
+  version: '3'
+  nodecount: 248
+  edgecount: 394
+  submission_id: '2'
+  source_bytes: 248255
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCAT3.tar.gz
+- id: DCCDFV
+  status: OK
+  reason: ''
+  name: Dublin Core Collection Description Frequency Vocabulary
+  version: NA
+  nodecount: 28
+  edgecount: 68
+  submission_id: '1'
+  source_bytes: 9334
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCCDFV.tar.gz
+- id: DCM
+  status: OK
+  reason: ''
+  name: DICOM Controlled Terminology
+  version: 2026c_20260612
+  nodecount: 5188
+  edgecount: 45
+  submission_id: '56'
+  source_bytes: 253485
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCM.tar.gz
+- id: DCMITYPE
+  status: OK
+  reason: ''
+  name: DCMI Type Vocabulary
+  version: NA
+  nodecount: 54
+  edgecount: 84
+  submission_id: '4'
+  source_bytes: 40488
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCMITYPE.tar.gz
+- id: DCO
+  status: OK
+  reason: ''
+  name: Dispedia Core Ontology
+  version: 0.7.0.0002
+  nodecount: 132
+  edgecount: 184
+  submission_id: '34'
+  source_bytes: 53215
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/DCO.tar.gz
+- id: DCT
+  status: OK
+  reason: ''
+  name: DC Terms
+  version: NA
+  nodecount: 240
+  edgecount: 360
+  submission_id: '1'
+  source_bytes: 87171
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCT.tar.gz
+- id: DCTERMS
+  status: OK
+  reason: ''
+  name: 'DCMI Metadata Terms: properties in /terms/ namespace'
+  version: NA
+  nodecount: 240
+  edgecount: 368
+  submission_id: '1'
+  source_bytes: 87171
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCTERMS.tar.gz
+- id: DDANAT
+  status: OK
+  reason: ''
+  name: Dictyostelium Discoideum Anatomy Ontology
+  version: '1.19'
+  nodecount: 163
+  edgecount: 360
+  submission_id: '24'
+  source_bytes: 59322
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DDANAT.tar.gz
+- id: DDI
+  status: OK
+  reason: ''
+  name: Ontology for Drug Discovery Investigations
+  version: $Revision$
+  nodecount: 180
+  edgecount: 284
+  submission_id: '2'
+  source_bytes: 145235
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/DDI.tar.gz
+- id: DDIEM
+  status: OK
+  reason: ''
+  name: Drug Database for Inborn Errors of Metabolism (DDIEM) Ontology
+  version: '1.2'
+  nodecount: 28
+  edgecount: 22
+  submission_id: '4'
+  source_bytes: 20850
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DDIEM.tar.gz
+- id: DDPHENO
+  status: OK
+  reason: ''
+  name: Dictyostelium Discoideum Phenotype Ontology
+  version: NA
+  nodecount: 1399
+  edgecount: 1435
+  submission_id: '508'
+  source_bytes: 372016
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DDPHENO.tar.gz
+- id: DDSS
+  status: OK
+  reason: ''
+  name: Health_ontology
+  version: NA
+  nodecount: 89369
+  edgecount: 413522
+  submission_id: '1'
+  source_bytes: 20722272
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/DDSS.tar.gz
+- id: DEB
+  status: OK
+  reason: ''
+  name: Devices, Experimental scaffolds and Biomaterials Ontology
+  version: '4.0'
+  nodecount: 732
+  edgecount: 1037
+  submission_id: '7'
+  source_bytes: 315434
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DEB.tar.gz
+- id: DECIDE
+  status: OK
+  reason: ''
+  name: DECIDE ONTOLOGY
+  version: Version 1.2
+  nodecount: 96
+  edgecount: 58
+  submission_id: '2'
+  source_bytes: 42312
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DECIDE.tar.gz
+- id: DEMLAB
+  status: OK
+  reason: ''
+  name: Dem@Care Lab Ontology for Dementia Assessment
+  version: '1.0'
+  nodecount: 365
+  edgecount: 586
+  submission_id: '1'
+  source_bytes: 118221
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DEMLAB.tar.gz
+- id: DERMLEX
+  status: OK
+  reason: ''
+  name: Dermatology Lexicon
+  version: '1'
+  nodecount: 6127
+  edgecount: 6120
+  submission_id: '4'
+  source_bytes: 1699022
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DERMLEX.tar.gz
+- id: DERMO
+  status: OK
+  reason: ''
+  name: Human Dermatological Disease Ontology
+  version: '1.19'
+  nodecount: 3549
+  edgecount: 4181
+  submission_id: '10'
+  source_bytes: 979248
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DERMO.tar.gz
+- id: DFO
+  status: OK
+  reason: ''
+  name: Databank Family Ontology
+  version: '0.1'
+  nodecount: 37
+  edgecount: 28
+  submission_id: '1'
+  source_bytes: 14578
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DFO.tar.gz
+- id: DHMO
+  status: OK
+  reason: ''
+  name: RADx Data Hub Metadata Ontology
+  version: '2024-11-06'
+  nodecount: 2667
+  edgecount: 7126
+  submission_id: '1'
+  source_bytes: 1427397
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DHMO.tar.gz
+- id: DIAB
+  status: OK
+  reason: ''
+  name: BioMedBridges Diabetes Ontology
+  version: '2.0'
+  nodecount: 418
+  edgecount: 2181
+  submission_id: '73'
+  source_bytes: 812265
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DIAB.tar.gz
+- id: DIAGONT
+  status: OK
+  reason: ''
+  name: Diagnostic Ontology
+  version: '2.0'
+  nodecount: 116
+  edgecount: 242
+  submission_id: '1'
+  source_bytes: 50374
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DIAGONT.tar.gz
+- id: DICOM
+  status: OK
+  reason: ''
+  name: Healthcare metadata - DICOM ontology
+  version: v2015-01-11
+  nodecount: 8640
+  edgecount: 29667
+  submission_id: '2'
+  source_bytes: 6852758
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DICOM.tar.gz
+- id: DIDEO
+  status: OK
+  reason: ''
+  name: Drug Interaction and Evidence Ontology
+  version: release version 2017-11-17
+  nodecount: 675
+  edgecount: 822
+  submission_id: '48'
+  source_bytes: 984245
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DIDEO.tar.gz
+- id: DIKB
+  status: OK
+  reason: ''
+  name: Drug Interaction Knowledge Base Ontology
+  version: Version 1.6
+  nodecount: 316
+  edgecount: 644
+  submission_id: '5'
+  source_bytes: 274139
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/DIKB.tar.gz
+- id: DILON
+  status: OK
+  reason: ''
+  name: Dietary lifestyle ontology
+  version: '2'
+  nodecount: 802
+  edgecount: 285
+  submission_id: '2'
+  source_bytes: 506812
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DILON.tar.gz
+- id: DINTO
+  status: Skipped
+  reason: too_large
+  name: The Drug-Drug Interactions Ontology
+  version: '1.3'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 113524941
+- id: DISDRIV
+  status: OK
+  reason: ''
+  name: Disease Drivers Ontology
+  version: '2026-03-31'
+  nodecount: 99
+  edgecount: 84
+  submission_id: '5'
+  source_bytes: 110519
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DISDRIV.tar.gz
+- id: DLORO
+  status: OK
+  reason: ''
+  name: Dependency Layered Ontology for Radiation Oncology
+  version: NA
+  nodecount: 379
+  edgecount: 703
+  submission_id: '3'
+  source_bytes: 330808
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DLORO.tar.gz
+- id: DMDSONT
+  status: OK
+  reason: ''
+  name: 'Diabetes Mellitus Diagnosis and Support Ontology '
+  version: ver 1.0
+  nodecount: 166
+  edgecount: 126
+  submission_id: '1'
+  source_bytes: 177173
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DMDSONT.tar.gz
+- id: DMTO
+  status: Failed
+  reason: not_downloadable
+  name: Diabetes Mellitus Treatment Ontology
+  version: '2015-11-20'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 0
+- id: DOCCC
+  status: OK
+  reason: ''
+  name: Diagnosis Ontology of Clinical Care Classification
+  version: '20131004'
+  nodecount: 206
+  edgecount: 203
+  submission_id: '3'
+  source_bytes: 144215
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DOCCC.tar.gz
+- id: DOID
+  status: OK
+  reason: ''
+  name: Human Disease Ontology
+  version: '2026-07-31'
+  nodecount: 16717
+  edgecount: 39169
+  submission_id: '674'
+  source_bytes: 28539731
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/DOID.tar.gz
+- id: DOREMUS-KEYS
+  status: OK
+  reason: ''
+  name: Doremus List of Keys
+  version: NA
+  nodecount: 130
+  edgecount: 354
+  submission_id: '3'
+  source_bytes: 54176
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DOREMUS-KEYS.tar.gz
+- id: DOVES
+  status: Failed
+  reason: transform_error
+  name: Digital medicine Outcomes Value Set (DOVeS) Ontology
+  version: v1.0.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 34069943
+- id: DPCO
+  status: OK
+  reason: ''
+  name: Diabetes Pharmacology Ontology
+  version: '1.0'
+  nodecount: 311
+  edgecount: 410
+  submission_id: '2'
+  source_bytes: 287146
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DPCO.tar.gz
+- id: DPO
+  status: OK
+  reason: ''
+  name: Drosophila Phenotype Ontology
+  version: '2026-07-10'
+  nodecount: 2172
+  edgecount: 5184
+  submission_id: '43'
+  source_bytes: 4038896
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DPO.tar.gz
+- id: DRANPTO
+  status: OK
+  reason: ''
+  name: Dementia-Related Agitation Non-Pharmacological Treatment Ontology
+  version: Version 1.0
+  nodecount: 628
+  edgecount: 770
+  submission_id: '1'
+  source_bytes: 579469
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DRANPTO.tar.gz
+- id: DREAMDNPTO
+  status: OK
+  reason: ''
+  name: Dementia-Related Emotional And Mood Disturbance Non-Pharmacological Treatment
+    Ontology
+  version: v1.0
+  nodecount: 1341
+  edgecount: 1559
+  submission_id: '1'
+  source_bytes: 1021729
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DREAMDNPTO.tar.gz
+- id: DRMO
+  status: Failed
+  reason: transform_error
+  name: Dental Restorative Material Ontology
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 295118
+- id: DRON
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: DRPSNPTO
+  status: OK
+  reason: ''
+  name: Dementia-Related Psychotic Symptoms Non-Pharmacological Treatment Ontology
+  version: v1.0
+  nodecount: 683
+  edgecount: 838
+  submission_id: '1'
+  source_bytes: 575707
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DRPSNPTO.tar.gz
+- id: DSAV
+  status: Failed
+  reason: no_submission
+  name: Digital Specimen Accessibility Vocabulary
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: DSEO
+  status: OK
+  reason: ''
+  name: Data Science Education Ontology
+  version: '1.1'
+  nodecount: 140
+  edgecount: 135
+  submission_id: '4'
+  source_bytes: 58444
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSEO.tar.gz
+- id: DSIP
+  status: Failed
+  reason: not_downloadable
+  name: Pharmacy mock data
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: DSIP1V
+  status: OK
+  reason: ''
+  name: DSIP1_vocabulary
+  version: NA
+  nodecount: 27
+  edgecount: 42
+  submission_id: '2'
+  source_bytes: 4960
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSIP1V.tar.gz
+- id: DSIP2324_DEMO
+  status: OK
+  reason: ''
+  name: DSIP2324_Demonstration
+  version: '0.2'
+  nodecount: 34
+  edgecount: 58
+  submission_id: '2'
+  source_bytes: 5974
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSIP2324_DEMO.tar.gz
+- id: DSIP7
+  status: OK
+  reason: ''
+  name: DSIP_FieldLab_7
+  version: NA
+  nodecount: 36
+  edgecount: 69
+  submission_id: '1'
+  source_bytes: 10157
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSIP7.tar.gz
+- id: DSIP8
+  status: OK
+  reason: ''
+  name: DSIP8REFUGEE
+  version: NA
+  nodecount: 31
+  edgecount: 57
+  submission_id: '3'
+  source_bytes: 6024
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSIP8.tar.gz
+- id: DSIPF7
+  status: OK
+  reason: ''
+  name: 'DSIP FiledLab7 '
+  version: NA
+  nodecount: 36
+  edgecount: 69
+  submission_id: '3'
+  source_bytes: 10157
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSIPF7.tar.gz
+- id: DSIPFL7
+  status: OK
+  reason: ''
+  name: DSIP_Fieldlab_7
+  version: latest_v1
+  nodecount: 41
+  edgecount: 125
+  submission_id: '12'
+  source_bytes: 23620
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSIPFL7.tar.gz
+- id: DSIP_FL_7
+  status: OK
+  reason: ''
+  name: DSIP_FL_7
+  version: v1
+  nodecount: 36
+  edgecount: 69
+  submission_id: '1'
+  source_bytes: 10317
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DSIP_FL_7.tar.gz
+- id: DTO
+  status: OK
+  reason: ''
+  name: Drug Target Ontology
+  version: 1.1.1
+  nodecount: 4
+  edgecount: 3
+  submission_id: '5'
+  source_bytes: 3995
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DTO.tar.gz
+- id: DUO
+  status: OK
+  reason: ''
+  name: The Data Use Ontology
+  version: NA
+  nodecount: 316
+  edgecount: 311
+  submission_id: '8'
+  source_bytes: 108348
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DUO.tar.gz
+- id: E-PPO
+  status: OK
+  reason: ''
+  name: Enhanced Personal Profile Ontology
+  version: NA
+  nodecount: 58
+  edgecount: 53
+  submission_id: '1'
+  source_bytes: 10981
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/E-PPO.tar.gz
+- id: EBP
+  status: OK
+  reason: ''
+  name: EmpowerBP
+  version: '2.5'
+  nodecount: 450
+  edgecount: 181
+  submission_id: '2'
+  source_bytes: 793869
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EBP.tar.gz
+- id: ECAO
+  status: OK
+  reason: ''
+  name: The Echinoderm Anatomy and Development Ontology
+  version: NA
+  nodecount: 8222
+  edgecount: 35290
+  submission_id: '7'
+  source_bytes: 25560155
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECAO.tar.gz
+- id: ECDO
+  status: OK
+  reason: ''
+  name: Elderly Care Dementia Ontology
+  version: NA
+  nodecount: 70
+  edgecount: 159
+  submission_id: '1'
+  source_bytes: 19878
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECDO.tar.gz
+- id: ECG
+  status: OK
+  reason: ''
+  name: Electrocardiography Ontology
+  version: '1'
+  nodecount: 1165
+  edgecount: 1194
+  submission_id: '12'
+  source_bytes: 746538
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECG.tar.gz
+- id: ECM4M-MD-VOCABS
+  status: OK
+  reason: ''
+  name: EarthCube M4M Metadata Vocabulary
+  version: 0.1.2
+  nodecount: 51
+  edgecount: 89
+  submission_id: '4'
+  source_bytes: 10766
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECM4M-MD-VOCABS.tar.gz
+- id: ECO
+  status: OK
+  reason: ''
+  name: Evidence and Conclusion Ontology
+  version: releases/2025-06-23
+  nodecount: 2351
+  edgecount: 5362
+  submission_id: '128'
+  source_bytes: 1371481
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECO.tar.gz
+- id: ECOCORE
+  status: OK
+  reason: ''
+  name: An ontology of core ecological entities
+  version: '2022-03-09'
+  nodecount: 7497
+  edgecount: 23306
+  submission_id: '7'
+  source_bytes: 20699912
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECOCORE.tar.gz
+- id: ECOSIM
+  status: OK
+  reason: ''
+  name: ecosim ontology
+  version: '2025-05-29'
+  nodecount: 6
+  edgecount: 1
+  submission_id: '4'
+  source_bytes: 2377
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECOSIM.tar.gz
+- id: ECP
+  status: OK
+  reason: ''
+  name: Electronic Care Plan
+  version: '0.6'
+  nodecount: 82
+  edgecount: 101
+  submission_id: '2'
+  source_bytes: 49990
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECP.tar.gz
+- id: ECSO
+  status: OK
+  reason: ''
+  name: The Ecosystem Ontology
+  version: '0.9'
+  nodecount: 2315
+  edgecount: 4713
+  submission_id: '64'
+  source_bytes: 2302681
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECSO.tar.gz
+- id: ECTO
+  status: OK
+  reason: ''
+  name: Environmental conditions, treatments and exposures ontology
+  version: '2026-07-28'
+  nodecount: 21399
+  edgecount: 61849
+  submission_id: '13'
+  source_bytes: 28320857
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECTO.tar.gz
+- id: EDAM
+  status: OK
+  reason: ''
+  name: EDAM - The ontology of data analysis and management
+  version: 1.25-20260626T1230Z
+  nodecount: 4613
+  edgecount: 15464
+  submission_id: '44'
+  source_bytes: 3475749
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EDAM.tar.gz
+- id: EDAM-BIOIMAGING
+  status: OK
+  reason: ''
+  name: EDAM Bioimaging ontology
+  version: 1.0alpha_pre-pre-release-20251026T0104Z
+  nodecount: 867
+  edgecount: 1045
+  submission_id: '7'
+  source_bytes: 418067
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EDAM-BIOIMAGING.tar.gz
+- id: EDDA
+  status: OK
+  reason: ''
+  name: EDDA Study Designs Taxonomy
+  version: '2.0'
+  nodecount: 569
+  edgecount: 723
+  submission_id: '11'
+  source_bytes: 1457348
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/EDDA.tar.gz
+- id: EDDA_PT
+  status: OK
+  reason: ''
+  name: EDDA Publication Types Taxonomy
+  version: '1.0'
+  nodecount: 168
+  edgecount: 113
+  submission_id: '1'
+  source_bytes: 242386
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/EDDA_PT.tar.gz
+- id: EDEM-CONNECTONTO
+  status: OK
+  reason: ''
+  name: 'eDEM-Connect: Ontology of Dementia-related Agitation and Relationship between
+    Informal Caregivers and Persons with Dementia'
+  version: Version_2.0
+  nodecount: 593
+  edgecount: 349
+  submission_id: '2'
+  source_bytes: 476609
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EDEM-CONNECTONTO.tar.gz
+- id: EDONTOLOGY
+  status: OK
+  reason: ''
+  name: Emergency Department Ontology
+  version: NA
+  nodecount: 967
+  edgecount: 1982
+  submission_id: '2'
+  source_bytes: 1702214
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EDONTOLOGY.tar.gz
+- id: EFO
+  status: Skipped
+  reason: too_large
+  name: Experimental Factor Ontology
+  version: 3.92.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '290'
+  source_bytes: 347558240
+- id: EGO
+  status: OK
+  reason: ''
+  name: Epigenome Ontology
+  version: Arbor version; 1.0.1
+  nodecount: 39
+  edgecount: 20
+  submission_id: '1'
+  source_bytes: 13670
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/EGO.tar.gz
+- id: EHDA
+  status: OK
+  reason: ''
+  name: Human Developmental Anatomy Ontology, timed version
+  version: unknown
+  nodecount: 8353
+  edgecount: 8339
+  submission_id: '7'
+  source_bytes: 1148413
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDA.tar.gz
+- id: EHDAA
+  status: OK
+  reason: ''
+  name: Human Developmental Anatomy Ontology, abstract version 1
+  version: unknown
+  nodecount: 2326
+  edgecount: 2335
+  submission_id: '7'
+  source_bytes: 220476
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDAA.tar.gz
+- id: EHDAA2
+  status: OK
+  reason: ''
+  name: Human Developmental Anatomy Ontology, abstract version 2
+  version: releases/2024-01-11
+  nodecount: 2776
+  edgecount: 11768
+  submission_id: '34'
+  source_bytes: 933914
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDAA2.tar.gz
+- id: ELD
+  status: Failed
+  reason: transform_error
+  name: EthiopianListOfDiseases
+  version: '4'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 1001895
+- id: ELECTRICA
+  status: OK
+  reason: ''
+  name: Ontology for ELEctronic tool for Clinicians, Trainers and Researchers In Child
+    Abuse
+  version: '2024-09-09'
+  nodecount: 1846
+  edgecount: 1914
+  submission_id: '7'
+  source_bytes: 759540
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ELECTRICA.tar.gz
+- id: ELIG
+  status: OK
+  reason: ''
+  name: Eligibility Feature Hierarchy
+  version: v. 1.0
+  nodecount: 35
+  edgecount: 38
+  submission_id: '1'
+  source_bytes: 15539
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ELIG.tar.gz
+- id: ELTER_CL
+  status: OK
+  reason: ''
+  name: eLTER Controlled Lists
+  version: 1.1.1
+  nodecount: 876
+  edgecount: 2242
+  submission_id: '58'
+  source_bytes: 210524
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ELTER_CL.tar.gz
+- id: EMAP
+  status: OK
+  reason: ''
+  name: Mouse Gross Anatomy and Development Ontology
+  version: unknown
+  nodecount: 19455
+  edgecount: 21721
+  submission_id: '7'
+  source_bytes: 2378895
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMAP.tar.gz
+- id: EMAPA
+  status: OK
+  reason: ''
+  name: Mouse gross anatomy and development, timed
+  version: NA
+  nodecount: 8797
+  edgecount: 23289
+  submission_id: '48'
+  source_bytes: 10768731
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMAPA.tar.gz
+- id: EMIF-AD
+  status: Failed
+  reason: transform_error
+  name: EMIF-AD ontology
+  version: 0.0.2
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 414779
+- id: EMO
+  status: OK
+  reason: ''
+  name: Enzyme Mechanism Ontology
+  version: NA
+  nodecount: 193
+  edgecount: 185
+  submission_id: '1'
+  source_bytes: 263370
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMO.tar.gz
+- id: EMRO
+  status: OK
+  reason: ''
+  name: Emotion Response Ontology
+  version: '2026-06-22'
+  nodecount: 314
+  edgecount: 702
+  submission_id: '11'
+  source_bytes: 273904
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMRO.tar.gz
+- id: ENDOH
+  status: OK
+  reason: ''
+  name: Environmental Determinants of Health
+  version: BETA
+  nodecount: 111
+  edgecount: 108
+  submission_id: '2'
+  source_bytes: 35091
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ENDOH.tar.gz
+- id: ENM
+  status: OK
+  reason: ''
+  name: eNanoMapper
+  version: '10.0'
+  nodecount: 14
+  edgecount: 13
+  submission_id: '34'
+  source_bytes: 6526
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ENM.tar.gz
+- id: ENTITY
+  status: OK
+  reason: ''
+  name: ISO-15926-2_2003_entityMembership
+  version: Created 2008-07-14. Version 1.0.
+  nodecount: 128
+  edgecount: 44
+  submission_id: '1'
+  source_bytes: 25649
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ENTITY.tar.gz
+- id: ENVO
+  status: OK
+  reason: ''
+  name: Environment Ontology
+  version: '2026-06-26'
+  nodecount: 8323
+  edgecount: 15406
+  submission_id: '64'
+  source_bytes: 9614229
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ENVO.tar.gz
+- id: ENVS_VARIABLES
+  status: OK
+  reason: ''
+  name: ENVS variables
+  version: 0.1.1
+  nodecount: 47
+  edgecount: 52
+  submission_id: '2'
+  source_bytes: 5505
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ENVS_VARIABLES.tar.gz
+- id: ENVTHES
+  status: OK
+  reason: ''
+  name: Thesaurus for long-term ecological research, monitoring, experiments
+  version: 5.0.16
+  nodecount: 8597
+  edgecount: 25685
+  submission_id: '54'
+  source_bytes: 3138937
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ENVTHES.tar.gz
+- id: EO
+  status: Failed
+  reason: transform_error
+  name: Ethnicity Ontoloy
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 657291
+- id: EO1
+  status: OK
+  reason: ''
+  name: Example Ontology
+  version: NA
+  nodecount: 43
+  edgecount: 77
+  submission_id: '1'
+  source_bytes: 11397
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EO1.tar.gz
+- id: EOL
+  status: OK
+  reason: ''
+  name: Environment Ontology for Livestock
+  version: NA
+  nodecount: 673
+  edgecount: 659
+  submission_id: '1'
+  source_bytes: 562239
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EOL.tar.gz
+- id: EP
+  status: OK
+  reason: ''
+  name: Cardiac Electrophysiology Ontology
+  version: '1'
+  nodecount: 243
+  edgecount: 216
+  submission_id: '2'
+  source_bytes: 107938
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/EP.tar.gz
+- id: EPIE
+  status: OK
+  reason: ''
+  name: Epigenetic Entity
+  version: '1.3'
+  nodecount: 610
+  edgecount: 605
+  submission_id: '4'
+  source_bytes: 742758
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPIE.tar.gz
+- id: EPILONT
+  status: OK
+  reason: ''
+  name: Epilepsy Ontology
+  version: V1
+  nodecount: 149
+  edgecount: 145
+  submission_id: '2'
+  source_bytes: 82828
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPILONT.tar.gz
+- id: EPIO
+  status: OK
+  reason: ''
+  name: EpilepsyOntology
+  version: 'Version Release: 1.0.0'
+  nodecount: 3100
+  edgecount: 5472
+  submission_id: '1'
+  source_bytes: 3259626
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPIO.tar.gz
+- id: EPIP
+  status: OK
+  reason: ''
+  name: Epigenetic Process
+  version: '1.3'
+  nodecount: 491
+  edgecount: 484
+  submission_id: '4'
+  source_bytes: 481545
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPIP.tar.gz
+- id: EPISEM
+  status: OK
+  reason: ''
+  name: Epilepsy Semiology
+  version: '5.0'
+  nodecount: 1603
+  edgecount: 1588
+  submission_id: '8'
+  source_bytes: 911174
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPISEM.tar.gz
+- id: EPO
+  status: Failed
+  reason: transform_error
+  name: Early Pregnancy Ontology
+  version: '1.1'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 839514
+- id: EPSO
+  status: OK
+  reason: ''
+  name: Epilepsy and Seizure Ontology
+  version: '3.1'
+  nodecount: 2455
+  edgecount: 2862
+  submission_id: '8'
+  source_bytes: 1365937
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPSO.tar.gz
+- id: ERO
+  status: OK
+  reason: ''
+  name: Eagle-I Research Resource Ontology
+  version: '2013-08-02'
+  nodecount: 4384
+  edgecount: 9033
+  submission_id: '14'
+  source_bytes: 4099007
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ERO.tar.gz
+- id: ESFO
+  status: OK
+  reason: ''
+  name: Enzyme Structure Function Ontology
+  version: '1'
+  nodecount: 169
+  edgecount: 278
+  submission_id: '1'
+  source_bytes: 136228
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ESFO.tar.gz
+- id: ESO_C
+  status: OK
+  reason: ''
+  name: Epilepsy Semiology Ontology
+  version: '1.0'
+  nodecount: 183
+  edgecount: 177
+  submission_id: '1'
+  source_bytes: 100364
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ESO_C.tar.gz
+- id: ESSO
+  status: OK
+  reason: ''
+  name: Epilepsy Syndrome Seizure Ontology
+  version: '1.03'
+  nodecount: 2888
+  edgecount: 4139
+  submission_id: '5'
+  source_bytes: 2007880
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ESSO.tar.gz
+- id: ETANC
+  status: OK
+  reason: ''
+  name: ETHIOPIANC
+  version: '0.2'
+  nodecount: 80
+  edgecount: 162
+  submission_id: '2'
+  source_bytes: 19381
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ETANC.tar.gz
+- id: ETHANC
+  status: OK
+  reason: ''
+  name: ETHANC
+  version: '14'
+  nodecount: 58
+  edgecount: 140
+  submission_id: '16'
+  source_bytes: 13947
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ETHANC.tar.gz
+- id: ETHOPD
+  status: OK
+  reason: ''
+  name: Ethiopian OPD
+  version: '0.3'
+  nodecount: 84
+  edgecount: 181
+  submission_id: '1'
+  source_bytes: 20016
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ETHOPD.tar.gz
+- id: EUPATH
+  status: OK
+  reason: ''
+  name: VEuPathDB Ontology
+  version: '2023-05-30'
+  nodecount: 6164
+  edgecount: 13057
+  submission_id: '19'
+  source_bytes: 5496422
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EUPATH.tar.gz
+- id: EVI
+  status: OK
+  reason: ''
+  name: Evidence Graph Ontology
+  version: '1.5'
+  nodecount: 134
+  edgecount: 185
+  submission_id: '12'
+  source_bytes: 63802
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EVI.tar.gz
+- id: EVORAO
+  status: OK
+  reason: ''
+  name: European Viral Outbreak Response Alliance Ontology
+  version: 1.2.0
+  nodecount: 789
+  edgecount: 1633
+  submission_id: '28'
+  source_bytes: 242514
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EVORAO.tar.gz
+- id: EVS
+  status: OK
+  reason: ''
+  name: Exposure Value Set
+  version: 0.0.6
+  nodecount: 81
+  edgecount: 213
+  submission_id: '6'
+  source_bytes: 23800
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EVS.tar.gz
+- id: EXACT
+  status: OK
+  reason: ''
+  name: An ontology for experimental actions
+  version: '2'
+  nodecount: 199
+  edgecount: 357
+  submission_id: '2'
+  source_bytes: 182206
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/EXACT.tar.gz
+- id: EXMO
+  status: OK
+  reason: ''
+  name: Exercise Medicine Ontology
+  version: '2025-06-05'
+  nodecount: 1732
+  edgecount: 3466
+  submission_id: '6'
+  source_bytes: 1667556
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXMO.tar.gz
+- id: EXO
+  status: OK
+  reason: ''
+  name: Exposure Ontology
+  version: '2025-08-29'
+  nodecount: 198
+  edgecount: 222
+  submission_id: '12'
+  source_bytes: 67331
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXO.tar.gz
+- id: EXON
+  status: OK
+  reason: ''
+  name: Experimental Ontology
+  version: NA
+  nodecount: 11
+  edgecount: 4
+  submission_id: '1'
+  source_bytes: 2405
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXON.tar.gz
+- id: EXTRACT
+  status: OK
+  reason: ''
+  name: EXTeRnAl Conditions Taxonomy (EXTRACT)
+  version: v0.1.0
+  nodecount: 38
+  edgecount: 62
+  submission_id: '2'
+  source_bytes: 5274
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXTRACT.tar.gz
+- id: FALDO
+  status: OK
+  reason: ''
+  name: 'Feature Annotation Location Description Ontology '
+  version: Created at the Biohackathon 2012 and 2013
+  nodecount: 40
+  edgecount: 46
+  submission_id: '18'
+  source_bytes: 25812
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FALDO.tar.gz
+- id: FALL
+  status: OK
+  reason: ''
+  name: MyOntoServiceFull_FallDetection
+  version: '1'
+  nodecount: 172
+  edgecount: 121
+  submission_id: '1'
+  source_bytes: 85706
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/FALL.tar.gz
+- id: FALLS
+  status: OK
+  reason: ''
+  name: 'falls prevention '
+  version: '0.1'
+  nodecount: 143
+  edgecount: 87
+  submission_id: '1'
+  source_bytes: 70365
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FALLS.tar.gz
+- id: FAO
+  status: OK
+  reason: ''
+  name: Fungal Gross Anatomy Ontology
+  version: NA
+  nodecount: 146
+  edgecount: 156
+  submission_id: '28'
+  source_bytes: 168301
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAO.tar.gz
+- id: FARMACI
+  status: Failed
+  reason: no_submission
+  name: FARMACI AIFA
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: FAST-CHRONO
+  status: OK
+  reason: ''
+  name: FAST (Faceted Access of Subject Terminology) Chronological Facet
+  version: NA
+  nodecount: 692
+  edgecount: 1354
+  submission_id: '1'
+  source_bytes: 632615
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAST-CHRONO.tar.gz
+- id: FAST-EVENT
+  status: OK
+  reason: ''
+  name: FAST (Faceted Application of Subject Terminology) Event
+  version: NA
+  nodecount: 37619
+  edgecount: 62123
+  submission_id: '1'
+  source_bytes: 20199323
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAST-EVENT.tar.gz
+- id: FAST-EVENT-SKOS
+  status: OK
+  reason: ''
+  name: FAST (Faceted Application of Subject Terminology) Event Facet
+  version: NA
+  nodecount: 37619
+  edgecount: 62123
+  submission_id: '1'
+  source_bytes: 20199323
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAST-EVENT-SKOS.tar.gz
+- id: FAST-FORMGENRE
+  status: OK
+  reason: ''
+  name: FAST (Faceted Application of Subject Terminology) FormGenre facet
+  version: NA
+  nodecount: 5703
+  edgecount: 11824
+  submission_id: '1'
+  source_bytes: 4186012
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAST-FORMGENRE.tar.gz
+- id: FAST-GENREFORM
+  status: OK
+  reason: ''
+  name: FAST (Faceted Access of Subject Terminology) GenreForm
+  version: NA
+  nodecount: 6066
+  edgecount: 16942
+  submission_id: '3'
+  source_bytes: 5004210
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAST-GENREFORM.tar.gz
+- id: FAST-TITLE
+  status: OK
+  reason: ''
+  name: FAST (Faceted Application of Subject Terminology) Title Facet
+  version: NA
+  nodecount: 192830
+  edgecount: 265158
+  submission_id: '1'
+  source_bytes: 100945658
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAST-TITLE.tar.gz
+- id: FASTO
+  status: Failed
+  reason: not_downloadable
+  name: HL7 FHIR and SSN ontology based Type 1 Diabetes Mellitus Ontology
+  version: '2015-11-20'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 0
+- id: FB-BT
+  status: OK
+  reason: ''
+  name: Drosophila Gross Anatomy Ontology
+  version: '2026-07-09'
+  nodecount: 28932
+  edgecount: 167970
+  submission_id: '92'
+  source_bytes: 38696075
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-BT.tar.gz
+- id: FB-CV
+  status: OK
+  reason: ''
+  name: FlyBase Controlled Vocabulary
+  version: '2026-07-10'
+  nodecount: 2467
+  edgecount: 5471
+  submission_id: '61'
+  source_bytes: 4294030
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-CV.tar.gz
+- id: FB-DV
+  status: OK
+  reason: ''
+  name: Drosophila Development Ontology
+  version: '2026-07-09'
+  nodecount: 271
+  edgecount: 731
+  submission_id: '70'
+  source_bytes: 118696
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-DV.tar.gz
+- id: FB-SP
+  status: OK
+  reason: ''
+  name: Fly Taxonomy
+  version: NA
+  nodecount: 6622
+  edgecount: 6619
+  submission_id: '8'
+  source_bytes: 838705
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-SP.tar.gz
+- id: FBbi
+  status: OK
+  reason: ''
+  name: Biological Imaging Methods Ontology
+  version: '2026-06-25'
+  nodecount: 896
+  edgecount: 1062
+  submission_id: '107'
+  source_bytes: 673967
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FBbi.tar.gz
+- id: FCC1
+  status: OK
+  reason: ''
+  name: Fernald Community Cohort N
+  version: '1.0'
+  nodecount: 113
+  edgecount: 237
+  submission_id: '1'
+  source_bytes: 55503
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FCC1.tar.gz
+- id: FDC-GDMT
+  status: OK
+  reason: ''
+  name: Ontology for Generic Dataset Metadata Template
+  version: v0.3.7
+  nodecount: 1576
+  edgecount: 3414
+  submission_id: '12'
+  source_bytes: 294575
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FDC-GDMT.tar.gz
+- id: FDSAJFAHSJK
+  status: OK
+  reason: ''
+  name: OWL_XML_Tool5
+  version: NA
+  nodecount: 7
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 890
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/FDSAJFAHSJK.tar.gz
+- id: FDT-O
+  status: OK
+  reason: ''
+  name: FAIR Data Train Ontology
+  version: '- Refactored FHIR API and FHIR Train as sub-classes of REST API and REST
+    Train, respectively.'
+  nodecount: 95
+  edgecount: 108
+  submission_id: '9'
+  source_bytes: 35749
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FDT-O.tar.gz
+- id: FENICS
+  status: OK
+  reason: ''
+  name: Functional Electrophysiology Nomenclature for Ion Channels
+  version: 0.0.5
+  nodecount: 227
+  edgecount: 237
+  submission_id: '9'
+  source_bytes: 197780
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FENICS.tar.gz
+- id: FG
+  status: OK
+  reason: ''
+  name: FAIR Genomes
+  version: 1.2-Minor
+  nodecount: 314
+  edgecount: 326
+  submission_id: '4'
+  source_bytes: 147774
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FG.tar.gz
+- id: FGNHNS
+  status: OK
+  reason: ''
+  name: FoodGroupNHNS
+  version: '0.300'
+  nodecount: 6525
+  edgecount: 10727
+  submission_id: '68'
+  source_bytes: 4039796
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FGNHNS.tar.gz
+- id: FHHO
+  status: OK
+  reason: ''
+  name: Family Health History Ontology
+  version: '1'
+  nodecount: 693
+  edgecount: 1001
+  submission_id: '1'
+  source_bytes: 422327
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/FHHO.tar.gz
+- id: FIDEO
+  status: OK
+  reason: ''
+  name: Food Interactions with Drugs Evidence Ontology
+  version: '2023-12-18'
+  nodecount: 3565
+  edgecount: 7649
+  submission_id: '8'
+  source_bytes: 3229407
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIDEO.tar.gz
+- id: FIRE
+  status: OK
+  reason: ''
+  name: Fire Ontology
+  version: '0.8'
+  nodecount: 95
+  edgecount: 106
+  submission_id: '7'
+  source_bytes: 49735
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIRE.tar.gz
+- id: FISH-AST
+  status: OK
+  reason: ''
+  name: FISH Archaeological Sciences Thesaurus
+  version: NA
+  nodecount: 148
+  edgecount: 758
+  submission_id: '1'
+  source_bytes: 139990
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FISH-AST.tar.gz
+- id: FISHO
+  status: OK
+  reason: ''
+  name: Fish Ontology
+  version: "Version 1.0.3 (Possible addition)\n\n-Considering to add more fish study\
+    \ related terms in the ontology such as fish immune sytem, and Fish Locomotion\
+    \ and Feeding Behavior.\n-Also focused on completing other classification of fish,\
+    \ and adding more relationships between the classes.\n\n\nVersion 1.0.2\n\n-Added\
+    \ a lot of annotations and metadata for fish terms, and added several more subclasses\
+    \ for the ontology. \n\n\nVersion 1.0.1\n\n-Change  the structure and the hierarchy\
+    \ of a lot of classes to follow the main references. Several classes are deleted\
+    \ and marked as \"deprecated\" or \"In Review\" in case they might be useful later.\n\
+    \n\nVersion 1.0.0\n\n-The first version of the fish ontology is created."
+  nodecount: 501
+  edgecount: 518
+  submission_id: '1'
+  source_bytes: 292773
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FISHO.tar.gz
+- id: FITBIT
+  status: Failed
+  reason: no_submission
+  name: Fitbit Vocabulary
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: FIT_BIT
+  status: OK
+  reason: ''
+  name: 'Fitbit Vocabularies '
+  version: NA
+  nodecount: 58
+  edgecount: 190
+  submission_id: '1'
+  source_bytes: 19278
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIT_BIT.tar.gz
+- id: FIX
+  status: OK
+  reason: ''
+  name: Physico-Chemical Methods and Properties
+  version: '1.2'
+  nodecount: 1179
+  edgecount: 1684
+  submission_id: '4'
+  source_bytes: 185632
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIX.tar.gz
+- id: FL8DSIP
+  status: OK
+  reason: ''
+  name: Fieldlab 8 - Ontology
+  version: NA
+  nodecount: 89
+  edgecount: 63
+  submission_id: '2'
+  source_bytes: 37693
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FL8DSIP.tar.gz
+- id: FLDLB3
+  status: OK
+  reason: ''
+  name: FIELDLAB3_2023_2
+  version: '3'
+  nodecount: 21
+  edgecount: 30
+  submission_id: '4'
+  source_bytes: 7818
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FLDLB3.tar.gz
+- id: FLOPO
+  status: OK
+  reason: ''
+  name: Flora Phenotype Ontology
+  version: '2026-07-31'
+  nodecount: 58680
+  edgecount: 69743
+  submission_id: '10'
+  source_bytes: 35076228
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/FLOPO.tar.gz
+- id: FLU
+  status: OK
+  reason: ''
+  name: Influenza Ontology
+  version: 0.9.0
+  nodecount: 272
+  edgecount: 215
+  submission_id: '27'
+  source_bytes: 127517
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/FLU.tar.gz
+- id: FLYGLYCODB
+  status: OK
+  reason: ''
+  name: FlyGlycoDB
+  version: 1.0.0
+  nodecount: 126
+  edgecount: 110
+  submission_id: '2'
+  source_bytes: 27663
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FLYGLYCODB.tar.gz
+- id: FMA
+  status: Skipped
+  reason: too_large
+  name: Foundational Model of Anatomy
+  version: 5.1.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '29'
+  source_bytes: 266165317
+- id: FMPM
+  status: OK
+  reason: ''
+  name: Food Matrix for Predictive Microbiology
+  version: 0.9.2
+  nodecount: 172
+  edgecount: 160
+  submission_id: '5'
+  source_bytes: 331944
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FMPM.tar.gz
+- id: FNS-H
+  status: OK
+  reason: ''
+  name: FNS-Harmony
+  version: '1.3'
+  nodecount: 11
+  edgecount: 7
+  submission_id: '2'
+  source_bytes: 3136
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FNS-H.tar.gz
+- id: FO
+  status: Failed
+  reason: not_downloadable
+  name: Fern Ontology
+  version: '0.05'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 0
+- id: FOAF
+  status: OK
+  reason: ''
+  name: Friend of a Friend Vocabulary
+  version: '0.99'
+  nodecount: 94
+  edgecount: 249
+  submission_id: '1'
+  source_bytes: 44209
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FOAF.tar.gz
+- id: FOBI
+  status: OK
+  reason: ''
+  name: FOBI (Food-Biomarker Ontology)
+  version: NA
+  nodecount: 1359
+  edgecount: 6815
+  submission_id: '3'
+  source_bytes: 2473019
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FOBI.tar.gz
+- id: FOODON
+  status: Failed
+  reason: transform_error
+  name: The FoodOn Food Ontology
+  version: '2025-12-30'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '110'
+  source_bytes: 40429965
+- id: FOUR-M_VOCABS
+  status: OK
+  reason: ''
+  name: AGE-FRIENDLY 4M VOCABULARY
+  version: '1'
+  nodecount: 397
+  edgecount: 392
+  submission_id: '1'
+  source_bytes: 161415
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FOUR-M_VOCABS.tar.gz
+- id: FOVT
+  status: Failed
+  reason: transform_error
+  name: FuTRES Ontology of Vertebrate Traits
+  version: '2026-03-19'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '8'
+  source_bytes: 43834846
+- id: FPLX
+  status: OK
+  reason: ''
+  name: FamPlex
+  version: '1.0'
+  nodecount: 718
+  edgecount: 675
+  submission_id: '38'
+  source_bytes: 267972
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FPLX.tar.gz
+- id: FRMO
+  status: Failed
+  reason: transform_error
+  name: 'Fall Risk Management Ontology '
+  version: '09.10'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '19'
+  source_bytes: 867041
+- id: FTC
+  status: OK
+  reason: ''
+  name: Functional Therapeutic Chemical Classification System
+  version: '1'
+  nodecount: 89178
+  edgecount: 169168
+  submission_id: '1'
+  source_bytes: 24161625
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FTC.tar.gz
+- id: FYPO
+  status: Failed
+  reason: transform_error
+  name: Fission Yeast Phenotype Ontology
+  version: '2026-07-02'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '512'
+  source_bytes: 45287817
+- id: G-PROV
+  status: Failed
+  reason: transform_error
+  name: Guideline Provenance
+  version: '1'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 37649
+- id: G4-DSIP
+  status: OK
+  reason: ''
+  name: Group 4-Data Science in Practice
+  version: 1.0.0
+  nodecount: 47
+  edgecount: 91
+  submission_id: '6'
+  source_bytes: 11266
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/G4-DSIP.tar.gz
+- id: GALEN
+  status: OK
+  reason: ''
+  name: Galen Ontology
+  version: '1.1'
+  nodecount: 28814
+  edgecount: 48595
+  submission_id: '1'
+  source_bytes: 21090844
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GALEN.tar.gz
+- id: GALLONT
+  status: OK
+  reason: ''
+  name: Plant Gall Ontology
+  version: '2024-04-19'
+  nodecount: 861
+  edgecount: 1776
+  submission_id: '1'
+  source_bytes: 1072074
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GALLONT.tar.gz
+- id: GAMUTS
+  status: OK
+  reason: ''
+  name: Radiology Gamuts Ontology
+  version: '2.0'
+  nodecount: 16888
+  edgecount: 126163
+  submission_id: '25'
+  source_bytes: 31649869
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GAMUTS.tar.gz
+- id: GAZ
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: GB
+  status: OK
+  reason: ''
+  name: GlycanBind
+  version: 1.1.1
+  nodecount: 122
+  edgecount: 127
+  submission_id: '3'
+  source_bytes: 36430
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GB.tar.gz
+- id: GBM
+  status: OK
+  reason: ''
+  name: Glioblastoma
+  version: NA
+  nodecount: 154
+  edgecount: 295
+  submission_id: '1'
+  source_bytes: 78247
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GBM.tar.gz
+- id: GBOL
+  status: OK
+  reason: ''
+  name: GBOL
+  version: '1'
+  nodecount: 1899
+  edgecount: 1890
+  submission_id: '2'
+  source_bytes: 1059033
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GBOL.tar.gz
+- id: GCBO
+  status: OK
+  reason: ''
+  name: Global Code Book Ontology
+  version: NA
+  nodecount: 1486
+  edgecount: 4602
+  submission_id: '6'
+  source_bytes: 1135840
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GCBO.tar.gz
+- id: GCDFO
+  status: OK
+  reason: ''
+  name: DFO Salmon Ontology
+  version: 0.0.8
+  nodecount: 376
+  edgecount: 1422
+  submission_id: '3'
+  source_bytes: 183993
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GCDFO.tar.gz
+- id: GCO
+  status: OK
+  reason: ''
+  name: Genome Component Ontology
+  version: '0.2'
+  nodecount: 13
+  edgecount: 9
+  submission_id: '4'
+  source_bytes: 4511
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GCO.tar.gz
+- id: GDCO
+  status: OK
+  reason: ''
+  name: Data Collection Ontology
+  version: '1.0'
+  nodecount: 145
+  edgecount: 194
+  submission_id: '1'
+  source_bytes: 134464
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GDCO.tar.gz
+- id: GDMT
+  status: OK
+  reason: ''
+  name: Generic Dataset Metadata Template Vocabulary
+  version: 1.1.0-alpha
+  nodecount: 2571
+  edgecount: 7373
+  submission_id: '5'
+  source_bytes: 471853
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GDMT.tar.gz
+- id: GDOA
+  status: OK
+  reason: ''
+  name: Graphic Descriptor Ontology Anatomy Extension
+  version: 1.1.4
+  nodecount: 404
+  edgecount: 344
+  submission_id: '10'
+  source_bytes: 269990
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GDOA.tar.gz
+- id: GECCO
+  status: Failed
+  reason: not_downloadable
+  name: COVID-19 Common Datamodel
+  version: 1.0.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: GECKO
+  status: OK
+  reason: ''
+  name: Genomics Cohorts Knowledge Ontology
+  version: NA
+  nodecount: 176
+  edgecount: 155
+  submission_id: '11'
+  source_bytes: 160220
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GECKO.tar.gz
+- id: GENAI
+  status: OK
+  reason: ''
+  name: Generative AI Ontology
+  version: '1.0'
+  nodecount: 68
+  edgecount: 35
+  submission_id: '1'
+  source_bytes: 12142
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENAI.tar.gz
+- id: GENDER
+  status: OK
+  reason: ''
+  name: Gender Identity
+  version: NA
+  nodecount: 24
+  edgecount: 19
+  submission_id: '1'
+  source_bytes: 2523
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENDER.tar.gz
+- id: GENE-CDS
+  status: Failed
+  reason: transform_error
+  name: Genomic Clinical Decision Support Ontology
+  version: 0.8.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 620645
+- id: GENEPIO
+  status: OK
+  reason: ''
+  name: 'Genomic Epidemiology Application Ontology '
+  version: '2026-04-13'
+  nodecount: 10962
+  edgecount: 23079
+  submission_id: '3'
+  source_bytes: 7909993
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENEPIO.tar.gz
+- id: GENEVIEVE
+  status: Failed
+  reason: no_submission
+  name: Charlotte
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: GENO
+  status: OK
+  reason: ''
+  name: Genotype Ontology
+  version: '2026-02-02'
+  nodecount: 1352
+  edgecount: 1942
+  submission_id: '33'
+  source_bytes: 1367462
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENO.tar.gz
+- id: GEO
+  status: OK
+  reason: ''
+  name: Geographical Entity Ontology
+  version: production version 2018-02-23
+  nodecount: 3
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 7770
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/GEO.tar.gz
+- id: GEOSPARQL
+  status: OK
+  reason: ''
+  name: GeoSPARQL
+  version: OGC GeoSPARQL 1.0
+  nodecount: 55
+  edgecount: 156
+  submission_id: '1'
+  source_bytes: 46372
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/GEOSPARQL.tar.gz
+- id: GEOSPECIES
+  status: Failed
+  reason: transform_error
+  name: GeoSpecies Ontology
+  version: '2012-10-02'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 244650
+- id: GERO
+  status: OK
+  reason: ''
+  name: Gerotranscendence Ontology
+  version: '2026-02-25'
+  nodecount: 165
+  edgecount: 357
+  submission_id: '2'
+  source_bytes: 167054
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GERO.tar.gz
+- id: GEXO
+  status: Skipped
+  reason: too_large
+  name: Gene Expression Ontology
+  version: '2015'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 133201182
+- id: GFF-M4M
+  status: OK
+  reason: ''
+  name: GO FAIR M4M
+  version: 0.0.5
+  nodecount: 493
+  edgecount: 1292
+  submission_id: '42'
+  source_bytes: 89317
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GFF-M4M.tar.gz
+- id: GFFO
+  status: OK
+  reason: ''
+  name: Genetic Feature Format Ontology
+  version: 0.0.1
+  nodecount: 65
+  edgecount: 13
+  submission_id: '1'
+  source_bytes: 25991
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GFFO.tar.gz
+- id: GFO
+  status: OK
+  reason: ''
+  name: General Formal Ontology
+  version: 'Version 1.0 ($Revision: 1.13 $)'
+  nodecount: 90
+  edgecount: 168
+  submission_id: '1'
+  source_bytes: 62747
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GFO.tar.gz
+- id: GFO-BIO
+  status: OK
+  reason: ''
+  name: General Formal Ontology for Biology
+  version: '1.1'
+  nodecount: 245
+  edgecount: 135
+  submission_id: '1'
+  source_bytes: 36474
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GFO-BIO.tar.gz
+- id: GFVO
+  status: OK
+  reason: ''
+  name: Genomic Feature and Variation Ontology
+  version: 1.0.6
+  nodecount: 156
+  edgecount: 387
+  submission_id: '20'
+  source_bytes: 146583
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GFVO.tar.gz
+- id: GLYCO
+  status: OK
+  reason: ''
+  name: Glycomics Ontology
+  version: 4.6.0.0
+  nodecount: 2092
+  edgecount: 483
+  submission_id: '1'
+  source_bytes: 4431815
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/GLYCO.tar.gz
+- id: GLYCOCOO
+  status: OK
+  reason: ''
+  name: GlycoConjugate Ontology
+  version: 1.1.3
+  nodecount: 94
+  edgecount: 94
+  submission_id: '2'
+  source_bytes: 29233
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GLYCOCOO.tar.gz
+- id: GLYCORDF
+  status: OK
+  reason: ''
+  name: GlycoRDF
+  version: 1.2.1
+  nodecount: 605
+  edgecount: 514
+  submission_id: '61'
+  source_bytes: 389060
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GLYCORDF.tar.gz
+- id: GML
+  status: OK
+  reason: ''
+  name: Ontology for Geography Markup Language (GML3.0)
+  version: version 1.0
+  nodecount: 333
+  edgecount: 407
+  submission_id: '1'
+  source_bytes: 137224
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/GML.tar.gz
+- id: GMM
+  status: OK
+  reason: ''
+  name: GoMapMan
+  version: '1.2'
+  nodecount: 1902
+  edgecount: 1895
+  submission_id: '25'
+  source_bytes: 279577
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GMM.tar.gz
+- id: GMO
+  status: OK
+  reason: ''
+  name: Growth Medium Ontology
+  version: 0.24 Beta
+  nodecount: 4539
+  edgecount: 9332
+  submission_id: '9'
+  source_bytes: 629118
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GMO.tar.gz
+- id: GNO
+  status: Skipped
+  reason: too_large
+  name: Glycan Naming Ontology
+  version: V2.7.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '21'
+  source_bytes: 216258008
+- id: GO
+  status: OK
+  reason: ''
+  name: Gene Ontology
+  version: '2026-06-15'
+  nodecount: 66332
+  edgecount: 114015
+  submission_id: '1835'
+  source_bytes: 36693085
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GO.tar.gz
+- id: GO-EXT
+  status: OK
+  reason: ''
+  name: Gene Ontology Extension
+  version: '2'
+  nodecount: 35917
+  edgecount: 82709
+  submission_id: '2'
+  source_bytes: 21472563
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GO-EXT.tar.gz
+- id: GO-PLUS
+  status: Skipped
+  reason: too_large
+  name: go-plus
+  version: '2026-06-15'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '710'
+  source_bytes: 237491319
+- id: GOLDTERMS
+  status: OK
+  reason: ''
+  name: GOLD Ecosystem Classification
+  version: NA
+  nodecount: 2428
+  edgecount: 11199
+  submission_id: '7'
+  source_bytes: 4602231
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GOLDTERMS.tar.gz
+- id: GPML
+  status: OK
+  reason: ''
+  name: Graphical Pathway Markup Language
+  version: 2013a
+  nodecount: 103
+  edgecount: 340
+  submission_id: '344'
+  source_bytes: 59839
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GPML.tar.gz
+- id: GRO
+  status: OK
+  reason: ''
+  name: Gene Regulation Ontology
+  version: '0.5'
+  nodecount: 550
+  edgecount: 984
+  submission_id: '5'
+  source_bytes: 428840
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GRO.tar.gz
+- id: GRO-CPD
+  status: OK
+  reason: ''
+  name: Cereal Plant Development Ontology
+  version: '1.6'
+  nodecount: 258
+  edgecount: 241
+  submission_id: '1'
+  source_bytes: 73156
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GRO-CPD.tar.gz
+- id: GRO-CPGA
+  status: OK
+  reason: ''
+  name: Cereal Plant Gross Anatomy Ontology
+  version: unknown
+  nodecount: 1606
+  edgecount: 3628
+  submission_id: '11'
+  source_bytes: 924184
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GRO-CPGA.tar.gz
+- id: GS1WEBVOC
+  status: OK
+  reason: ''
+  name: GS1 Web Vocabulary
+  version: '1.18'
+  nodecount: 6470
+  edgecount: 6014
+  submission_id: '1'
+  source_bytes: 1270763
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GS1WEBVOC.tar.gz
+- id: GSSO
+  status: Failed
+  reason: transform_error
+  name: Gender, Sex, and Sexual Orientation Ontology
+  version: 2.0.6
+  nodecount: 0
+  edgecount: 0
+  submission_id: '75'
+  source_bytes: 11791249
+- id: GVO
+  status: OK
+  reason: ''
+  name: Genome Variation Ontology
+  version: '2021-11-18'
+  nodecount: 260
+  edgecount: 357
+  submission_id: '3'
+  source_bytes: 11815
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GVO.tar.gz
+- id: HAAURAADO
+  status: OK
+  reason: ''
+  name: Halocynthia aurantium Anatomy and Development Ontology
+  version: NA
+  nodecount: 875
+  edgecount: 4617
+  submission_id: '2'
+  source_bytes: 343996
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HAAURAADO.tar.gz
+- id: HAMIDEHSGH
+  status: OK
+  reason: ''
+  name: Inherited Retinal Dystrophy
+  version: NA
+  nodecount: 417
+  edgecount: 404
+  submission_id: '1'
+  source_bytes: 766205
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HAMIDEHSGH.tar.gz
+- id: HANCESTRO
+  status: Failed
+  reason: transform_error
+  name: Human Ancestry Ontology
+  version: '2025-10-14'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '21'
+  source_bytes: 2142942
+- id: HAO
+  status: OK
+  reason: ''
+  name: Hymenoptera Anatomy Ontology
+  version: '2023-06-01'
+  nodecount: 5384
+  edgecount: 4952
+  submission_id: '27'
+  source_bytes: 7007288
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HAO.tar.gz
+- id: HAROREADO
+  status: OK
+  reason: ''
+  name: Halocynthia roretzi Anatomy and Development Ontology
+  version: NA
+  nodecount: 875
+  edgecount: 4617
+  submission_id: '2'
+  source_bytes: 343962
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HAROREADO.tar.gz
+- id: HASCO
+  status: Failed
+  reason: transform_error
+  name: Human-Aware Science Ontology
+  version: '0.9'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '8'
+  source_bytes: 54645
+- id: HC
+  status: Failed
+  reason: no_submission
+  name: Habronattus Courtship Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: HCDR
+  status: OK
+  reason: ''
+  name: Homelessness and Clinical Data Recording
+  version: '1'
+  nodecount: 126
+  edgecount: 114
+  submission_id: '1'
+  source_bytes: 68615
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HCDR.tar.gz
+- id: HCMO
+  status: Failed
+  reason: not_downloadable
+  name: Home Cage Monitoring Ontology
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 0
+- id: HCODONONT
+  status: OK
+  reason: ''
+  name: HGeneCodonOntology
+  version: '2'
+  nodecount: 101
+  edgecount: 159
+  submission_id: '4'
+  source_bytes: 75567
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/HCODONONT.tar.gz
+- id: HCPCS
+  status: OK
+  reason: ''
+  name: Healthcare Common Procedure Coding System
+  version: '2025_04'
+  nodecount: 8078
+  edgecount: 8051
+  submission_id: '26'
+  source_bytes: 11157689
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HCPCS.tar.gz
+- id: HDMPONTO
+  status: OK
+  reason: ''
+  name: HierarchicalDMProcessOnto
+  version: NA
+  nodecount: 481
+  edgecount: 531
+  submission_id: '1'
+  source_bytes: 718805
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HDMPONTO.tar.gz
+- id: HDS
+  status: OK
+  reason: ''
+  name: Humanitarian Data Space
+  version: NA
+  nodecount: 68
+  edgecount: 53
+  submission_id: '1'
+  source_bytes: 9557
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HDS.tar.gz
+- id: HECON
+  status: OK
+  reason: ''
+  name: 'HECON: Health Condition Evolution Ontology'
+  version: '0.1'
+  nodecount: 70
+  edgecount: 42
+  submission_id: '1'
+  source_bytes: 33135
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HECON.tar.gz
+- id: HED
+  status: OK
+  reason: ''
+  name: Hierarchical Event Descriptors
+  version: releases/2024-06-10
+  nodecount: 1453
+  edgecount: 1891
+  submission_id: '1'
+  source_bytes: 925369
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HED.tar.gz
+- id: HEIO
+  status: OK
+  reason: ''
+  name: Regional Healthcare System Interoperability and Information Exchange Measurement
+    Ontology
+  version: Version 1.15
+  nodecount: 1811
+  edgecount: 281
+  submission_id: '17'
+  source_bytes: 2770499
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HEIO.tar.gz
+- id: HELIFIT
+  status: Failed
+  reason: transform_error
+  name: HeLiFit-Ontology
+  version: 1.6.4
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 207862
+- id: HENECON
+  status: OK
+  reason: ''
+  name: Head and Neck Cancer Ontology
+  version: '2.0'
+  nodecount: 2052
+  edgecount: 1861
+  submission_id: '1'
+  source_bytes: 1445677
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/HENECON.tar.gz
+- id: HENEGEO
+  status: OK
+  reason: ''
+  name: Head and Neck Cancer - Clinical and Gene Ontology
+  version: '1.0'
+  nodecount: 30010
+  edgecount: 29969
+  submission_id: '1'
+  source_bytes: 26510908
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HENEGEO.tar.gz
+- id: HERO
+  status: Failed
+  reason: not_downloadable
+  name: Healthcare Monitoring and Emergency Response Ontology
+  version: FHIR W5 categorization (Preliminary)
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: HFO
+  status: OK
+  reason: ''
+  name: Heart Failure Ontology
+  version: version 1.0
+  nodecount: 1655
+  edgecount: 2064
+  submission_id: '1'
+  source_bytes: 707183
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HFO.tar.gz
+- id: HGNC
+  status: Skipped
+  reason: too_large
+  name: HUGO Gene Nomenclature
+  version: dev
+  nodecount: 0
+  edgecount: 0
+  submission_id: '9'
+  source_bytes: 170853867
+- id: HGNC-NR
+  status: Failed
+  reason: transform_error
+  name: HGNC New Releases Ontology
+  version: '2026-05-11'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '13'
+  source_bytes: 7782656
+- id: HHEAR
+  status: OK
+  reason: ''
+  name: Human Health Exposure Analysis Resource
+  version: 1.13.1
+  nodecount: 4473
+  edgecount: 5670
+  submission_id: '20'
+  source_bytes: 3060531
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HHEAR.tar.gz
+- id: HHEARP
+  status: OK
+  reason: ''
+  name: HHEAR Properties
+  version: 0.0.4
+  nodecount: 52
+  edgecount: 58
+  submission_id: '4'
+  source_bytes: 20433
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/HHEARP.tar.gz
+- id: HHEARVS
+  status: OK
+  reason: ''
+  name: HHEAR Value Sets
+  version: '1.2'
+  nodecount: 10446
+  edgecount: 10425
+  submission_id: '15'
+  source_bytes: 3773599
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/HHEARVS.tar.gz
+- id: HIFM
+  status: OK
+  reason: ''
+  name: HIFM Ontology
+  version: '1.1'
+  nodecount: 29
+  edgecount: 22
+  submission_id: '1'
+  source_bytes: 3452
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HIFM.tar.gz
+- id: HINO
+  status: OK
+  reason: ''
+  name: Human Interaction Network Ontology
+  version: 'Vision Release: 1.0.69'
+  nodecount: 36258
+  edgecount: 133295
+  submission_id: '6'
+  source_bytes: 49899542
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HINO.tar.gz
+- id: HIO
+  status: OK
+  reason: ''
+  name: Hearing Impairment Ontology
+  version: '1'
+  nodecount: 959
+  edgecount: 1096
+  submission_id: '3'
+  source_bytes: 531193
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HIO.tar.gz
+- id: HIV
+  status: Failed
+  reason: not_downloadable
+  name: HIV ontology
+  version: '2.6'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '10'
+  source_bytes: 0
+- id: HIVCRS
+  status: OK
+  reason: ''
+  name: HIVCompoundRels
+  version: '1'
+  nodecount: 12
+  edgecount: 8
+  submission_id: '1'
+  source_bytes: 5746
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/HIVCRS.tar.gz
+- id: HIVHPV
+  status: Failed
+  reason: no_submission
+  name: HIVHPV
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: HIVHPVFGS
+  status: OK
+  reason: ''
+  name: HIV, HPV, FGS vocabulary
+  version: NA
+  nodecount: 27
+  edgecount: 30
+  submission_id: '2'
+  source_bytes: 4551
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HIVHPVFGS.tar.gz
+- id: HIVHPVSCHISTOSOM
+  status: OK
+  reason: ''
+  name: HIVHPVSchistosomiasis
+  version: '1.1'
+  nodecount: 36
+  edgecount: 28
+  submission_id: '2'
+  source_bytes: 7695
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HIVHPVSCHISTOSOM.tar.gz
+- id: HIVHPVSTOM
+  status: Failed
+  reason: not_downloadable
+  name: HIVHPVStom
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: HIVMT
+  status: OK
+  reason: ''
+  name: HIVMutation
+  version: '01'
+  nodecount: 198
+  edgecount: 321
+  submission_id: '6'
+  source_bytes: 226939
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/HIVMT.tar.gz
+- id: HIVO004
+  status: OK
+  reason: ''
+  name: HIVOntologymain.owl
+  version: '020'
+  nodecount: 2504
+  edgecount: 2880
+  submission_id: '29'
+  source_bytes: 1256125
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HIVO004.tar.gz
+- id: HL7
+  status: OK
+  reason: ''
+  name: Health Level Seven Reference Implementation Model, Version 3.0
+  version: '2025_07'
+  nodecount: 9172
+  edgecount: 9073
+  submission_id: '27'
+  source_bytes: 10006671
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HL7.tar.gz
+- id: HMADO
+  status: Failed
+  reason: not_downloadable
+  name: 'Human Microbiome Associated Disease Ontology '
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: HMIS033B
+  status: OK
+  reason: ''
+  name: HMIS 033
+  version: NA
+  nodecount: 78
+  edgecount: 2
+  submission_id: '1'
+  source_bytes: 15811
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HMIS033B.tar.gz
+- id: HMISLAB0115
+  status: OK
+  reason: ''
+  name: HMIS LAB 011 5
+  version: NA
+  nodecount: 36
+  edgecount: 63
+  submission_id: '1'
+  source_bytes: 7917
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HMISLAB0115.tar.gz
+- id: HNS
+  status: OK
+  reason: ''
+  name: HNS_Ontolgoy
+  version: '4.0'
+  nodecount: 712
+  edgecount: 595
+  submission_id: '1'
+  source_bytes: 255339
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HNS.tar.gz
+- id: HO
+  status: OK
+  reason: ''
+  name: Histological Ontology
+  version: '1.1'
+  nodecount: 62
+  edgecount: 42
+  submission_id: '78'
+  source_bytes: 13459
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HO.tar.gz
+- id: HOIP
+  status: OK
+  reason: ''
+  name: Homeostasis imbalance process ontology
+  version: 2024/04/03
+  nodecount: 15678
+  edgecount: 43323
+  submission_id: '65'
+  source_bytes: 31381830
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HOIP.tar.gz
+- id: HOM
+  status: OK
+  reason: ''
+  name: Ontology of Homology and Related Concepts in Biology
+  version: releases/2015-01-07
+  nodecount: 86
+  edgecount: 84
+  submission_id: '7'
+  source_bytes: 128032
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HOM.tar.gz
+- id: HOME
+  status: OK
+  reason: ''
+  name: Health Ontology for Minority Equity
+  version: '1'
+  nodecount: 83
+  edgecount: 123
+  submission_id: '1'
+  source_bytes: 53228
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HOME.tar.gz
+- id: HOOM
+  status: Skipped
+  reason: too_large
+  name: HPO - ORDO Ontological Module
+  version: '2.6'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '14'
+  source_bytes: 206953793
+- id: HOOM_V3
+  status: OK
+  reason: ''
+  name: HOOM_New_Model
+  version: '3.0'
+  nodecount: 4373
+  edgecount: 15
+  submission_id: '1'
+  source_bytes: 35411157
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HOOM_V3.tar.gz
+- id: HORD
+  status: OK
+  reason: ''
+  name: Holistic Ontology of Rare Diseases
+  version: '4.0'
+  nodecount: 115
+  edgecount: 63
+  submission_id: '4'
+  source_bytes: 53710
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HORD.tar.gz
+- id: HOSP
+  status: OK
+  reason: ''
+  name: Hospital Vocabulary
+  version: v2015-09-30
+  nodecount: 32
+  edgecount: 30
+  submission_id: '1'
+  source_bytes: 9284
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HOSP.tar.gz
+- id: HP
+  status: OK
+  reason: ''
+  name: Human Phenotype Ontology
+  version: '2026-06-23'
+  nodecount: 25358
+  edgecount: 52509
+  submission_id: '627'
+  source_bytes: 11222341
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HP.tar.gz
+- id: HPIO
+  status: OK
+  reason: ''
+  name: Host Pathogen Interactions Ontology
+  version: '1'
+  nodecount: 260
+  edgecount: 244
+  submission_id: '2'
+  source_bytes: 198883
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/HPIO.tar.gz
+- id: HPO
+  status: OK
+  reason: ''
+  name: Hypertension-Ontology
+  version: NA
+  nodecount: 283
+  edgecount: 407
+  submission_id: '1'
+  source_bytes: 233746
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HPO.tar.gz
+- id: HP_O
+  status: OK
+  reason: ''
+  name: Hypersensitivity pneumonitis ontology
+  version: '1.0'
+  nodecount: 208
+  edgecount: 305
+  submission_id: '1'
+  source_bytes: 165014
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HP_O.tar.gz
+- id: HRA
+  status: Skipped
+  reason: too_large
+  name: Human Reference Atlas
+  version: v2.3
+  nodecount: 0
+  edgecount: 0
+  submission_id: '12'
+  source_bytes: 104987415
+- id: HRAVS
+  status: OK
+  reason: ''
+  name: HuBMAP Research Attributes Value Set
+  version: NA
+  nodecount: 969
+  edgecount: 2596
+  submission_id: '195'
+  source_bytes: 402852
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HRAVS.tar.gz
+- id: HRDO
+  status: OK
+  reason: ''
+  name: Disease core ontology applied to Rare Diseases
+  version: V2
+  nodecount: 13964
+  edgecount: 85030
+  submission_id: '2'
+  source_bytes: 42436202
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HRDO.tar.gz
+- id: HSAPDV
+  status: OK
+  reason: ''
+  name: Human Developmental Stages Ontology
+  version: '2025-01-23'
+  nodecount: 368
+  edgecount: 975
+  submission_id: '181'
+  source_bytes: 528600
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HSAPDV.tar.gz
+- id: HSCLO38
+  status: Failed
+  reason: not_downloadable
+  name: Homo sapiens Chromosomal Location Ontology for GRCh38
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 0
+- id: HSO
+  status: OK
+  reason: ''
+  name: Health Surveillance Ontology
+  version: 3.1.1
+  nodecount: 1283
+  edgecount: 2042
+  submission_id: '10'
+  source_bytes: 1360745
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HSO.tar.gz
+- id: HSPO
+  status: OK
+  reason: ''
+  name: Health and Social Person-centric Ontology
+  version: 0.1.0
+  nodecount: 324
+  edgecount: 285
+  submission_id: '3'
+  source_bytes: 125327
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HSPO.tar.gz
+- id: HTN
+  status: OK
+  reason: ''
+  name: Hypertension Ontology
+  version: NA
+  nodecount: 1130
+  edgecount: 1963
+  submission_id: '1'
+  source_bytes: 1322067
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HTN.tar.gz
+- id: HTNCO
+  status: OK
+  reason: ''
+  name: Hypertension Clinical Ontology
+  version: NA
+  nodecount: 181
+  edgecount: 203
+  submission_id: '1'
+  source_bytes: 120142
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HTNCO.tar.gz
+- id: HTO
+  status: Failed
+  reason: no_submission
+  name: Horridge Test Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: HUPSON
+  status: OK
+  reason: ''
+  name: Human Physiology Simulation Ontology
+  version: 1.1.1
+  nodecount: 3173
+  edgecount: 3901
+  submission_id: '1'
+  source_bytes: 3250724
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HUPSON.tar.gz
+- id: HW
+  status: OK
+  reason: ''
+  name: wsm
+  version: NA
+  nodecount: 147
+  edgecount: 38
+  submission_id: '2'
+  source_bytes: 86199
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HW.tar.gz
+- id: I-ADOPT
+  status: OK
+  reason: ''
+  name: I-ADOPT Framework Ontology
+  version: 1.1.0
+  nodecount: 51
+  edgecount: 48
+  submission_id: '6'
+  source_bytes: 16059
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/I-ADOPT.tar.gz
+- id: I2SV
+  status: OK
+  reason: ''
+  name: Integration and Implementation Sciences Vocabulary
+  version: 1.0.0
+  nodecount: 203
+  edgecount: 558
+  submission_id: '5'
+  source_bytes: 138131
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/I2SV.tar.gz
+- id: IAML-MOP
+  status: OK
+  reason: ''
+  name: IAML Medium of Performance Vocabulary
+  version: NA
+  nodecount: 834
+  edgecount: 1236
+  submission_id: '2'
+  source_bytes: 272186
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IAML-MOP.tar.gz
+- id: IAO
+  status: OK
+  reason: ''
+  name: Information Artifact Ontology
+  version: '2026-03-30'
+  nodecount: 505
+  edgecount: 878
+  submission_id: '11'
+  source_bytes: 609839
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IAO.tar.gz
+- id: IBD
+  status: OK
+  reason: ''
+  name: Indian Biodiversity Ontology
+  version: '1.1'
+  nodecount: 386
+  edgecount: 409
+  submission_id: '1'
+  source_bytes: 197765
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IBD.tar.gz
+- id: IBIO
+  status: OK
+  reason: ''
+  name: IndianBiodiversity
+  version: NA
+  nodecount: 386
+  edgecount: 409
+  submission_id: '1'
+  source_bytes: 197765
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IBIO.tar.gz
+- id: IBO
+  status: OK
+  reason: ''
+  name: Imaging Biomarker Ontology
+  version: NA
+  nodecount: 848
+  edgecount: 963
+  submission_id: '2'
+  source_bytes: 599364
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/IBO.tar.gz
+- id: ICD-O-3
+  status: OK
+  reason: ''
+  name: International Classification of Diseases for Oncology, 3rd edition
+  version: OCD-O Revision 3.2 (complete)
+  nodecount: 4667
+  edgecount: 4480
+  submission_id: '5'
+  source_bytes: 2131803
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICD-O-3.tar.gz
+- id: ICD10
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: ICD10CM
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: ICD10PCS
+  status: OK
+  reason: ''
+  name: International Classification of Diseases, Version 10 - Procedure Coding System
+  version: '2026'
+  nodecount: 192696
+  edgecount: 192686
+  submission_id: '27'
+  source_bytes: 104600528
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICD10PCS.tar.gz
+- id: ICD9CM
+  status: OK
+  reason: ''
+  name: International Classification of Diseases, Version 9 - Clinical Modification
+  version: ICD9CM_2014
+  nodecount: 22545
+  edgecount: 22532
+  submission_id: '26'
+  source_bytes: 10513539
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICD9CM.tar.gz
+- id: ICDO
+  status: OK
+  reason: ''
+  name: International Classification of Diseases Ontology
+  version: 1.0.83
+  nodecount: 2023
+  edgecount: 3594
+  submission_id: '13'
+  source_bytes: 1994009
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICDO.tar.gz
+- id: ICECI
+  status: OK
+  reason: ''
+  name: International Classification of  External Causes of Injuries
+  version: 'Original Source: 1.2; OWL version 1.02'
+  nodecount: 2241
+  edgecount: 2236
+  submission_id: '6'
+  source_bytes: 1651565
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICECI.tar.gz
+- id: ICEO
+  status: Failed
+  reason: transform_error
+  name: Integrative and Conjugative Element Ontology
+  version: '2.1'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '31'
+  source_bytes: 37320151
+- id: ICF
+  status: OK
+  reason: ''
+  name: International Classification of Functioning, Disability and Health
+  version: 1.0.2
+  nodecount: 4916
+  edgecount: 1963
+  submission_id: '3'
+  source_bytes: 2893424
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICF.tar.gz
+- id: ICHOM-PROMS-PCB
+  status: OK
+  reason: ''
+  name: ICHOM Set Pregnancy and Childbirth
+  version: NA
+  nodecount: 119
+  edgecount: 315
+  submission_id: '3'
+  source_bytes: 97838
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICHOM-PROMS-PCB.tar.gz
+- id: ICNP
+  status: Failed
+  reason: not_downloadable
+  name: International Classification for Nursing Practice
+  version: classified
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 0
+- id: ICO
+  status: OK
+  reason: ''
+  name: Informed Consent Ontology
+  version: '2026-02-28'
+  nodecount: 1589
+  edgecount: 3300
+  submission_id: '19'
+  source_bytes: 1819741
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICO.tar.gz
+- id: ICOP
+  status: OK
+  reason: ''
+  name: International Classification of Orofacial Pain Ontology
+  version: '2026-04-03'
+  nodecount: 712
+  edgecount: 2253
+  submission_id: '1'
+  source_bytes: 1106754
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICOP.tar.gz
+- id: ICPC2P
+  status: Failed
+  reason: not_downloadable
+  name: International Classification of Primary Care - 2 PLUS
+  version: ICPC2P_2005
+  nodecount: 0
+  edgecount: 0
+  submission_id: '24'
+  source_bytes: 0
+- id: ICPS
+  status: Failed
+  reason: transform_error
+  name: International Classification for Patient Safety
+  version: Created by Aldo Gangemi and Valentina Presutti
+  nodecount: 0
+  edgecount: 0
+  submission_id: '7'
+  source_bytes: 84425
+- id: ICW
+  status: OK
+  reason: ''
+  name: International Classification of Wellness
+  version: '1.3'
+  nodecount: 115
+  edgecount: 103
+  submission_id: '5'
+  source_bytes: 118360
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICW.tar.gz
+- id: ID-AMR
+  status: OK
+  reason: ''
+  name: Infectious Diseases and Antimicrobial Resistance
+  version: 1.2.1
+  nodecount: 343
+  edgecount: 901
+  submission_id: '35'
+  source_bytes: 52947
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ID-AMR.tar.gz
+- id: IDEM
+  status: OK
+  reason: ''
+  name: 'IDEM: wInD Energy Models Taxonomy'
+  version: v0.1.0
+  nodecount: 54
+  edgecount: 115
+  submission_id: '2'
+  source_bytes: 7852
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDEM.tar.gz
+- id: IDG_GL
+  status: OK
+  reason: ''
+  name: IDG gene list
+  version: '1.0'
+  nodecount: 423
+  edgecount: 419
+  submission_id: '5'
+  source_bytes: 126758
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDG_GL.tar.gz
+- id: IDO
+  status: OK
+  reason: ''
+  name: Infectious Disease Ontology
+  version: 8-3-20
+  nodecount: 538
+  edgecount: 835
+  submission_id: '13'
+  source_bytes: 389650
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDO.tar.gz
+- id: IDO-COVID-19
+  status: OK
+  reason: ''
+  name: The COVID-19 Infectious Disease Ontology
+  version: 8-3-2020
+  nodecount: 676
+  edgecount: 1028
+  submission_id: '2'
+  source_bytes: 465687
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDO-COVID-19.tar.gz
+- id: IDOBRU
+  status: OK
+  reason: ''
+  name: Brucellosis Ontology
+  version: Arbor version; 1.2.92
+  nodecount: 3941
+  edgecount: 6731
+  submission_id: '61'
+  source_bytes: 4878624
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDOBRU.tar.gz
+- id: IDODEN
+  status: OK
+  reason: ''
+  name: Dengue Fever Ontology
+  version: 0.15b
+  nodecount: 5109
+  edgecount: 5904
+  submission_id: '6'
+  source_bytes: 3017656
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/IDODEN.tar.gz
+- id: IDOMAL
+  status: OK
+  reason: ''
+  name: Malaria Ontology
+  version: 1.3.9
+  nodecount: 3203
+  edgecount: 4505
+  submission_id: '186'
+  source_bytes: 858001
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDOMAL.tar.gz
+- id: IDQA
+  status: OK
+  reason: ''
+  name: Image and Data Quality Assessment Ontology
+  version: v50
+  nodecount: 283
+  edgecount: 275
+  submission_id: '8'
+  source_bytes: 43442
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDQA.tar.gz
+- id: IFAR
+  status: OK
+  reason: ''
+  name: Fanconi Anemia Ontology
+  version: '3'
+  nodecount: 4534
+  edgecount: 4977
+  submission_id: '5'
+  source_bytes: 2880310
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IFAR.tar.gz
+- id: ILLNESSINJURY
+  status: OK
+  reason: ''
+  name: Illness and Injury
+  version: 1.0.2
+  nodecount: 162
+  edgecount: 41
+  submission_id: '1'
+  source_bytes: 89545
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ILLNESSINJURY.tar.gz
+- id: IMGT-ONTOLOGY
+  status: OK
+  reason: ''
+  name: Immunogenetics Ontology
+  version: 1.0.3
+  nodecount: 1624
+  edgecount: 15159
+  submission_id: '5'
+  source_bytes: 3828117
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IMGT-ONTOLOGY.tar.gz
+- id: IMOBO
+  status: OK
+  reason: ''
+  name: Intelligent Medicine oriented Biobank Ontology
+  version: '0.1'
+  nodecount: 103
+  edgecount: 101
+  submission_id: '1'
+  source_bytes: 51497
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IMOBO.tar.gz
+- id: INBANCIDO
+  status: OK
+  reason: ''
+  name: 'Assessment of Indian Economy During Covid-19 '
+  version: 1.0.214
+  nodecount: 9411
+  edgecount: 31852
+  submission_id: '1'
+  source_bytes: 14396470
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/INBANCIDO.tar.gz
+- id: INBIO
+  status: OK
+  reason: ''
+  name: Invasion Biology Ontology
+  version: '1.2'
+  nodecount: 786
+  edgecount: 1563
+  submission_id: '3'
+  source_bytes: 668738
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INBIO.tar.gz
+- id: INBIODIV
+  status: OK
+  reason: ''
+  name: An Ontology for Indian Biodiversity Knowledge Management
+  version: '1.1'
+  nodecount: 678
+  edgecount: 666
+  submission_id: '1'
+  source_bytes: 298538
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INBIODIV.tar.gz
+- id: INCENTIVE
+  status: OK
+  reason: ''
+  name: INCENTIVE Community Controlled Vocabulary
+  version: 0.1.3
+  nodecount: 109
+  edgecount: 251
+  submission_id: '7'
+  source_bytes: 23964
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INCENTIVE.tar.gz
+- id: INCENTIVE-VARS
+  status: OK
+  reason: ''
+  name: INCENTIVE Variables
+  version: 0.1.0
+  nodecount: 109
+  edgecount: 251
+  submission_id: '9'
+  source_bytes: 23964
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INCENTIVE-VARS.tar.gz
+- id: INFECTION_TRANS
+  status: OK
+  reason: ''
+  name: Infection Transmission Ontology
+  version: 1.0.2
+  nodecount: 89
+  edgecount: 95
+  submission_id: '2'
+  source_bytes: 18991
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INFECTION_TRANS.tar.gz
+- id: INFRA-EN
+  status: Failed
+  reason: not_downloadable
+  name: Infrastructure
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: INFRARISK
+  status: Failed
+  reason: transform_error
+  name: InfraRisk Ontology
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 81799
+- id: INJURYTYPES
+  status: OK
+  reason: ''
+  name: Injury Types
+  version: NA
+  nodecount: 26
+  edgecount: 35
+  submission_id: '1'
+  source_bytes: 3707
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INJURYTYPES.tar.gz
+- id: INO
+  status: OK
+  reason: ''
+  name: Interaction Network Ontology
+  version: 1.1.13
+  nodecount: 496
+  edgecount: 965
+  submission_id: '34'
+  source_bytes: 493136
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INO.tar.gz
+- id: INSECTH
+  status: OK
+  reason: ''
+  name: insectH
+  version: '0.1'
+  nodecount: 337
+  edgecount: 162
+  submission_id: '7'
+  source_bytes: 133405
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INSECTH.tar.gz
+- id: INSNAME
+  status: OK
+  reason: ''
+  name: VODANAINSNAMES
+  version: '5'
+  nodecount: 38
+  edgecount: 70
+  submission_id: '5'
+  source_bytes: 10734
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INSNAME.tar.gz
+- id: INTO
+  status: OK
+  reason: ''
+  name: Indian Terrorism Ontology
+  version: '1.1'
+  nodecount: 1235
+  edgecount: 333
+  submission_id: '1'
+  source_bytes: 583508
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INTO.tar.gz
+- id: INTVEETYPE
+  status: OK
+  reason: ''
+  name: Interviewee Type
+  version: NA
+  nodecount: 23
+  edgecount: 23
+  submission_id: '1'
+  source_bytes: 2850
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INTVEETYPE.tar.gz
+- id: INTVMODE
+  status: OK
+  reason: ''
+  name: Interview Mode
+  version: NA
+  nodecount: 25
+  edgecount: 31
+  submission_id: '1'
+  source_bytes: 3639
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INTVMODE.tar.gz
+- id: INVERSEROLES
+  status: OK
+  reason: ''
+  name: ISO-15926-2_2003_inverseRoles
+  version: Generated 2008-09-03T19:12:44.687+02:00
+  nodecount: 209
+  edgecount: 104
+  submission_id: '1'
+  source_bytes: 16028
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/INVERSEROLES.tar.gz
+- id: IOBC
+  status: Skipped
+  reason: too_large
+  name: Interlinking Ontology for Biological Concepts
+  version: version 1.6.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '25'
+  source_bytes: 171791980
+- id: IPD
+  status: OK
+  reason: ''
+  name: injury process description ontology
+  version: '1.0'
+  nodecount: 68
+  edgecount: 113
+  submission_id: '2'
+  source_bytes: 46945
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IPD.tar.gz
+- id: IRAEO
+  status: OK
+  reason: ''
+  name: Immune-Related Adverse Event Ontology
+  version: NA
+  nodecount: 898
+  edgecount: 1998
+  submission_id: '1'
+  source_bytes: 1901034
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IRAEO.tar.gz
+- id: IRD
+  status: OK
+  reason: ''
+  name: Inherited Retinal Dystrophies
+  version: NA
+  nodecount: 550
+  edgecount: 540
+  submission_id: '1'
+  source_bytes: 1000795
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IRD.tar.gz
+- id: IRDG
+  status: OK
+  reason: ''
+  name: 'Data harmonization ontology for cross border malaria surveillance '
+  version: NA
+  nodecount: 190
+  edgecount: 407
+  submission_id: '1'
+  source_bytes: 98463
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IRDG.tar.gz
+- id: ISO-15926-2_2003
+  status: OK
+  reason: ''
+  name: ISO-15926-2_2003_oil
+  version: Generated 2008-02-21T17:29:19.558+01:00
+  nodecount: 332
+  edgecount: 1266
+  submission_id: '1'
+  source_bytes: 193193
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ISO-15926-2_2003.tar.gz
+- id: ISO-ANNOTATIONS
+  status: OK
+  reason: ''
+  name: ISO-15926-2_2003_annotations
+  version: NA
+  nodecount: 205
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 113436
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ISO-ANNOTATIONS.tar.gz
+- id: ISO-FOOD
+  status: OK
+  reason: ''
+  name: A formal representation of the knowledge within the domain of Isotopes for
+    Food Science
+  version: NA
+  nodecount: 1632
+  edgecount: 1931
+  submission_id: '1'
+  source_bytes: 1024964
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO-FOOD.tar.gz
+- id: ISO19108TO
+  status: OK
+  reason: ''
+  name: ISO 19108 Temporal Objects
+  version: '2006-10-15'
+  nodecount: 52
+  edgecount: 101
+  submission_id: '2'
+  source_bytes: 32719
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ISO19108TO.tar.gz
+- id: ISO19110
+  status: OK
+  reason: ''
+  name: ISO 19110 Methodology for Feature Cataloguing
+  version: '2005-02-15'
+  nodecount: 112
+  edgecount: 221
+  submission_id: '2'
+  source_bytes: 105965
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19110.tar.gz
+- id: ISO19115
+  status: OK
+  reason: ''
+  name: ISO 19115
+  version: version 1.10
+  nodecount: 698
+  edgecount: 652
+  submission_id: '3'
+  source_bytes: 385843
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ISO19115.tar.gz
+- id: ISO19115CC
+  status: OK
+  reason: ''
+  name: ISO 19115 Common Classes
+  version: '2014'
+  nodecount: 78
+  edgecount: 104
+  submission_id: '3'
+  source_bytes: 60518
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19115CC.tar.gz
+- id: ISO19115CI
+  status: OK
+  reason: ''
+  name: ISO 19115 Citation Information
+  version: '2014'
+  nodecount: 166
+  edgecount: 242
+  submission_id: '4'
+  source_bytes: 150311
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19115CI.tar.gz
+- id: ISO19115CON
+  status: OK
+  reason: ''
+  name: ISO 19115 Constraints Information
+  version: '2014'
+  nodecount: 68
+  edgecount: 106
+  submission_id: '3'
+  source_bytes: 33988
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ISO19115CON.tar.gz
+- id: ISO19115DI
+  status: OK
+  reason: ''
+  name: ISO 19115 Distribution Information
+  version: '2014'
+  nodecount: 74
+  edgecount: 122
+  submission_id: '3'
+  source_bytes: 60361
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19115DI.tar.gz
+- id: ISO19115DTC
+  status: OK
+  reason: ''
+  name: ISO 19115 Date Type Code
+  version: '2.0'
+  nodecount: 29
+  edgecount: 50
+  submission_id: '1'
+  source_bytes: 23715
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19115DTC.tar.gz
+- id: ISO19115EX
+  status: OK
+  reason: ''
+  name: ISO 19115 Extent Information
+  version: '2014'
+  nodecount: 44
+  edgecount: 67
+  submission_id: '28'
+  source_bytes: 35384
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19115EX.tar.gz
+- id: ISO19115ID
+  status: OK
+  reason: ''
+  name: ISO 19115 Identification Information
+  version: 2003-05-0
+  nodecount: 159
+  edgecount: 262
+  submission_id: '6'
+  source_bytes: 82063
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ISO19115ID.tar.gz
+- id: ISO19115MI
+  status: Failed
+  reason: transform_error
+  name: ISO 19115 Metadata Information
+  version: '2014'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '126'
+  source_bytes: 16733
+- id: ISO19115PR
+  status: OK
+  reason: ''
+  name: ISO 19115 Codelists
+  version: '2.0'
+  nodecount: 294
+  edgecount: 18
+  submission_id: '5'
+  source_bytes: 106987
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ISO19115PR.tar.gz
+- id: ISO19115ROLES
+  status: OK
+  reason: ''
+  name: ISO 19115 Role Codes
+  version: '2.0'
+  nodecount: 29
+  edgecount: 40
+  submission_id: '6'
+  source_bytes: 20600
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19115ROLES.tar.gz
+- id: ISO19115SRS
+  status: Failed
+  reason: transform_error
+  name: ISO 19115 Reference Systems
+  version: '2014'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 28600
+- id: ISO19115TCC
+  status: OK
+  reason: ''
+  name: ISO 19115 Topic Categories
+  version: NA
+  nodecount: 21
+  edgecount: 19
+  submission_id: '11'
+  source_bytes: 12596
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO19115TCC.tar.gz
+- id: ISO639-1
+  status: OK
+  reason: ''
+  name: 'ISO 639-1: Codes for the Representation of Names of Languages - Part 1: Two-letter
+    codes for languages'
+  version: 1.0.0
+  nodecount: 207
+  edgecount: 570
+  submission_id: '1'
+  source_bytes: 75289
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO639-1.tar.gz
+- id: ISO639-2
+  status: OK
+  reason: ''
+  name: 'ISO 639-2: Codes for the Representation of Names of Languages'
+  version: NA
+  nodecount: 15561
+  edgecount: 49
+  submission_id: '3'
+  source_bytes: 6675107
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISO639-2.tar.gz
+- id: ISPO
+  status: OK
+  reason: ''
+  name: Integrated Ontology for Symptom Phenotype Terminologies
+  version: 2023V1
+  nodecount: 3154
+  edgecount: 3147
+  submission_id: '1'
+  source_bytes: 3667839
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISPO.tar.gz
+- id: ISSVA
+  status: OK
+  reason: ''
+  name: International Society for the Study of Vascular Anomalies (ISSVA) Ontology
+  version: 1.1.3
+  nodecount: 415
+  edgecount: 531
+  submission_id: '5'
+  source_bytes: 136603
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ISSVA.tar.gz
+- id: ITEMAS
+  status: OK
+  reason: ''
+  name: Medical Technology Innovation in healthcare centers
+  version: '3.0'
+  nodecount: 311
+  edgecount: 546
+  submission_id: '1'
+  source_bytes: 144751
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ITEMAS.tar.gz
+- id: ITO
+  status: OK
+  reason: ''
+  name: Intelligence Task Ontology
+  version: 1.12 (PWC export dated 2022-07-30) - internal, just a minor fix
+  nodecount: 69152
+  edgecount: 141447
+  submission_id: '17'
+  source_bytes: 53946229
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ITO.tar.gz
+- id: IVAN
+  status: Failed
+  reason: not_downloadable
+  name: IVAN OTERO
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: IXNO
+  status: OK
+  reason: ''
+  name: Interaction Ontology
+  version: '1'
+  nodecount: 99
+  edgecount: 104
+  submission_id: '2'
+  source_bytes: 20596
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IXNO.tar.gz
+- id: JERM
+  status: OK
+  reason: ''
+  name: Just Enough Results Model Ontology
+  version: '2'
+  nodecount: 355
+  edgecount: 434
+  submission_id: '15'
+  source_bytes: 269104
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/JERM.tar.gz
+- id: JFO
+  status: OK
+  reason: ''
+  name: Japanese Food Ontology
+  version: '0.72'
+  nodecount: 9764
+  edgecount: 19161
+  submission_id: '69'
+  source_bytes: 10882218
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/JFO.tar.gz
+- id: JSO
+  status: Failed
+  reason: no_submission
+  name: JS Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: KENYAANC
+  status: OK
+  reason: ''
+  name: kenyaancfile
+  version: '1'
+  nodecount: 152
+  edgecount: 225
+  submission_id: '1'
+  source_bytes: 42297
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/KENYAANC.tar.gz
+- id: KGCL
+  status: OK
+  reason: ''
+  name: Knowledge Graph Change Language
+  version: 0.1.0
+  nodecount: 218
+  edgecount: 526
+  submission_id: '9'
+  source_bytes: 127224
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/KGCL.tar.gz
+- id: KISAO
+  status: Failed
+  reason: transform_error
+  name: Kinetic Simulation Algorithm Ontology
+  version: '2.34'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '64'
+  source_bytes: 1122492
+- id: KOIO
+  status: OK
+  reason: ''
+  name: Knowledge Object Implementation Ontology
+  version: '2.1'
+  nodecount: 49
+  edgecount: 55
+  submission_id: '1'
+  source_bytes: 23416
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/KOIO.tar.gz
+- id: KORO
+  status: OK
+  reason: ''
+  name: Knowledge Object Reference Ontology
+  version: '1.3'
+  nodecount: 192
+  edgecount: 219
+  submission_id: '6'
+  source_bytes: 247142
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/KORO.tar.gz
+- id: KTAO
+  status: OK
+  reason: ''
+  name: Kidney Tissue Atlas Ontology
+  version: 'Vision Release: 1.0.121'
+  nodecount: 22173
+  edgecount: 60800
+  submission_id: '20'
+  source_bytes: 23338360
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/KTAO.tar.gz
+- id: KUSIIMA
+  status: Failed
+  reason: no_submission
+  name: naava
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: LABO
+  status: OK
+  reason: ''
+  name: clinical LABoratory Ontology
+  version: NA
+  nodecount: 298
+  edgecount: 547
+  submission_id: '4'
+  source_bytes: 380173
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LABO.tar.gz
+- id: LAND-SURFACE
+  status: OK
+  reason: ''
+  name: Land Surface classifiers
+  version: 3rd Edition
+  nodecount: 531
+  edgecount: 1703
+  submission_id: '1'
+  source_bytes: 253505
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LAND-SURFACE.tar.gz
+- id: LANDFORM
+  status: OK
+  reason: ''
+  name: Landform classifiers
+  version: 3rd edition
+  nodecount: 439
+  edgecount: 1048
+  submission_id: '2'
+  source_bytes: 335679
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LANDFORM.tar.gz
+- id: LBO
+  status: OK
+  reason: ''
+  name: Livestock Breed Ontology
+  version: '2026-07-22'
+  nodecount: 1169
+  edgecount: 1155
+  submission_id: '77'
+  source_bytes: 163196
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LBO.tar.gz
+- id: LC-CARRIERS
+  status: OK
+  reason: ''
+  name: Library of Congress Carriers Scheme
+  version: NA
+  nodecount: 76
+  edgecount: 56
+  submission_id: '5'
+  source_bytes: 29459
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LC-CARRIERS.tar.gz
+- id: LC-MEDIA
+  status: OK
+  reason: ''
+  name: Library of Congress Media Types Scheme
+  version: NA
+  nodecount: 31
+  edgecount: 24
+  submission_id: '17'
+  source_bytes: 13256
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LC-MEDIA.tar.gz
+- id: LCDGT
+  status: OK
+  reason: ''
+  name: Library of Congress Demographic Group Terms
+  version: NA
+  nodecount: 26
+  edgecount: 11
+  submission_id: '2'
+  source_bytes: 4378
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LCDGT.tar.gz
+- id: LCGFT
+  status: Skipped
+  reason: too_large
+  name: Library of Congress Genre/Form Thesaurus for Library and Archival Materials
+  version: '2017-09-05'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 148003626
+- id: LDA
+  status: Failed
+  reason: not_downloadable
+  name: Ontology of Language Disorder in Autism
+  version: 12-15-2008
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: LDBASE
+  status: OK
+  reason: ''
+  name: LDbase
+  version: 0.0.1
+  nodecount: 665
+  edgecount: 1907
+  submission_id: '2'
+  source_bytes: 128543
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LDBASE.tar.gz
+- id: LEGALAPA
+  status: OK
+  reason: ''
+  name: legalapa
+  version: '01'
+  nodecount: 228
+  edgecount: 220
+  submission_id: '1'
+  source_bytes: 39295
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/LEGALAPA.tar.gz
+- id: LEGALAPATEST2
+  status: OK
+  reason: ''
+  name: apalegal
+  version: '1'
+  nodecount: 228
+  edgecount: 220
+  submission_id: '1'
+  source_bytes: 39261
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/LEGALAPATEST2.tar.gz
+- id: LEO
+  status: OK
+  reason: ''
+  name: Living Environment Ontology
+  version: '1.0'
+  nodecount: 258
+  edgecount: 236
+  submission_id: '1'
+  source_bytes: 425266
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LEO.tar.gz
+- id: LEPAO
+  status: OK
+  reason: ''
+  name: Lepidoptera Anatomy Ontology
+  version: '2023-02-18'
+  nodecount: 1215
+  edgecount: 2404
+  submission_id: '2'
+  source_bytes: 2688178
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LEPAO.tar.gz
+- id: LHN
+  status: OK
+  reason: ''
+  name: Loggerhead Nesting Ontology
+  version: NA
+  nodecount: 325
+  edgecount: 348
+  submission_id: '4'
+  source_bytes: 338136
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LHN.tar.gz
+- id: LHO
+  status: OK
+  reason: ''
+  name: LivestockHealthOntology
+  version: V1.4
+  nodecount: 308
+  edgecount: 216
+  submission_id: '9'
+  source_bytes: 184108
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LHO.tar.gz
+- id: LIB
+  status: Failed
+  reason: no_submission
+  name: MWS-WSM
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: LIBRARY
+  status: Failed
+  reason: no_submission
+  name: wsm24
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: LICO
+  status: OK
+  reason: ''
+  name: Liver Case Ontology (LiCO)
+  version: 'changes
+
+    * Segments and Regions are modelling as Classes in order to identify which patient
+    (liver) they belong to.
+
+    * Redundant restrictions are removed
+
+    '
+  nodecount: 270
+  edgecount: 364
+  submission_id: '2'
+  source_bytes: 217274
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LICO.tar.gz
+- id: LIFO
+  status: OK
+  reason: ''
+  name: Life Ontology
+  version: 'Vision Release: 1.0.17'
+  nodecount: 475
+  edgecount: 1101
+  submission_id: '1'
+  source_bytes: 448438
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LIFO.tar.gz
+- id: LION
+  status: OK
+  reason: ''
+  name: LipidOntology
+  version: '1.1'
+  nodecount: 63579
+  edgecount: 188638
+  submission_id: '1'
+  source_bytes: 12241771
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LION.tar.gz
+- id: LIPRO
+  status: OK
+  reason: ''
+  name: Lipid Ontology
+  version: See Remote Site
+  nodecount: 292
+  edgecount: 17
+  submission_id: '4'
+  source_bytes: 50539
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/LIPRO.tar.gz
+- id: LOINC
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: LONGCOVID
+  status: OK
+  reason: ''
+  name: Long Covid Phenotype Ontology
+  version: '20220106'
+  nodecount: 10
+  edgecount: 11
+  submission_id: '2'
+  source_bytes: 6665
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LONGCOVID.tar.gz
+- id: LPT
+  status: OK
+  reason: ''
+  name: Livestock Product Trait Ontology
+  version: '2026-04-01'
+  nodecount: 557
+  edgecount: 1564
+  submission_id: '16'
+  source_bytes: 220265
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LPT.tar.gz
+- id: LSFC
+  status: Failed
+  reason: no_submission
+  name: LSFC
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: LSFO
+  status: OK
+  reason: ''
+  name: Lifestyle Factor Ontology
+  version: '1.01'
+  nodecount: 5624
+  edgecount: 6687
+  submission_id: '1'
+  source_bytes: 2984245
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LSFO.tar.gz
+- id: LTER-CV
+  status: OK
+  reason: ''
+  name: LTER Controlled Vocabulary
+  version: NA
+  nodecount: 723
+  edgecount: 2610
+  submission_id: '1'
+  source_bytes: 398822
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LTER-CV.tar.gz
+- id: LUNGMAP-HUMAN
+  status: OK
+  reason: ''
+  name: Anatomic Ontology for Human Lung Maturation
+  version: '1.4'
+  nodecount: 341
+  edgecount: 898
+  submission_id: '6'
+  source_bytes: 383384
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LUNGMAP-HUMAN.tar.gz
+- id: LUNGMAP-MOUSE
+  status: OK
+  reason: ''
+  name: Anatomic Ontology for Mouse Lung Maturation
+  version: '1.2'
+  nodecount: 353
+  edgecount: 4768
+  submission_id: '4'
+  source_bytes: 750507
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LUNGMAP-MOUSE.tar.gz
+- id: LUNGMAP_H_CELL
+  status: OK
+  reason: ''
+  name: Cell Ontology for Human Lung Maturation
+  version: '3.2'
+  nodecount: 112
+  edgecount: 207
+  submission_id: '6'
+  source_bytes: 82643
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LUNGMAP_H_CELL.tar.gz
+- id: LUNGMAP_M_CELL
+  status: OK
+  reason: ''
+  name: Cell Ontology for Mouse Lung Maturation
+  version: '3.2'
+  nodecount: 124
+  edgecount: 241
+  submission_id: '5'
+  source_bytes: 101014
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LUNGMAP_M_CELL.tar.gz
+- id: M
+  status: Failed
+  reason: no_submission
+  name: May
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: M4M-20-SUBJECTS
+  status: OK
+  reason: ''
+  name: M4M.20 FAIRWare Subjects
+  version: 0.1.3
+  nodecount: 65
+  edgecount: 71
+  submission_id: '6'
+  source_bytes: 9526
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/M4M-20-SUBJECTS.tar.gz
+- id: M4M-20-VARIABLES
+  status: OK
+  reason: ''
+  name: M4M.20 FAIRWare Variables
+  version: 0.1.3
+  nodecount: 53
+  edgecount: 45
+  submission_id: '7'
+  source_bytes: 5600
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/M4M-20-VARIABLES.tar.gz
+- id: M4M-21-SUBJECTS
+  status: OK
+  reason: ''
+  name: M4M.21 FAIRWare Subjects
+  version: 0.1.2
+  nodecount: 62
+  edgecount: 59
+  submission_id: '4'
+  source_bytes: 8398
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/M4M-21-SUBJECTS.tar.gz
+- id: M4M-21-VARIABLES
+  status: OK
+  reason: ''
+  name: M4M.21 FAIRWare Variables
+  version: 0.1.2
+  nodecount: 58
+  edgecount: 48
+  submission_id: '5'
+  source_bytes: 6654
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/M4M-21-VARIABLES.tar.gz
+- id: M4M-CHAR
+  status: OK
+  reason: ''
+  name: M4M-CHAR
+  version: 0.0.1
+  nodecount: 552
+  edgecount: 1569
+  submission_id: '1'
+  source_bytes: 85502
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/M4M-CHAR.tar.gz
+- id: M4M19-SUBS
+  status: OK
+  reason: ''
+  name: M4M19 Subjects
+  version: 0.1.0
+  nodecount: 42
+  edgecount: 68
+  submission_id: '3'
+  source_bytes: 6025
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/M4M19-SUBS.tar.gz
+- id: M4M19-VARS
+  status: OK
+  reason: ''
+  name: M4M19 Variables
+  version: 0.2.0
+  nodecount: 38
+  edgecount: 64
+  submission_id: '4'
+  source_bytes: 6655
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/M4M19-VARS.tar.gz
+- id: MA
+  status: OK
+  reason: ''
+  name: Mouse Adult Gross Anatomy Ontology
+  version: '2026-02-24'
+  nodecount: 3408
+  edgecount: 4284
+  submission_id: '132'
+  source_bytes: 410329
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MA.tar.gz
+- id: MACROALGAETRAITS
+  status: OK
+  reason: ''
+  name: Macroalgae Traits Thesaurus
+  version: NA
+  nodecount: 151
+  edgecount: 341
+  submission_id: '1'
+  source_bytes: 75870
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MACROALGAETRAITS.tar.gz
+- id: MADS-RDF
+  status: OK
+  reason: ''
+  name: Metadata Authority Description Schema in RDF
+  version: '1.0'
+  nodecount: 186
+  edgecount: 209
+  submission_id: '5'
+  source_bytes: 91264
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MADS-RDF.tar.gz
+- id: MAMO
+  status: OK
+  reason: ''
+  name: Mathematical Modelling Ontology
+  version: '2023-02-03'
+  nodecount: 117
+  edgecount: 168
+  submission_id: '17'
+  source_bytes: 204902
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MAMO.tar.gz
+- id: MAMO-SCR-ONTO
+  status: OK
+  reason: ''
+  name: Mammography Screening Ontology
+  version: '1.0'
+  nodecount: 140
+  edgecount: 100
+  submission_id: '1'
+  source_bytes: 71649
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MAMO-SCR-ONTO.tar.gz
+- id: MARC-LANGUAGES
+  status: OK
+  reason: ''
+  name: MARC List for Languages
+  version: NA
+  nodecount: 889
+  edgecount: 864
+  submission_id: '271'
+  source_bytes: 464803
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MARC-LANGUAGES.tar.gz
+- id: MARC-RELATORS
+  status: OK
+  reason: ''
+  name: MARC Code List for Relators
+  version: NA
+  nodecount: 326
+  edgecount: 305
+  submission_id: '15'
+  source_bytes: 235943
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MARC-RELATORS.tar.gz
+- id: MAT
+  status: OK
+  reason: ''
+  name: Minimal Anatomical Terminology
+  version: '1.1'
+  nodecount: 2204
+  edgecount: 3954
+  submission_id: '4'
+  source_bytes: 102344
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MAT.tar.gz
+- id: MATERIALSMINE
+  status: Failed
+  reason: transform_error
+  name: MaterialsMine Ontology
+  version: '1.1'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 153621
+- id: MATR
+  status: OK
+  reason: ''
+  name: Material
+  version: '2.3'
+  nodecount: 37
+  edgecount: 29
+  submission_id: '1'
+  source_bytes: 7459
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MATR.tar.gz
+- id: MATRCOMPOUND
+  status: OK
+  reason: ''
+  name: Material Compound
+  version: '2.3'
+  nodecount: 134
+  edgecount: 158
+  submission_id: '1'
+  source_bytes: 17572
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MATRCOMPOUND.tar.gz
+- id: MATRELEMENT
+  status: OK
+  reason: ''
+  name: Material Element
+  version: '2.3'
+  nodecount: 101
+  edgecount: 61
+  submission_id: '1'
+  source_bytes: 16313
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MATRELEMENT.tar.gz
+- id: MATRROCK
+  status: OK
+  reason: ''
+  name: Material Rock
+  version: '2.3'
+  nodecount: 25
+  edgecount: 24
+  submission_id: '1'
+  source_bytes: 7669
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MATRROCK.tar.gz
+- id: MATRROCKIGNEOUS
+  status: OK
+  reason: ''
+  name: Material Rock Igneouus
+  version: '2.3'
+  nodecount: 48
+  edgecount: 51
+  submission_id: '2'
+  source_bytes: 16328
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MATRROCKIGNEOUS.tar.gz
+- id: MAXO
+  status: Failed
+  reason: transform_error
+  name: Medical Action Ontology
+  version: '2026-01-15'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '57'
+  source_bytes: 16448041
+- id: MCBCC
+  status: OK
+  reason: ''
+  name: Breast Tissue Cell Lines Ontology
+  version: '2'
+  nodecount: 413
+  edgecount: 2388
+  submission_id: '2'
+  source_bytes: 1020053
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCBCC.tar.gz
+- id: MCCL
+  status: OK
+  reason: ''
+  name: Cell Line Ontology [by Mahadevan]
+  version: '2'
+  nodecount: 5493
+  edgecount: 12404
+  submission_id: '2'
+  source_bytes: 3182434
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCCL.tar.gz
+- id: MCCV
+  status: OK
+  reason: ''
+  name: Microbial Culture Collection Vocabulary
+  version: Version 0.99 beta
+  nodecount: 131
+  edgecount: 120
+  submission_id: '11'
+  source_bytes: 28172
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCCV.tar.gz
+- id: MCHVODANATERMS
+  status: OK
+  reason: ''
+  name: MCHVODANATERMS
+  version: '3.0'
+  nodecount: 52
+  edgecount: 107
+  submission_id: '5'
+  source_bytes: 14937
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCHVODANATERMS.tar.gz
+- id: MCO
+  status: OK
+  reason: ''
+  name: Microbial Conditions Ontology
+  version: NA
+  nodecount: 3561
+  edgecount: 9520
+  submission_id: '1'
+  source_bytes: 17308396
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCO.tar.gz
+- id: MCO4HKE
+  status: OK
+  reason: ''
+  name: Multiplex Classification Ontology for the HyperKvasir Experiment
+  version: NA
+  nodecount: 27
+  edgecount: 22
+  submission_id: '2'
+  source_bytes: 15791
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCO4HKE.tar.gz
+- id: MCO4MCRE
+  status: OK
+  reason: ''
+  name: Multiplex Classification Ontology for the MultiCaRe Experiment
+  version: NA
+  nodecount: 44
+  edgecount: 37
+  submission_id: '1'
+  source_bytes: 26104
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCO4MCRE.tar.gz
+- id: MCRO
+  status: OK
+  reason: ''
+  name: Model Card Report Ontology
+  version: '2023-03-07'
+  nodecount: 92
+  edgecount: 124
+  submission_id: '3'
+  source_bytes: 63121
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCRO.tar.gz
+- id: MCR_TX
+  status: OK
+  reason: ''
+  name: MultiCaRe Taxonomy
+  version: '1.0'
+  nodecount: 175
+  edgecount: 197
+  submission_id: '2'
+  source_bytes: 199963
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCR_TX.tar.gz
+- id: MDDB
+  status: Failed
+  reason: not_downloadable
+  name: Master Drug Data Base Clinical Drugs
+  version: MDDB_2017_02_08
+  nodecount: 0
+  edgecount: 0
+  submission_id: '10'
+  source_bytes: 0
+- id: MDM
+  status: OK
+  reason: ''
+  name: Mapping of Drug Names and MeSH 2022
+  version: '0.330'
+  nodecount: 44791
+  edgecount: 2905
+  submission_id: '5'
+  source_bytes: 47140702
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MDM.tar.gz
+- id: MEDDRA
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: MEDEON
+  status: OK
+  reason: ''
+  name: Medical Error Ontology
+  version: NA
+  nodecount: 84
+  edgecount: 56
+  submission_id: '1'
+  source_bytes: 16322
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEDEON.tar.gz
+- id: MEDICALINFO
+  status: OK
+  reason: ''
+  name: mymedicalinformation
+  version: NA
+  nodecount: 23
+  edgecount: 20
+  submission_id: '2'
+  source_bytes: 14146
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEDICALINFO.tar.gz
+- id: MEDLINEPLUS
+  status: OK
+  reason: ''
+  name: MedlinePlus Health Topics
+  version: '20250624'
+  nodecount: 6111
+  edgecount: 2037
+  submission_id: '26'
+  source_bytes: 20494265
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEDLINEPLUS.tar.gz
+- id: MEDO
+  status: OK
+  reason: ''
+  name: Mouse Experimental Design Ontology
+  version: '1.0'
+  nodecount: 95
+  edgecount: 86
+  submission_id: '1'
+  source_bytes: 48832
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEDO.tar.gz
+- id: MEDRED
+  status: Failed
+  reason: transform_error
+  name: 'MedRed ontology: clinical data acquisition model'
+  version: 0.0.1
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 15631
+- id: MEGO
+  status: OK
+  reason: ''
+  name: Mobile Genetic Element Ontology
+  version: '2_1'
+  nodecount: 400
+  edgecount: 441
+  submission_id: '2'
+  source_bytes: 119301
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEGO.tar.gz
+- id: MELLO-D
+  status: OK
+  reason: ''
+  name: MEdical LifeLog Ontology for people with Disability
+  version: '2.0'
+  nodecount: 7401
+  edgecount: 7425
+  submission_id: '9'
+  source_bytes: 5366818
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MELLO-D.tar.gz
+- id: MELO
+  status: OK
+  reason: ''
+  name: Melanoma Ontology
+  version: '1.0'
+  nodecount: 726
+  edgecount: 1745
+  submission_id: '2'
+  source_bytes: 753329
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MELO.tar.gz
+- id: MEO
+  status: Failed
+  reason: transform_error
+  name: Metagenome and Microbes Environmental Ontology
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '11'
+  source_bytes: 498808
+- id: MEPO
+  status: OK
+  reason: ''
+  name: Mapping of Epilepsy Ontologies
+  version: '0.6'
+  nodecount: 5689
+  edgecount: 485
+  submission_id: '6'
+  source_bytes: 3649809
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEPO.tar.gz
+- id: MERA
+  status: OK
+  reason: ''
+  name: Medical Educational Resource Aggregator
+  version: 0.0.1
+  nodecount: 46
+  edgecount: 71
+  submission_id: '1'
+  source_bytes: 14975
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MERA.tar.gz
+- id: MESH
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: METABUS
+  status: OK
+  reason: ''
+  name: metaBUS controlled vocabulary for organizational and applied psychology research
+  version: '0.1'
+  nodecount: 5187
+  edgecount: 5180
+  submission_id: '18'
+  source_bytes: 1781574
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/METABUS.tar.gz
+- id: METAMESH
+  status: OK
+  reason: ''
+  name: Meta Mesh Ontology
+  version: 1.0.0
+  nodecount: 132
+  edgecount: 117
+  submission_id: '2'
+  source_bytes: 53877
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/METAMESH.tar.gz
+- id: METPO
+  status: OK
+  reason: ''
+  name: METPO
+  version: '2026-06-12'
+  nodecount: 1654
+  edgecount: 3189
+  submission_id: '26'
+  source_bytes: 1115523
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/METPO.tar.gz
+- id: MF
+  status: OK
+  reason: ''
+  name: Mental Functioning Ontology
+  version: '2025-07-08'
+  nodecount: 533
+  edgecount: 806
+  submission_id: '29'
+  source_bytes: 430780
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MF.tar.gz
+- id: MFMO
+  status: OK
+  reason: ''
+  name: Mammalian Feeding Muscle Ontology
+  version: NA
+  nodecount: 282
+  edgecount: 425
+  submission_id: '1'
+  source_bytes: 199737
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFMO.tar.gz
+- id: MFO
+  status: OK
+  reason: ''
+  name: Medaka Fish Anatomy and Development Ontology
+  version: NA
+  nodecount: 4374
+  edgecount: 4402
+  submission_id: '15'
+  source_bytes: 512204
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFO.tar.gz
+- id: MFOEM
+  status: OK
+  reason: ''
+  name: Emotion Ontology
+  version: '2025-07-31'
+  nodecount: 771
+  edgecount: 1109
+  submission_id: '45'
+  source_bytes: 640327
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFOEM.tar.gz
+- id: MFOMD
+  status: OK
+  reason: ''
+  name: MFO Mental Disease Ontology
+  version: '2020-04-26'
+  nodecount: 34
+  edgecount: 11
+  submission_id: '2'
+  source_bytes: 7116
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFOMD.tar.gz
+- id: MGBD
+  status: OK
+  reason: ''
+  name: MGB Drug List
+  version: '0.6'
+  nodecount: 13
+  edgecount: 5
+  submission_id: '7'
+  source_bytes: 6659
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MGBD.tar.gz
+- id: MHC
+  status: OK
+  reason: ''
+  name: Major Histocompatibility Complex Ontology
+  version: 1.0.1
+  nodecount: 138
+  edgecount: 300
+  submission_id: '4'
+  source_bytes: 61015
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MHC.tar.gz
+- id: MHCRO
+  status: OK
+  reason: ''
+  name: MHC Restriction Ontology
+  version: '2026-02-10'
+  nodecount: 51499
+  edgecount: 168477
+  submission_id: '46'
+  source_bytes: 82450469
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MHCRO.tar.gz
+- id: MHIO
+  status: OK
+  reason: ''
+  name: Mental Health Interface Ontology
+  version: NA
+  nodecount: 370
+  edgecount: 365
+  submission_id: '1'
+  source_bytes: 97271
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MHIO.tar.gz
+- id: MHMO
+  status: OK
+  reason: ''
+  name: Mental Health Management Ontology
+  version: '3.2'
+  nodecount: 533
+  edgecount: 573
+  submission_id: '9'
+  source_bytes: 347111
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MHMO.tar.gz
+- id: MI
+  status: OK
+  reason: ''
+  name: Molecular Interactions
+  version: NA
+  nodecount: 1703
+  edgecount: 3178
+  submission_id: '75'
+  source_bytes: 741379
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MI.tar.gz
+- id: MIAPA
+  status: OK
+  reason: ''
+  name: MIAPA Ontology
+  version: NA
+  nodecount: 88
+  edgecount: 58
+  submission_id: '1'
+  source_bytes: 37095
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIAPA.tar.gz
+- id: MICRONT
+  status: OK
+  reason: ''
+  name: microntology
+  version: v1.0.1
+  nodecount: 165
+  edgecount: 228
+  submission_id: '2'
+  source_bytes: 117639
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MICRONT.tar.gz
+- id: MIDO
+  status: OK
+  reason: ''
+  name: Medical Imaging and Diagnostic Ontology
+  version: '2015-11-20'
+  nodecount: 55499
+  edgecount: 141069
+  submission_id: '1'
+  source_bytes: 77913990
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIDO.tar.gz
+- id: MIFD
+  status: OK
+  reason: ''
+  name: Minimum Information for Fermentation Devices
+  version: NA
+  nodecount: 57
+  edgecount: 132
+  submission_id: '5'
+  source_bytes: 21815
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIFD.tar.gz
+- id: MIFE
+  status: OK
+  reason: ''
+  name: Minimum information for fermentation experiments
+  version: NA
+  nodecount: 134
+  edgecount: 375
+  submission_id: '3'
+  source_bytes: 73473
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIFE.tar.gz
+- id: MIM
+  status: OK
+  reason: ''
+  name: Molecular Interaction Map
+  version: 10:30:2014 16:04
+  nodecount: 34
+  edgecount: 18
+  submission_id: '3'
+  source_bytes: 19725
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MIM.tar.gz
+- id: MINERAL
+  status: OK
+  reason: ''
+  name: Material Mineral
+  version: '2.3'
+  nodecount: 17
+  edgecount: 15
+  submission_id: '1'
+  source_bytes: 4038
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MINERAL.tar.gz
+- id: MINI-FAST-1
+  status: OK
+  reason: ''
+  name: mini fast test
+  version: NA
+  nodecount: 12
+  edgecount: 3
+  submission_id: '1'
+  source_bytes: 1073
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MINI-FAST-1.tar.gz
+- id: MIO
+  status: OK
+  reason: ''
+  name: Myocardial Infarction Ontology
+  version: V1.0.0
+  nodecount: 6612
+  edgecount: 3723
+  submission_id: '7'
+  source_bytes: 4771618
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIO.tar.gz
+- id: MIRAPIE
+  status: OK
+  reason: ''
+  name: MInimal Requirements for Automated Provenance Information Enrichment in biomedical
+    research
+  version: 1.0.1
+  nodecount: 200
+  edgecount: 249
+  submission_id: '2'
+  source_bytes: 140904
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIRAPIE.tar.gz
+- id: MIRNAO
+  status: OK
+  reason: ''
+  name: MicroRNA Ontology
+  version: '1.7'
+  nodecount: 695
+  edgecount: 764
+  submission_id: '12'
+  source_bytes: 511004
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIRNAO.tar.gz
+- id: MIRO
+  status: OK
+  reason: ''
+  name: Mosquito Insecticide Resistance
+  version: releases/2014-05-14
+  nodecount: 4450
+  edgecount: 4456
+  submission_id: '1152'
+  source_bytes: 836846
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIRO.tar.gz
+- id: MISO
+  status: Failed
+  reason: not_downloadable
+  name: Microbial Isolation Source Ontology
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 0
+- id: MIXS
+  status: OK
+  reason: ''
+  name: Minimal Information about any Sequence Ontology
+  version: 7.0.1
+  nodecount: 2391
+  edgecount: 7242
+  submission_id: '20'
+  source_bytes: 2061855
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/MIXS.tar.gz
+- id: MIXSCV
+  status: OK
+  reason: ''
+  name: Minimal Information about any Sequence (MIxS) Controlled Vocabularies
+  version: '1'
+  nodecount: 531
+  edgecount: 518
+  submission_id: '2'
+  source_bytes: 70786
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIXSCV.tar.gz
+- id: MLTX
+  status: OK
+  reason: ''
+  name: Machine Learning Methodology Taxonomy Mapping
+  version: '1'
+  nodecount: 24
+  edgecount: 16
+  submission_id: '1'
+  source_bytes: 25319
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MLTX.tar.gz
+- id: ML_MCR_TX
+  status: OK
+  reason: ''
+  name: MultiCaRe Taxonomy (ML Labels)
+  version: NA
+  nodecount: 93
+  edgecount: 81
+  submission_id: '1'
+  source_bytes: 97691
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ML_MCR_TX.tar.gz
+- id: MM
+  status: Failed
+  reason: no_submission
+  name: mm
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: MMO
+  status: OK
+  reason: ''
+  name: Measurement Method Ontology
+  version: '2.109'
+  nodecount: 880
+  edgecount: 987
+  submission_id: '133'
+  source_bytes: 493846
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MMO.tar.gz
+- id: MMUSDV
+  status: OK
+  reason: ''
+  name: Mouse Developmental Stages
+  version: NA
+  nodecount: 174
+  edgecount: 367
+  submission_id: '40'
+  source_bytes: 310367
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MMUSDV.tar.gz
+- id: MNR
+  status: OK
+  reason: ''
+  name: 'Material Natural Resource '
+  version: '2.3'
+  nodecount: 25
+  edgecount: 23
+  submission_id: '1'
+  source_bytes: 6258
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MNR.tar.gz
+- id: MNV
+  status: OK
+  reason: ''
+  name: VODANA Migrants
+  version: '1.0'
+  nodecount: 324
+  edgecount: 1012
+  submission_id: '1'
+  source_bytes: 84021
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MNV.tar.gz
+- id: MO
+  status: OK
+  reason: ''
+  name: Microarray and Gene Expression Data Ontology
+  version: 1.3.1.1
+  nodecount: 1045
+  edgecount: 464
+  submission_id: '3'
+  source_bytes: 569802
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MO.tar.gz
+- id: MOC
+  status: OK
+  reason: ''
+  name: Material Organic Compound
+  version: '2.3'
+  nodecount: 182
+  edgecount: 181
+  submission_id: '1'
+  source_bytes: 21244
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MOC.tar.gz
+- id: MODSCI
+  status: OK
+  reason: ''
+  name: Modern Science Ontology
+  version: '1.0'
+  nodecount: 434
+  edgecount: 314
+  submission_id: '3'
+  source_bytes: 143917
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MODSCI.tar.gz
+- id: MOLSIM
+  status: OK
+  reason: ''
+  name: Molecular Simulation Ontology
+  version: '2026-07-29'
+  nodecount: 2700
+  edgecount: 3566
+  submission_id: '8'
+  source_bytes: 3004157
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOLSIM.tar.gz
+- id: MOMCARE
+  status: Failed
+  reason: transform_error
+  name: MomCareVocabulary
+  version: '1.1'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 85537
+- id: MONDO
+  status: Skipped
+  reason: too_large
+  name: Mondo Disease Ontology
+  version: '2026-07-06'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '82'
+  source_bytes: 226246699
+- id: MONO
+  status: OK
+  reason: ''
+  name: Monogenean Ontology
+  version: NA
+  nodecount: 3875
+  edgecount: 383
+  submission_id: '2'
+  source_bytes: 2469526
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MONO.tar.gz
+- id: MOOCCIADO
+  status: OK
+  reason: ''
+  name: Molgula occidentalis Anatomy and Development Ontology
+  version: NA
+  nodecount: 875
+  edgecount: 4617
+  submission_id: '2'
+  source_bytes: 344002
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOOCCIADO.tar.gz
+- id: MOOCCUADO
+  status: OK
+  reason: ''
+  name: Molgula occulta Anatomy and Development Ontology
+  version: NA
+  nodecount: 875
+  edgecount: 4617
+  submission_id: '2'
+  source_bytes: 343998
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOOCCUADO.tar.gz
+- id: MOOCULADO
+  status: OK
+  reason: ''
+  name: Molgula oculata Anatomy and Development Ontology
+  version: NA
+  nodecount: 875
+  edgecount: 4617
+  submission_id: '2'
+  source_bytes: 343998
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOOCULADO.tar.gz
+- id: MOP
+  status: OK
+  reason: ''
+  name: Molecular Process Ontology
+  version: NA
+  nodecount: 3731
+  edgecount: 3893
+  submission_id: '8'
+  source_bytes: 4842233
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOP.tar.gz
+- id: MOSAIC
+  status: OK
+  reason: ''
+  name: The MOSAiC Ontology
+  version: Version 1.0.1
+  nodecount: 9737
+  edgecount: 408
+  submission_id: '4'
+  source_bytes: 8713575
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOSAIC.tar.gz
+- id: MP
+  status: OK
+  reason: ''
+  name: Mammalian Phenotype Ontology
+  version: '2026-06-17'
+  nodecount: 16057
+  edgecount: 30356
+  submission_id: '462'
+  source_bytes: 7635846
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MP.tar.gz
+- id: MPATH
+  status: OK
+  reason: ''
+  name: Mouse Pathology Ontology
+  version: '2020-05-19'
+  nodecount: 916
+  edgecount: 952
+  submission_id: '22'
+  source_bytes: 251774
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MPATH.tar.gz
+- id: MPIO
+  status: OK
+  reason: ''
+  name: Minimum PDDI Information Ontology
+  version: '2023-10-17'
+  nodecount: 111
+  edgecount: 78
+  submission_id: '2'
+  source_bytes: 111125
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MPIO.tar.gz
+- id: MPO
+  status: OK
+  reason: ''
+  name: Microbial Phenotype Ontology
+  version: Version 0.74 alpha
+  nodecount: 442
+  edgecount: 452
+  submission_id: '7'
+  source_bytes: 69051
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MPO.tar.gz
+- id: MRO
+  status: OK
+  reason: ''
+  name: Defen
+  version: NA
+  nodecount: 205
+  edgecount: 133
+  submission_id: '1'
+  source_bytes: 87788
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MRO.tar.gz
+- id: MS
+  status: OK
+  reason: ''
+  name: Mass Spectrometry Ontology
+  version: 4.1.195
+  nodecount: 4182
+  edgecount: 7529
+  submission_id: '292'
+  source_bytes: 1172950
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/MS.tar.gz
+- id: MSCDO
+  status: OK
+  reason: ''
+  name: 'Medication Safety Co-Decision Ontology '
+  version: NA
+  nodecount: 128
+  edgecount: 127
+  submission_id: '2'
+  source_bytes: 41864
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MSCDO.tar.gz
+- id: MSO
+  status: OK
+  reason: ''
+  name: Multiple sclerosis ontology
+  version: NA
+  nodecount: 1376
+  edgecount: 584
+  submission_id: '2'
+  source_bytes: 2945623
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MSO.tar.gz
+- id: MSR
+  status: OK
+  reason: ''
+  name: Mammography screening recommendation
+  version: 0.0.1
+  nodecount: 152
+  edgecount: 137
+  submission_id: '1'
+  source_bytes: 87988
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MSR.tar.gz
+- id: MSSMHHEAR
+  status: OK
+  reason: ''
+  name: Test HHEAR
+  version: NA
+  nodecount: 4473
+  edgecount: 5668
+  submission_id: '2'
+  source_bytes: 3060542
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MSSMHHEAR.tar.gz
+- id: MSTDE
+  status: OK
+  reason: ''
+  name: Minimal Standard Terminology of Digestive Endoscopy
+  version: MTHMST2001
+  nodecount: 1860
+  edgecount: 128
+  submission_id: '24'
+  source_bytes: 1768104
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MSTDE.tar.gz
+- id: MSV
+  status: Failed
+  reason: transform_error
+  name: Metagenome Sample Vocabulary
+  version: '0.2'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 719403
+- id: MVAONT
+  status: OK
+  reason: ''
+  name: Mosquito Vector Association Ontology with Biocontrol Agents
+  version: Version2
+  nodecount: 179
+  edgecount: 178
+  submission_id: '2'
+  source_bytes: 43834
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MVAONT.tar.gz
+- id: MWLA
+  status: OK
+  reason: ''
+  name: Medical Web Lifestyle Aggregator
+  version: 0.0.1
+  nodecount: 270
+  edgecount: 43
+  submission_id: '1'
+  source_bytes: 87137
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MWLA.tar.gz
+- id: MWO
+  status: OK
+  reason: ''
+  name: NFDI MatWerk Ontology
+  version: 3.0.0
+  nodecount: 673
+  edgecount: 862
+  submission_id: '1'
+  source_bytes: 592537
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MWO.tar.gz
+- id: MY_SYRIANCINEMA
+  status: OK
+  reason: ''
+  name: MWS-WSM Syrian Cinema Ontology
+  version: '4.3'
+  nodecount: 137
+  edgecount: 39
+  submission_id: '1'
+  source_bytes: 71935
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MY_SYRIANCINEMA.tar.gz
+- id: N-CDOH
+  status: OK
+  reason: ''
+  name: Non Clinical Determinants of Health
+  version: v1
+  nodecount: 363
+  edgecount: 387
+  submission_id: '4'
+  source_bytes: 158945
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/N-CDOH.tar.gz
+- id: NAMO
+  status: OK
+  reason: ''
+  name: New Approach Methodology Ontology
+  version: NA
+  nodecount: 517
+  edgecount: 1134
+  submission_id: '2'
+  source_bytes: 216780
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/NAMO.tar.gz
+- id: NANDO
+  status: OK
+  reason: ''
+  name: Nanbyo Disease Ontology
+  version: '2025-08-26'
+  nodecount: 8125
+  edgecount: 14133
+  submission_id: '19'
+  source_bytes: 3024435
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NANDO.tar.gz
+- id: NATPRO
+  status: OK
+  reason: ''
+  name: Natural Products Ontology
+  version: unknown
+  nodecount: 84720
+  edgecount: 123953
+  submission_id: '1'
+  source_bytes: 21778314
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NATPRO.tar.gz
+- id: NBO
+  status: OK
+  reason: ''
+  name: Neuro Behavior Ontology
+  version: '2023-07-04'
+  nodecount: 5142
+  edgecount: 13594
+  submission_id: '38'
+  source_bytes: 5635046
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NBO.tar.gz
+- id: NCBITAXON
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: NCCNEHR
+  status: OK
+  reason: ''
+  name: NCCN EHR Oncology Categories
+  version: 1.0.0
+  nodecount: 16
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 11431
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NCCNEHR.tar.gz
+- id: NCCO
+  status: OK
+  reason: ''
+  name: Nursing Care Coordination Ontology
+  version: '1.0'
+  nodecount: 402
+  edgecount: 397
+  submission_id: '1'
+  source_bytes: 109236
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NCCO.tar.gz
+- id: NCIT
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: NCOD
+  status: Failed
+  reason: transform_error
+  name: NCoD
+  version: 0.1.1
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 921080
+- id: NCRO
+  status: OK
+  reason: ''
+  name: Non-coding RNA Ontology
+  version: Working version 06102015
+  nodecount: 100
+  edgecount: 96
+  submission_id: '12'
+  source_bytes: 37889
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NCRO.tar.gz
+- id: NDDF
+  status: Failed
+  reason: not_downloadable
+  name: National Drug Data File
+  version: '2025_08_13'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '27'
+  source_bytes: 0
+- id: NDDO
+  status: OK
+  reason: ''
+  name: Neurodegenerative Disease Data Ontology
+  version: '0.2'
+  nodecount: 323
+  edgecount: 573
+  submission_id: '10'
+  source_bytes: 202900
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NDDO.tar.gz
+- id: NDDRFO
+  status: OK
+  reason: ''
+  name: Neurodegenerative Disease Risk Factor Ontology
+  version: V1.0.0
+  nodecount: 934
+  edgecount: 1979
+  submission_id: '3'
+  source_bytes: 1065368
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NDDRFO.tar.gz
+- id: NDFRT
+  status: Failed
+  reason: not_downloadable
+  name: National Drug File - Reference Terminology
+  version: NDFRT_2018_02_05_18_03_05
+  nodecount: 0
+  edgecount: 0
+  submission_id: '13'
+  source_bytes: 0
+- id: NEET_
+  status: OK
+  reason: ''
+  name: NEET_Ontology_
+  version: NA
+  nodecount: 33
+  edgecount: 55
+  submission_id: '1'
+  source_bytes: 1353
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEET_.tar.gz
+- id: NEIC-ONTO
+  status: OK
+  reason: ''
+  name: Unoffical NeIC Organisation Vocabulary
+  version: 0.2.2
+  nodecount: 61
+  edgecount: 83
+  submission_id: '5'
+  source_bytes: 9531
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEIC-ONTO.tar.gz
+- id: NEICBEER
+  status: OK
+  reason: ''
+  name: The NeIC PaRI beer vocabulary
+  version: 0.1.0
+  nodecount: 90
+  edgecount: 152
+  submission_id: '1'
+  source_bytes: 11645
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEICBEER.tar.gz
+- id: NEIO
+  status: OK
+  reason: ''
+  name: Neural Electronic Interface Ontology
+  version: '2024-06-25'
+  nodecount: 537
+  edgecount: 982
+  submission_id: '3'
+  source_bytes: 554481
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEIO.tar.gz
+- id: NEMO
+  status: OK
+  reason: ''
+  name: Neural ElectroMagnetic Ontology
+  version: v3.10
+  nodecount: 2297
+  edgecount: 8001
+  submission_id: '24'
+  source_bytes: 4396395
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NEMO.tar.gz
+- id: NEO
+  status: OK
+  reason: ''
+  name: Neurologic Examination Ontology
+  version: '49.0'
+  nodecount: 1629
+  edgecount: 1614
+  submission_id: '90'
+  source_bytes: 1344926
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEO.tar.gz
+- id: NEOMARK3
+  status: OK
+  reason: ''
+  name: Neomark Oral Cancer Ontology, version 3
+  version: '3.1'
+  nodecount: 663
+  edgecount: 1115
+  submission_id: '2'
+  source_bytes: 707185
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEOMARK3.tar.gz
+- id: NEOMARK4
+  status: OK
+  reason: ''
+  name: Neomark Oral Cancer Ontology, version 4
+  version: '4.1'
+  nodecount: 702
+  edgecount: 483
+  submission_id: '1'
+  source_bytes: 667506
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEOMARK4.tar.gz
+- id: NERO
+  status: OK
+  reason: ''
+  name: 'Named Entity Recognition Ontology '
+  version: The main developer of NERO is Prof. Robert Stevens, the University of Manchester
+  nodecount: 99
+  edgecount: 115
+  submission_id: '1'
+  source_bytes: 50607
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NERO.tar.gz
+- id: NEUDIGS
+  status: OK
+  reason: ''
+  name: Neuroscience Domain Insight Graph
+  version: 0.0.1
+  nodecount: 54
+  edgecount: 34
+  submission_id: '1'
+  source_bytes: 11817
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEUDIGS.tar.gz
+- id: NEUMORE
+  status: OK
+  reason: ''
+  name: Neural Motor Recovery Ontology
+  version: '0.1'
+  nodecount: 34
+  edgecount: 24
+  submission_id: '1'
+  source_bytes: 8015
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NEUMORE.tar.gz
+- id: NEUROBRG
+  status: OK
+  reason: ''
+  name: NeuroBridge Ontology
+  version: 1.0 (Release 2023)
+  nodecount: 775
+  edgecount: 853
+  submission_id: '2'
+  source_bytes: 448146
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NEUROBRG.tar.gz
+- id: NGBO
+  status: OK
+  reason: ''
+  name: Next Generation Biobanking Ontology
+  version: '2024-08-27'
+  nodecount: 1824
+  edgecount: 2428
+  submission_id: '4'
+  source_bytes: 1413449
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NGBO.tar.gz
+- id: NGSONTO
+  status: OK
+  reason: ''
+  name: NGS ontology
+  version: '1.2'
+  nodecount: 162
+  edgecount: 165
+  submission_id: '32'
+  source_bytes: 104543
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NGSONTO.tar.gz
+- id: NHSQI2009
+  status: Failed
+  reason: no_submission
+  name: NHS Quality Indicators
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: NIC
+  status: Failed
+  reason: no_submission
+  name: Nursing Interventions Classification
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: NIDM-RESULTS
+  status: OK
+  reason: ''
+  name: NIDM-Results
+  version: Recommendation version 2013-04-30
+  nodecount: 433
+  edgecount: 900
+  submission_id: '2'
+  source_bytes: 304571
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIDM-RESULTS.tar.gz
+- id: NIFCELL
+  status: OK
+  reason: ''
+  name: Neuroscience Information Framework (NIF) Cell Ontology
+  version: v.1.10 - July 17, 2013
+  nodecount: 423
+  edgecount: 407
+  submission_id: '15'
+  source_bytes: 472097
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NIFCELL.tar.gz
+- id: NIFDYS
+  status: OK
+  reason: ''
+  name: Neuroscience Information Framework (NIF) Dysfunction Ontlogy
+  version: 1.5 (December, 2012)
+  nodecount: 422
+  edgecount: 1647
+  submission_id: '16'
+  source_bytes: 437531
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIFDYS.tar.gz
+- id: NIFSTD
+  status: OK
+  reason: ''
+  name: Neuroscience Information Framework (NIF) Standard Ontology
+  version: 3.1 - January 15, 2018
+  nodecount: 3
+  edgecount: 3
+  submission_id: '27'
+  source_bytes: 3801
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIFSTD.tar.gz
+- id: NIFSUBCELL
+  status: OK
+  reason: ''
+  name: Neuroscience Information Framework (NIF) Subcellular Ontology
+  version: 1.3 (May 2012)
+  nodecount: 468
+  edgecount: 904
+  submission_id: '1'
+  source_bytes: 551123
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NIFSUBCELL.tar.gz
+- id: NIGO
+  status: OK
+  reason: ''
+  name: Neural-Immune Gene Ontology
+  version: v1
+  nodecount: 4876
+  edgecount: 10608
+  submission_id: '2'
+  source_bytes: 2639802
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIGO.tar.gz
+- id: NIHSS
+  status: OK
+  reason: ''
+  name: National Institutes of Health Stroke Scale Ontology
+  version: 2024/06
+  nodecount: 169
+  edgecount: 119
+  submission_id: '15'
+  source_bytes: 106694
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIHSS.tar.gz
+- id: NIO
+  status: OK
+  reason: ''
+  name: Neuropsychological Integrative Ontology
+  version: 'v15
+
+    Heneka comments / shifs / modifications integrated'
+  nodecount: 5211
+  edgecount: 7269
+  submission_id: '2'
+  source_bytes: 6915565
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIO.tar.gz
+- id: NIRS
+  status: OK
+  reason: ''
+  name: Non-invasive Respiratory Support Ontology
+  version: NA
+  nodecount: 203
+  edgecount: 256
+  submission_id: '2'
+  source_bytes: 194436
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIRS.tar.gz
+- id: NIST_GEL
+  status: OK
+  reason: ''
+  name: NIST Genome Editing Lexicon
+  version: '2.2'
+  nodecount: 66
+  edgecount: 132
+  submission_id: '8'
+  source_bytes: 7524
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NIST_GEL.tar.gz
+- id: NLMVS
+  status: OK
+  reason: ''
+  name: NIH NLM Value Sets
+  version: '1.0'
+  nodecount: 75178
+  edgecount: 120543
+  submission_id: '1'
+  source_bytes: 1916020
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NLMVS.tar.gz
+- id: NLN
+  status: OK
+  reason: ''
+  name: NLighten Ontology
+  version: '2018-02-28'
+  nodecount: 240
+  edgecount: 235
+  submission_id: '1'
+  source_bytes: 171387
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NLN.tar.gz
+- id: NMDCO
+  status: Failed
+  reason: transform_error
+  name: NMDC Ontology
+  version: '2024-03-15'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '8'
+  source_bytes: 37553285
+- id: NMOBR
+  status: Failed
+  reason: transform_error
+  name: NeuroMorpho.Org brain region ontologies
+  version: '2.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '36'
+  source_bytes: 335349
+- id: NMOSP
+  status: OK
+  reason: ''
+  name: NeuroMorpho.Org species ontology
+  version: '1.3'
+  nodecount: 2090
+  edgecount: 1813
+  submission_id: '22'
+  source_bytes: 2446314
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NMOSP.tar.gz
+- id: NMR
+  status: OK
+  reason: ''
+  name: NMR-Controlled Vocabulary
+  version: 1.1.0
+  nodecount: 794
+  edgecount: 767
+  submission_id: '12'
+  source_bytes: 457554
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NMR.tar.gz
+- id: NND_CH
+  status: OK
+  reason: ''
+  name: NND_Clinical_history
+  version: '1'
+  nodecount: 127
+  edgecount: 108
+  submission_id: '2'
+  source_bytes: 218925
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NND_CH.tar.gz
+- id: NND_ND
+  status: OK
+  reason: ''
+  name: NND_Neuropathological_Diagnosis
+  version: '2023-03-31'
+  nodecount: 124
+  edgecount: 112
+  submission_id: '2'
+  source_bytes: 84663
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NND_ND.tar.gz
+- id: NOMEN
+  status: OK
+  reason: ''
+  name: NOMEN - A nomenclatural ontology for biological names
+  version: NA
+  nodecount: 390
+  edgecount: 474
+  submission_id: '17'
+  source_bytes: 178206
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NOMEN.tar.gz
+- id: NONRCTO
+  status: OK
+  reason: ''
+  name: Non-Randomized Controlled Trials Ontology
+  version: '2.0'
+  nodecount: 200
+  edgecount: 470
+  submission_id: '1'
+  source_bytes: 109843
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/NONRCTO.tar.gz
+- id: NPDX
+  status: OK
+  reason: ''
+  name: Neuropathologic Diagnoses
+  version: '1.3'
+  nodecount: 843
+  edgecount: 802
+  submission_id: '6'
+  source_bytes: 1814773
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NPDX.tar.gz
+- id: NPI
+  status: OK
+  reason: ''
+  name: Non-Pharmacological Interventions (NPIs)
+  version: Version 8
+  nodecount: 48
+  edgecount: 44
+  submission_id: '5'
+  source_bytes: 34789
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NPI.tar.gz
+- id: NPO
+  status: Failed
+  reason: transform_error
+  name: NanoParticle Ontology
+  version: 2011-12-08 (yyyy-mm-dd)
+  nodecount: 0
+  edgecount: 0
+  submission_id: '31'
+  source_bytes: 2930548
+- id: NPOKB
+  status: OK
+  reason: ''
+  name: Neuron Phenotype Ontology
+  version: '2026-03-19'
+  nodecount: 2916
+  edgecount: 5225
+  submission_id: '22'
+  source_bytes: 899857
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NPOKB.tar.gz
+- id: NRO
+  status: OK
+  reason: ''
+  name: NeuralReprogrammingOntology
+  version: 1.0.0
+  nodecount: 567
+  edgecount: 568
+  submission_id: '1'
+  source_bytes: 340903
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NRO.tar.gz
+- id: NXDX
+  status: OK
+  reason: ''
+  name: Test NXDX
+  version: 2021/8/10
+  nodecount: 474
+  edgecount: 455
+  submission_id: '1'
+  source_bytes: 765818
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NXDX.tar.gz
+- id: O-REXTECH
+  status: OK
+  reason: ''
+  name: OSIRIS-REx Analytical Technique
+  version: 0.0.2
+  nodecount: 66
+  edgecount: 253
+  submission_id: '2'
+  source_bytes: 22781
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/O-REXTECH.tar.gz
+- id: O3
+  status: OK
+  reason: ''
+  name: 'Operational Ontology for Oncology '
+  version: '2.0'
+  nodecount: 2138
+  edgecount: 3209
+  submission_id: '5'
+  source_bytes: 2372488
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/O3.tar.gz
+- id: OA
+  status: OK
+  reason: ''
+  name: Web Annotation Ontology
+  version: '2016-11-12T21:28:11Z'
+  nodecount: 82
+  edgecount: 119
+  submission_id: '4'
+  source_bytes: 30141
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OA.tar.gz
+- id: OAE
+  status: Failed
+  reason: transform_error
+  name: Ontology of Adverse Events
+  version: 1.2.54
+  nodecount: 0
+  edgecount: 0
+  submission_id: '172'
+  source_bytes: 12935408
+- id: OARCS
+  status: OK
+  reason: ''
+  name: Ontology of Arthropod Circulatory Systems
+  version: '2019-04-18'
+  nodecount: 652
+  edgecount: 565
+  submission_id: '2'
+  source_bytes: 704087
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OARCS.tar.gz
+- id: OBA
+  status: Skipped
+  reason: too_large
+  name: Ontology of Biological Attributes
+  version: '2026-07-14'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '29'
+  source_bytes: 168862854
+- id: OBCS
+  status: OK
+  reason: ''
+  name: Ontology of Biological and Clinical Statistics
+  version: '2023-12-08'
+  nodecount: 1592
+  edgecount: 3773
+  submission_id: '15'
+  source_bytes: 1880209
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBCS.tar.gz
+- id: OBEST
+  status: OK
+  reason: ''
+  name: Ontology of Bioethics and Ethics of Science & Technology
+  version: 1.0.1
+  nodecount: 1961
+  edgecount: 3717
+  submission_id: '2'
+  source_bytes: 2056549
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBEST.tar.gz
+- id: OBI
+  status: OK
+  reason: ''
+  name: Ontology for Biomedical Investigations
+  version: '2026-05-08'
+  nodecount: 7552
+  edgecount: 16102
+  submission_id: '65'
+  source_bytes: 9925991
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBI.tar.gz
+- id: OBIB
+  status: OK
+  reason: ''
+  name: Ontology for Biobanking
+  version: '2023-04-05'
+  nodecount: 2419
+  edgecount: 4499
+  submission_id: '14'
+  source_bytes: 2635524
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBIB.tar.gz
+- id: OBIWS
+  status: OK
+  reason: ''
+  name: Bioinformatics Web Service Ontology
+  version: Release v1.1
+  nodecount: 347
+  edgecount: 593
+  submission_id: '2'
+  source_bytes: 323480
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBIWS.tar.gz
+- id: OBI_BCGO
+  status: OK
+  reason: ''
+  name: Beta Cell Genomics Ontology
+  version: '2015-07-08'
+  nodecount: 2743
+  edgecount: 6407
+  submission_id: '14'
+  source_bytes: 3251596
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBI_BCGO.tar.gz
+- id: OBI_IEE
+  status: OK
+  reason: ''
+  name: 'The Ontology for Biomedical Investigation based Inner Ear Electrophysiology '
+  version: '2018-05-23'
+  nodecount: 4715
+  edgecount: 10647
+  submission_id: '1'
+  source_bytes: 6425777
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBI_IEE.tar.gz
+- id: OBOE
+  status: OK
+  reason: ''
+  name: The Extensible Observation Ontology
+  version: Version 1.2
+  nodecount: 4
+  edgecount: 3
+  submission_id: '4'
+  source_bytes: 3699
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBOE.tar.gz
+- id: OBOE-SBC
+  status: OK
+  reason: ''
+  name: Santa Barbara Coastal Observation Ontology
+  version: Version 1.0
+  nodecount: 161
+  edgecount: 159
+  submission_id: '1'
+  source_bytes: 61022
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OBOE-SBC.tar.gz
+- id: OBOREL
+  status: OK
+  reason: ''
+  name: Relations Ontology
+  version: '2025-12-17'
+  nodecount: 1234
+  edgecount: 2787
+  submission_id: '45'
+  source_bytes: 1215616
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBOREL.tar.gz
+- id: OBS
+  status: OK
+  reason: ''
+  name: OntoBioStat
+  version: NA
+  nodecount: 155
+  edgecount: 115
+  submission_id: '5'
+  source_bytes: 143851
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBS.tar.gz
+- id: OCCO
+  status: OK
+  reason: ''
+  name: Occupation Ontology
+  version: '2023-08-20'
+  nodecount: 1905
+  edgecount: 10972
+  submission_id: '5'
+  source_bytes: 5229545
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCCO.tar.gz
+- id: OCD
+  status: OK
+  reason: ''
+  name: Obsessive-Compulsive Disorder Ontology
+  version: '1.1'
+  nodecount: 6222
+  edgecount: 2960
+  submission_id: '10'
+  source_bytes: 2294062
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCD.tar.gz
+- id: OCDARREUSE
+  status: Failed
+  reason: metadata_http_error
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: OCDARV1
+  status: OK
+  reason: ''
+  name: Areej OCD Ontology V1 Original
+  version: v1-original-ncbo-ready-2026-06-18
+  nodecount: 95
+  edgecount: 102
+  submission_id: '13'
+  source_bytes: 76799
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCDARV1.tar.gz
+- id: OCDARWN
+  status: Failed
+  reason: transform_error
+  name: Areej OCD Ontology WordNet Enriched
+  version: wordnet-ncbo-ready-2026-06-18
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 14798698
+- id: OCDARWNE
+  status: Failed
+  reason: metadata_http_error
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: OCDM
+  status: OK
+  reason: ''
+  name: Ontology of Craniofacial Development and Malformation
+  version: 1.10.0
+  nodecount: 1
+  edgecount: 0
+  submission_id: '8'
+  source_bytes: 1647
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OCDM.tar.gz
+- id: OCDO
+  status: OK
+  reason: ''
+  name: OCD Ontology
+  version: NA
+  nodecount: 95
+  edgecount: 102
+  submission_id: '1'
+  source_bytes: 61688
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCDO.tar.gz
+- id: OCE
+  status: OK
+  reason: ''
+  name: Ontology of Chemical Elements
+  version: 'Vision Release: 1.0.29'
+  nodecount: 336
+  edgecount: 876
+  submission_id: '2'
+  source_bytes: 591863
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCE.tar.gz
+- id: OCHV
+  status: OK
+  reason: ''
+  name: Ontology of Consumer Health Vocabulary
+  version: '1'
+  nodecount: 171283
+  edgecount: 173460
+  submission_id: '2'
+  source_bytes: 58852191
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCHV.tar.gz
+- id: OCIMIDO
+  status: OK
+  reason: ''
+  name: Ocular Immune-Mediated Inflammatory Diseases Ontology
+  version: '1.2'
+  nodecount: 684
+  edgecount: 1654
+  submission_id: '2'
+  source_bytes: 812986
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCIMIDO.tar.gz
+- id: OCMR
+  status: OK
+  reason: ''
+  name: Ontology of Chinese Medicine for Rheumatism
+  version: Vision Release; 1.0.11
+  nodecount: 5141
+  edgecount: 16991
+  submission_id: '3'
+  source_bytes: 7366511
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCMR.tar.gz
+- id: OCO
+  status: OK
+  reason: ''
+  name: 'OpenCareOntology '
+  version: '1.1'
+  nodecount: 625
+  edgecount: 744
+  submission_id: '2'
+  source_bytes: 386135
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCO.tar.gz
+- id: OCRE
+  status: Failed
+  reason: transform_error
+  name: Ontology of Clinical Research
+  version: Revision 315
+  nodecount: 0
+  edgecount: 0
+  submission_id: '23'
+  source_bytes: 63643
+- id: OCS
+  status: OK
+  reason: ''
+  name: A Foundational Ontology for Computational Sociology
+  version: NA
+  nodecount: 2000
+  edgecount: 1220
+  submission_id: '4'
+  source_bytes: 3087261
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCS.tar.gz
+- id: OCVDAE
+  status: OK
+  reason: ''
+  name: Ontology of Cardiovascular Drug Adverse Events
+  version: Vision Release; 1.0.4
+  nodecount: 4987
+  edgecount: 19627
+  submission_id: '2'
+  source_bytes: 6732700
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCVDAE.tar.gz
+- id: OC_E
+  status: OK
+  reason: ''
+  name: OntoCaimer_Examples
+  version: NA
+  nodecount: 278
+  edgecount: 111
+  submission_id: '1'
+  source_bytes: 265593
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OC_E.tar.gz
+- id: ODAE
+  status: OK
+  reason: ''
+  name: Ontology of Drug Adverse Events
+  version: 'Vision Release: 1.0.08'
+  nodecount: 8480
+  edgecount: 19779
+  submission_id: '1'
+  source_bytes: 11724731
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ODAE.tar.gz
+- id: ODFA
+  status: OK
+  reason: ''
+  name: Ontology of Dental Care-Related Fear and Anxiety
+  version: '2026-04-03'
+  nodecount: 400
+  edgecount: 1064
+  submission_id: '6'
+  source_bytes: 475126
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ODFA.tar.gz
+- id: ODHT
+  status: OK
+  reason: ''
+  name: Digital Health Technologies
+  version: '0.2'
+  nodecount: 1394
+  edgecount: 615
+  submission_id: '2'
+  source_bytes: 541400
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ODHT.tar.gz
+- id: ODNAE
+  status: OK
+  reason: ''
+  name: Ontology of Drug Neuropathy Adverse Events
+  version: Vision Release; 1.0.13
+  nodecount: 1857
+  edgecount: 5201
+  submission_id: '3'
+  source_bytes: 2021077
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ODNAE.tar.gz
+- id: OF
+  status: OK
+  reason: ''
+  name: OntoFood
+  version: '1.0'
+  nodecount: 550
+  edgecount: 350
+  submission_id: '1'
+  source_bytes: 679358
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OF.tar.gz
+- id: OFDSIPT
+  status: OK
+  reason: ''
+  name: Ontology for Data Science in Practice (trial)
+  version: NA
+  nodecount: 81
+  edgecount: 61
+  submission_id: '1'
+  source_bytes: 34660
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OFDSIPT.tar.gz
+- id: OFL
+  status: OK
+  reason: ''
+  name: A comprehensive ontology of flaps in reconstructive surgery
+  version: 2.1.0
+  nodecount: 2354
+  edgecount: 2636
+  submission_id: '3'
+  source_bytes: 1379498
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OFL.tar.gz
+- id: OFSMR
+  status: OK
+  reason: ''
+  name: Open Predictive Microbiology Ontology
+  version: '0.4'
+  nodecount: 174
+  edgecount: 156
+  submission_id: '19'
+  source_bytes: 352740
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OFSMR.tar.gz
+- id: OGCO
+  status: OK
+  reason: ''
+  name: OriGinal Chemical Ontology
+  version: NA
+  nodecount: 8790
+  edgecount: 9939
+  submission_id: '1'
+  source_bytes: 3997608
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGCO.tar.gz
+- id: OGDI
+  status: OK
+  reason: ''
+  name: Ontology for Genetic Disease Investigations
+  version: '1.0'
+  nodecount: 813
+  edgecount: 610
+  submission_id: '3'
+  source_bytes: 300920
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OGDI.tar.gz
+- id: OGG
+  status: Skipped
+  reason: too_large
+  name: Ontology of Genes and Genomes
+  version: 'Vision Release: 1.0.59'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 127956460
+- id: OGG-MM
+  status: Skipped
+  reason: too_large
+  name: Ontology of Genes and Genomes - Mouse
+  version: 'Vision Release: 1.0.66'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 128722565
+- id: OGI
+  status: OK
+  reason: ''
+  name: Ontology for Genetic Interval
+  version: '2.0'
+  nodecount: 262
+  edgecount: 305
+  submission_id: '18'
+  source_bytes: 107641
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OGI.tar.gz
+- id: OGMD
+  status: OK
+  reason: ''
+  name: Ontology of Glucose Metabolism Disorder
+  version: '1'
+  nodecount: 145
+  edgecount: 133
+  submission_id: '46'
+  source_bytes: 16157
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGMD.tar.gz
+- id: OGMS
+  status: OK
+  reason: ''
+  name: Ontology for General Medical Science
+  version: '2021-08-19'
+  nodecount: 283
+  edgecount: 292
+  submission_id: '22'
+  source_bytes: 298806
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGMS.tar.gz
+- id: OGR
+  status: OK
+  reason: ''
+  name: Ontology of Geographical Region
+  version: '1.1'
+  nodecount: 40
+  edgecount: 38
+  submission_id: '2'
+  source_bytes: 10723
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGR.tar.gz
+- id: OGROUP
+  status: OK
+  reason: ''
+  name: Orthologous Group Ontology
+  version: '1.0'
+  nodecount: 56
+  edgecount: 43
+  submission_id: '1'
+  source_bytes: 16341
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGROUP.tar.gz
+- id: OGSF
+  status: OK
+  reason: ''
+  name: Ontology for Genetic Susceptibility Factor
+  version: '2.0'
+  nodecount: 693
+  edgecount: 1369
+  submission_id: '11'
+  source_bytes: 565149
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGSF.tar.gz
+- id: OHD
+  status: OK
+  reason: ''
+  name: The Oral Health and Disease Ontology
+  version: '2026-03-16'
+  nodecount: 2325
+  edgecount: 7280
+  submission_id: '9'
+  source_bytes: 3730440
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHD.tar.gz
+- id: OHMI
+  status: OK
+  reason: ''
+  name: Ontology of Host-Microbe Interactions
+  version: '2026-05-14'
+  nodecount: 2652
+  edgecount: 5277
+  submission_id: '30'
+  source_bytes: 3113369
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHMI.tar.gz
+- id: OHPI
+  status: OK
+  reason: ''
+  name: Ontology of Host-Pathogen Interactions
+  version: 1.0.26
+  nodecount: 14180
+  edgecount: 41474
+  submission_id: '11'
+  source_bytes: 29024306
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHPI.tar.gz
+- id: OLAM
+  status: OK
+  reason: ''
+  name: Ontology of Laboratory Animal Medicine
+  version: 'Vision Release: 1.0.20'
+  nodecount: 496
+  edgecount: 1113
+  submission_id: '7'
+  source_bytes: 539735
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OLAM.tar.gz
+- id: OLAS
+  status: OK
+  reason: ''
+  name: Ontology of Laboratory Animal Science
+  version: '2025-12-22'
+  nodecount: 96514
+  edgecount: 183430
+  submission_id: '3'
+  source_bytes: 77360789
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OLAS.tar.gz
+- id: OLATDV
+  status: OK
+  reason: ''
+  name: Medaka Developmental Stages
+  version: NA
+  nodecount: 64
+  edgecount: 91
+  submission_id: '174'
+  source_bytes: 131668
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OLATDV.tar.gz
+- id: OM
+  status: OK
+  reason: ''
+  name: Ontology of units of Measure
+  version: 2.0.59
+  nodecount: 2754
+  edgecount: 1165
+  submission_id: '33'
+  source_bytes: 2008552
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OM.tar.gz
+- id: OMCO
+  status: OK
+  reason: ''
+  name: OligoMetastatic Cancer Ontology
+  version: NA
+  nodecount: 15884
+  edgecount: 72411
+  submission_id: '1'
+  source_bytes: 66131745
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMCO.tar.gz
+- id: OMIM
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: OMIT
+  status: OK
+  reason: ''
+  name: Ontology for MicroRNA Target
+  version: OBO 4.0-12122013-2338
+  nodecount: 87856
+  edgecount: 97760
+  submission_id: '41'
+  source_bytes: 34847272
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMIT.tar.gz
+- id: OMO
+  status: OK
+  reason: ''
+  name: OBO Metadata Ontology
+  version: NA
+  nodecount: 118
+  edgecount: 67
+  submission_id: '1'
+  source_bytes: 75977
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMO.tar.gz
+- id: OMP
+  status: OK
+  reason: ''
+  name: Ontology of Microbial Phenotypes
+  version: releases/2019-06-07
+  nodecount: 2445
+  edgecount: 3815
+  submission_id: '46'
+  source_bytes: 4511122
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMP.tar.gz
+- id: OMRSE
+  status: OK
+  reason: ''
+  name: Ontology for Modeling and Representation of Social Entities
+  version: '2026-07-08'
+  nodecount: 1399
+  edgecount: 1341
+  submission_id: '70'
+  source_bytes: 1212146
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMRSE.tar.gz
+- id: OMV
+  status: OK
+  reason: ''
+  name: Ontology Metadata Vocabulary
+  version: 2.4.1
+  nodecount: 133
+  edgecount: 240
+  submission_id: '1'
+  source_bytes: 100595
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMV.tar.gz
+- id: ONE
+  status: OK
+  reason: ''
+  name: Ontology for Nutritional Epidemiology
+  version: V2.2
+  nodecount: 125
+  edgecount: 102
+  submission_id: '9'
+  source_bytes: 81100
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONE.tar.gz
+- id: ONL-DP
+  status: OK
+  reason: ''
+  name: Dataset processing
+  version: V1
+  nodecount: 135
+  edgecount: 135
+  submission_id: '1'
+  source_bytes: 88604
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONL-DP.tar.gz
+- id: ONL-MR-DA
+  status: OK
+  reason: ''
+  name: Magnetic Resonance Dataset Acquisition Ontology
+  version: V1
+  nodecount: 266
+  edgecount: 250
+  submission_id: '1'
+  source_bytes: 206153
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONL-MR-DA.tar.gz
+- id: ONL-MSA
+  status: OK
+  reason: ''
+  name: Mental State Assessment
+  version: v1
+  nodecount: 1060
+  edgecount: 1499
+  submission_id: '1'
+  source_bytes: 1009643
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONL-MSA.tar.gz
+- id: ONL-TASKS
+  status: OK
+  reason: ''
+  name: Cognitive Reserves Assessment Tasks
+  version: NA
+  nodecount: 48
+  edgecount: 47
+  submission_id: '1'
+  source_bytes: 19264
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONL-TASKS.tar.gz
+- id: ONLIRA
+  status: OK
+  reason: ''
+  name: Ontology of Liver for Radiology
+  version: 'changes
+
+    * Segments and Regions are modelling as Classes in order to identify which patient
+    (liver) they belong to.
+
+    * Redundant restrictions are removed
+
+    '
+  nodecount: 123
+  edgecount: 211
+  submission_id: '4'
+  source_bytes: 126914
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONLIRA.tar.gz
+- id: ONS
+  status: OK
+  reason: ''
+  name: Ontology for Nutritional Studies
+  version: '2026-02-06'
+  nodecount: 5129
+  edgecount: 13920
+  submission_id: '39'
+  source_bytes: 2915689
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONS.tar.gz
+- id: ONSTR
+  status: OK
+  reason: ''
+  name: Ontology for Newborn Screening Follow-up and Translational Research
+  version: '0.4'
+  nodecount: 2172
+  edgecount: 2232
+  submission_id: '5'
+  source_bytes: 4404854
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ONSTR.tar.gz
+- id: ONTOAD
+  status: OK
+  reason: ''
+  name: Bilingual Ontology of Alzheimer's Disease and Related Diseases
+  version: '1.0'
+  nodecount: 6100
+  edgecount: 8477
+  submission_id: '2'
+  source_bytes: 5774925
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOAD.tar.gz
+- id: ONTOAVIDA
+  status: OK
+  reason: ''
+  name: 'OntoAvida: ontology for Avida digital evolution platform'
+  version: NA
+  nodecount: 741
+  edgecount: 807
+  submission_id: '3'
+  source_bytes: 472853
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOAVIDA.tar.gz
+- id: ONTODM-ALGORITHM
+  status: OK
+  reason: ''
+  name: OntoDM-core/algorithms
+  version: '0.1'
+  nodecount: 391
+  edgecount: 388
+  submission_id: '2'
+  source_bytes: 204234
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTODM-ALGORITHM.tar.gz
+- id: ONTODM-CORE
+  status: OK
+  reason: ''
+  name: Ontology of Core Data Mining Entities
+  version: '2.0'
+  nodecount: 1362
+  edgecount: 1401
+  submission_id: '9'
+  source_bytes: 1070046
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ONTODM-CORE.tar.gz
+- id: ONTODM-KDD
+  status: OK
+  reason: ''
+  name: Ontology of Data Mining Investigations
+  version: '0.1'
+  nodecount: 326
+  edgecount: 563
+  submission_id: '1'
+  source_bytes: 407203
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTODM-KDD.tar.gz
+- id: ONTODT
+  status: OK
+  reason: ''
+  name: Ontology of Datatypes
+  version: '2.0'
+  nodecount: 422
+  edgecount: 833
+  submission_id: '9'
+  source_bytes: 326790
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ONTODT.tar.gz
+- id: ONTOKBCF
+  status: OK
+  reason: ''
+  name: Ontological Knowledge Base Model for Cystic Fibrosis
+  version: '1301'
+  nodecount: 458
+  edgecount: 802
+  submission_id: '3'
+  source_bytes: 245162
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOKBCF.tar.gz
+- id: ONTOLURGENCES
+  status: OK
+  reason: ''
+  name: Emergency care ontology
+  version: 3.0.4
+  nodecount: 10140
+  edgecount: 12289
+  submission_id: '1'
+  source_bytes: 7820719
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOLURGENCES.tar.gz
+- id: ONTOMA
+  status: OK
+  reason: ''
+  name: Ontology of Alternative Medicine, French
+  version: 'Version 1.1Date: 11-2011'
+  nodecount: 464
+  edgecount: 373
+  submission_id: '1'
+  source_bytes: 90052
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOMA.tar.gz
+- id: ONTONEO
+  status: OK
+  reason: ''
+  name: Obstetric and Neonatal Ontology
+  version: '2025-03-14'
+  nodecount: 2348
+  edgecount: 3316
+  submission_id: '15'
+  source_bytes: 2176503
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTONEO.tar.gz
+- id: ONTONEPHRO
+  status: OK
+  reason: ''
+  name: Nephrology Ontology in order to index MOOC
+  version: '2.0'
+  nodecount: 8103
+  edgecount: 9053
+  submission_id: '2'
+  source_bytes: 6144613
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTONEPHRO.tar.gz
+- id: ONTOPARON
+  status: OK
+  reason: ''
+  name: Ontology of Amyotrophic Lateral Sclerosis, all modules
+  version: '1.1'
+  nodecount: 2518
+  edgecount: 3007
+  submission_id: '9'
+  source_bytes: 1839723
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOPARON.tar.gz
+- id: ONTOPARON_SOCIAL
+  status: OK
+  reason: ''
+  name: Ontology of amyotrophic  lateral sclerosis, social module
+  version: '1.0'
+  nodecount: 1307
+  edgecount: 1377
+  submission_id: '12'
+  source_bytes: 762707
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOPARON_SOCIAL.tar.gz
+- id: ONTOPBM
+  status: OK
+  reason: ''
+  name: Ontology for Process-Based Modeling of Dynamical Systems (OntoPBM)
+  version: '0.1'
+  nodecount: 274
+  edgecount: 342
+  submission_id: '13'
+  source_bytes: 123143
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOPBM.tar.gz
+- id: ONTOPNEUMO
+  status: OK
+  reason: ''
+  name: Ontology of Pneumology
+  version: '0.1'
+  nodecount: 1190
+  edgecount: 1165
+  submission_id: '1'
+  source_bytes: 525115
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOPNEUMO.tar.gz
+- id: ONTOPSYCARE
+  status: Failed
+  reason: transform_error
+  name: Ontology developed during PsyCARE project
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 9546159
+- id: ONTOPSYCHIA
+  status: OK
+  reason: ''
+  name: OntoPsychia, social module
+  version: '1.0'
+  nodecount: 1956
+  edgecount: 2553
+  submission_id: '2'
+  source_bytes: 1335712
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ONTOPSYCHIA.tar.gz
+- id: ONTOREPLICOV
+  status: OK
+  reason: ''
+  name: OntoRepliCov
+  version: '0'
+  nodecount: 120
+  edgecount: 147
+  submission_id: '1'
+  source_bytes: 63768
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOREPLICOV.tar.gz
+- id: ONTOSIM
+  status: Failed
+  reason: transform_error
+  name: The Ontology of Information System on Mortality
+  version: 1.0.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 73431
+- id: ONTOSINASC
+  status: Failed
+  reason: transform_error
+  name: Ontology of Information System on Live Births
+  version: 1.0.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 55292
+- id: ONTOSPM
+  status: Failed
+  reason: transform_error
+  name: Ontology Surgical Process Model
+  version: '14062016'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 255380
+- id: ONTOSTAR
+  status: OK
+  reason: ''
+  name: Digital e-health startup Ontology
+  version: NA
+  nodecount: 216
+  edgecount: 213
+  submission_id: '1'
+  source_bytes: 84838
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOSTAR.tar.gz
+- id: ONTOTOX
+  status: OK
+  reason: ''
+  name: Chemotherapy Toxicities Ontology
+  version: '1.0'
+  nodecount: 31
+  edgecount: 41
+  submission_id: '1'
+  source_bytes: 5356
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOTOX.tar.gz
+- id: ONTOTOXNUC
+  status: OK
+  reason: ''
+  name: Ontology of Nuclear Toxicity
+  version: '1.0'
+  nodecount: 658
+  edgecount: 647
+  submission_id: '4'
+  source_bytes: 263481
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOTOXNUC.tar.gz
+- id: ONTRISCAL
+  status: OK
+  reason: ''
+  name: Ontology of Risk Stratification in Mental Health
+  version: '1.0'
+  nodecount: 370
+  edgecount: 403
+  submission_id: '1'
+  source_bytes: 130132
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTRISCAL.tar.gz
+- id: ONVOC
+  status: OK
+  reason: ''
+  name: OpenNeuro Vocabulary
+  version: 1.0.0
+  nodecount: 761
+  edgecount: 2300
+  submission_id: '9'
+  source_bytes: 386863
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONVOC.tar.gz
+- id: OOEVV
+  status: OK
+  reason: ''
+  name: Ontology of Experimental Variables and Values
+  version: 0.0.4
+  nodecount: 94
+  edgecount: 125
+  submission_id: '4'
+  source_bytes: 58386
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OOEVV.tar.gz
+- id: OOSTT
+  status: OK
+  reason: ''
+  name: Ontology of Organizational Structures of Trauma centers and Trauma systems
+  version: release version - 2025-01-24
+  nodecount: 1117
+  edgecount: 1178
+  submission_id: '14'
+  source_bytes: 759414
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OOSTT.tar.gz
+- id: OPB
+  status: OK
+  reason: ''
+  name: Ontology of Physics for Biology
+  version: '1.2'
+  nodecount: 945
+  edgecount: 977
+  submission_id: '18'
+  source_bytes: 570311
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPB.tar.gz
+- id: OPD-NAMBOBI
+  status: Failed
+  reason: transform_error
+  name: SELECTED OTHER PRIORITY DISEASES UNDER IDSR (INTEGRATED DISEASE SURVEILLANCE
+    AND RESPONSES)
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 9125
+- id: OPDE
+  status: OK
+  reason: ''
+  name: OPD-Ethiopia
+  version: NA
+  nodecount: 132
+  edgecount: 234
+  submission_id: '1'
+  source_bytes: 19517
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPDE.tar.gz
+- id: OPDRE
+  status: OK
+  reason: ''
+  name: OPD Regitry Ethiopia
+  version: 0.0.1
+  nodecount: 127
+  edgecount: 124
+  submission_id: '1'
+  source_bytes: 15321
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPDRE.tar.gz
+- id: OPDRONT
+  status: OK
+  reason: ''
+  name: OPD Register Ontology
+  version: 0.0.1
+  nodecount: 48
+  edgecount: 81
+  submission_id: '2'
+  source_bytes: 8327
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPDRONT.tar.gz
+- id: OPDT
+  status: OK
+  reason: ''
+  name: opd_test
+  version: NA
+  nodecount: 25
+  edgecount: 22
+  submission_id: '1'
+  source_bytes: 3105
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPDT.tar.gz
+- id: OPDZIMBABWE
+  status: OK
+  reason: ''
+  name: OPDZimbabwe
+  version: '1.1'
+  nodecount: 25
+  edgecount: 11
+  submission_id: '1'
+  source_bytes: 3092
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPDZIMBABWE.tar.gz
+- id: OPE
+  status: OK
+  reason: ''
+  name: Ontology of Physical Exercises
+  version: 0.0.1
+  nodecount: 666
+  edgecount: 713
+  submission_id: '6'
+  source_bytes: 1030814
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OPE.tar.gz
+- id: OPL
+  status: OK
+  reason: ''
+  name: Ontology for Parasite LifeCycle
+  version: '2023-08-28'
+  nodecount: 745
+  edgecount: 1839
+  submission_id: '11'
+  source_bytes: 941059
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPL.tar.gz
+- id: OPMI
+  status: OK
+  reason: ''
+  name: Ontology of Precision Medicine and Investigation
+  version: 'Vision Release: 1.0.166'
+  nodecount: 4201
+  edgecount: 10056
+  submission_id: '27'
+  source_bytes: 4188480
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPMI.tar.gz
+- id: OPTIMAL
+  status: OK
+  reason: ''
+  name: 'OPTImAL: An ontology for patient adherence modeling in physical activity
+    domain'
+  version: '1'
+  nodecount: 526
+  edgecount: 1781
+  submission_id: '1'
+  source_bytes: 934083
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPTIMAL.tar.gz
+- id: OPTION-ONTOLOGY
+  status: OK
+  reason: ''
+  name: Optimization Algorithm Benchmarking Ontology
+  version: 1.0.0
+  nodecount: 152
+  edgecount: 183
+  submission_id: '3'
+  source_bytes: 74593
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPTION-ONTOLOGY.tar.gz
+- id: ORCS
+  status: OK
+  reason: ''
+  name: Ontology for Representing CDM Semantics
+  version: '2021-11-13'
+  nodecount: 2016
+  edgecount: 3399
+  submission_id: '1'
+  source_bytes: 2187044
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORCS.tar.gz
+- id: ORDO
+  status: OK
+  reason: ''
+  name: Orphanet Rare Disease Ontology
+  version: '4.9'
+  nodecount: 16393
+  edgecount: 52455
+  submission_id: '33'
+  source_bytes: 52467529
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORDO.tar.gz
+- id: OREX-SAM
+  status: OK
+  reason: ''
+  name: OSIRIS-REx sample type
+  version: 0.2.0
+  nodecount: 37
+  edgecount: 99
+  submission_id: '1'
+  source_bytes: 15016
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OREX-SAM.tar.gz
+- id: OREX-WG
+  status: OK
+  reason: ''
+  name: OSIRIS-REx sample analysis workgroups
+  version: 0.1.0
+  nodecount: 19
+  edgecount: 33
+  submission_id: '1'
+  source_bytes: 3878
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OREX-WG.tar.gz
+- id: ORNASEQ
+  status: OK
+  reason: ''
+  name: Ontology of RNA Sequencing
+  version: NA
+  nodecount: 203
+  edgecount: 332
+  submission_id: '1'
+  source_bytes: 166036
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORNASEQ.tar.gz
+- id: ORTH
+  status: OK
+  reason: ''
+  name: Orthology Ontology
+  version: '2.0'
+  nodecount: 122
+  edgecount: 133
+  submission_id: '7'
+  source_bytes: 90527
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORTH.tar.gz
+- id: OSDI
+  status: OK
+  reason: ''
+  name: Ontology for the Simulation of Diseases
+  version: '1.0'
+  nodecount: 291
+  edgecount: 502
+  submission_id: '2'
+  source_bytes: 205537
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OSDI.tar.gz
+- id: OTO
+  status: Failed
+  reason: no_submission
+  name: ' Obesity Tracking Ontology'
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: OVAE
+  status: OK
+  reason: ''
+  name: Ontology of Vaccine Adverse Events
+  version: 'Vision Release: 1.0.34'
+  nodecount: 3350
+  edgecount: 8403
+  submission_id: '10'
+  source_bytes: 3945072
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OVAE.tar.gz
+- id: OntoVIP
+  status: OK
+  reason: ''
+  name: Medical image simulation
+  version: v1
+  nodecount: 3
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 6159
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OntoVIP.tar.gz
+- id: PACO
+  status: OK
+  reason: ''
+  name: Physical Activity Ontology
+  version: '0.2'
+  nodecount: 340
+  edgecount: 469
+  submission_id: '2'
+  source_bytes: 278015
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PACO.tar.gz
+- id: PAE
+  status: OK
+  reason: ''
+  name: Plant Anatomy
+  version: 'Release #20'
+  nodecount: 1606
+  edgecount: 3628
+  submission_id: '13'
+  source_bytes: 924184
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PAE.tar.gz
+- id: PAIN
+  status: OK
+  reason: ''
+  name: The Pain Ontology
+  version: '2026-07-03'
+  nodecount: 674
+  edgecount: 1734
+  submission_id: '8'
+  source_bytes: 880901
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PAIN.tar.gz
+- id: PAINO
+  status: Failed
+  reason: not_downloadable
+  name: Pain Ontology
+  version: 1.0.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: PANDA
+  status: OK
+  reason: ''
+  name: Probabilistic Knowledge Assembly Ontology
+  version: '0.9'
+  nodecount: 150
+  edgecount: 102
+  submission_id: '2'
+  source_bytes: 50543
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PANDA.tar.gz
+- id: PANET
+  status: OK
+  reason: ''
+  name: PaN Experimental technique
+  version: 1.3.0
+  nodecount: 529
+  edgecount: 1075
+  submission_id: '27'
+  source_bytes: 341600
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PANET.tar.gz
+- id: PARTUMDO
+  status: OK
+  reason: ''
+  name: postpartum depression ontology
+  version: NA
+  nodecount: 5629
+  edgecount: 1273
+  submission_id: '1'
+  source_bytes: 5054282
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PARTUMDO.tar.gz
+- id: PATAXO
+  status: OK
+  reason: ''
+  name: Technical Taxonomies for Patents
+  version: 1.0.0
+  nodecount: 4876
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 1053512
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATAXO.tar.gz
+- id: PATCT
+  status: OK
+  reason: ''
+  name: Placental Cell Type
+  version: '1.0'
+  nodecount: 161
+  edgecount: 159
+  submission_id: '1'
+  source_bytes: 408336
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATCT.tar.gz
+- id: PATEL
+  status: OK
+  reason: ''
+  name: Archana Patel
+  version: '1'
+  nodecount: 195
+  edgecount: 152
+  submission_id: '1'
+  source_bytes: 67702
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATEL.tar.gz
+- id: PATGV
+  status: OK
+  reason: ''
+  name: Placental Genetic Variance
+  version: '1.0'
+  nodecount: 89
+  edgecount: 80
+  submission_id: '1'
+  source_bytes: 510868
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATGV.tar.gz
+- id: PATHLEX
+  status: OK
+  reason: ''
+  name: Anatomic Pathology Lexicon
+  version: '1.2'
+  nodecount: 1792
+  edgecount: 1784
+  submission_id: '5'
+  source_bytes: 828959
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATHLEX.tar.gz
+- id: PATIT
+  status: OK
+  reason: ''
+  name: Placental Investigative Technique
+  version: '1.0'
+  nodecount: 156
+  edgecount: 155
+  submission_id: '1'
+  source_bytes: 686043
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATIT.tar.gz
+- id: PATMHC
+  status: OK
+  reason: ''
+  name: Placental Maternal Health Conditions
+  version: '1.0'
+  nodecount: 253
+  edgecount: 254
+  submission_id: '1'
+  source_bytes: 1698315
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATMHC.tar.gz
+- id: PATO
+  status: OK
+  reason: ''
+  name: Phenotypic Quality Ontology
+  version: '2025-05-14'
+  nodecount: 9032
+  edgecount: 31234
+  submission_id: '207'
+  source_bytes: 21082041
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATO.tar.gz
+- id: PAV
+  status: OK
+  reason: ''
+  name: PAV Provenance, Authoring and Versioning
+  version: 2.3.1
+  nodecount: 91
+  edgecount: 177
+  submission_id: '3'
+  source_bytes: 58630
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PAV.tar.gz
+- id: PAYMENTMODE
+  status: OK
+  reason: ''
+  name: Payment Mode
+  version: NA
+  nodecount: 24
+  edgecount: 27
+  submission_id: '1'
+  source_bytes: 3136
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PAYMENTMODE.tar.gz
+- id: PAYOR
+  status: OK
+  reason: ''
+  name: Payor
+  version: NA
+  nodecount: 23
+  edgecount: 23
+  submission_id: '1'
+  source_bytes: 2599
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PAYOR.tar.gz
+- id: PBO
+  status: OK
+  reason: ''
+  name: Plant Breeding Ontology
+  version: NA
+  nodecount: 2276
+  edgecount: 2267
+  submission_id: '4'
+  source_bytes: 253508
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PBO.tar.gz
+- id: PBPKO
+  status: OK
+  reason: ''
+  name: Physiologically-Based Pharmacokinetic ontology
+  version: '2026-07-15'
+  nodecount: 1541
+  edgecount: 5226
+  submission_id: '6'
+  source_bytes: 2132866
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PBPKO.tar.gz
+- id: PCALION
+  status: OK
+  reason: ''
+  name: Prostate Cancer Lifestyle Ontology
+  version: '3.0'
+  nodecount: 474
+  edgecount: 455
+  submission_id: '6'
+  source_bytes: 765818
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PCALION.tar.gz
+- id: PCAO
+  status: OK
+  reason: ''
+  name: Prostate Cancer Ontology
+  version: '2.0'
+  nodecount: 674
+  edgecount: 684
+  submission_id: '2'
+  source_bytes: 699748
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PCAO.tar.gz
+- id: PCL
+  status: Skipped
+  reason: too_large
+  name: Provisional Cell Ontology
+  version: '2025-07-07'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '25'
+  source_bytes: 167561057
+- id: PCMO
+  status: OK
+  reason: ''
+  name: 'Pediatric Consultation and Monitoring Ontology '
+  version: v.4.0
+  nodecount: 278
+  edgecount: 84
+  submission_id: '2'
+  source_bytes: 429237
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PCMO.tar.gz
+- id: PCO
+  status: OK
+  reason: ''
+  name: Population and Community Ontology
+  version: '2013-10-03'
+  nodecount: 558
+  edgecount: 1052
+  submission_id: '17'
+  source_bytes: 595304
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PCO.tar.gz
+- id: PDO
+  status: OK
+  reason: ''
+  name: Pathogenic Disease Ontology
+  version: Version 0.7
+  nodecount: 406
+  edgecount: 426
+  submission_id: '6'
+  source_bytes: 473127
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDO.tar.gz
+- id: PDON
+  status: OK
+  reason: ''
+  name: Parkinson's Disease Ontology
+  version: '1.0'
+  nodecount: 650
+  edgecount: 1252
+  submission_id: '1'
+  source_bytes: 984616
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDON.tar.gz
+- id: PDO_CAS
+  status: OK
+  reason: ''
+  name: Plant Diversity Ontology
+  version: NA
+  nodecount: 12628
+  edgecount: 869
+  submission_id: '1'
+  source_bytes: 4899713
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDO_CAS.tar.gz
+- id: PDQ
+  status: OK
+  reason: ''
+  name: Physician Data Query
+  version: PDQ_2018_10_27
+  nodecount: 13474
+  edgecount: 4420
+  submission_id: '16'
+  source_bytes: 19445103
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDQ.tar.gz
+- id: PDRO
+  status: OK
+  reason: ''
+  name: The Prescription of Drugs Ontology
+  version: '2026-06-09'
+  nodecount: 649
+  edgecount: 1456
+  submission_id: '11'
+  source_bytes: 787015
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDRO.tar.gz
+- id: PDUMDV
+  status: OK
+  reason: ''
+  name: Platynereis Developmental Stages
+  version: NA
+  nodecount: 40
+  edgecount: 42
+  submission_id: '175'
+  source_bytes: 73212
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDUMDV.tar.gz
+- id: PE
+  status: OK
+  reason: ''
+  name: Pulmonary Embolism Ontology
+  version: version 1.0
+  nodecount: 99
+  edgecount: 127
+  submission_id: '1'
+  source_bytes: 37990
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PE.tar.gz
+- id: PE-O
+  status: OK
+  reason: ''
+  name: Pre-eclampsia Ontology
+  version: 'v15
+
+    Heneka comments / shifs / modifications integrated'
+  nodecount: 1286
+  edgecount: 1494
+  submission_id: '3'
+  source_bytes: 664984
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PE-O.tar.gz
+- id: PEAO
+  status: OK
+  reason: ''
+  name: Plant Experimental Assay Ontology
+  version: NA
+  nodecount: 219
+  edgecount: 300
+  submission_id: '4'
+  source_bytes: 124810
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PEAO.tar.gz
+- id: PECO
+  status: Failed
+  reason: transform_error
+  name: Plant Experimental Conditions Ontology
+  version: v2025-12-02
+  nodecount: 0
+  edgecount: 0
+  submission_id: '33'
+  source_bytes: 422850
+- id: PEDTERM
+  status: OK
+  reason: ''
+  name: Pediatric Terminology
+  version: Version 2.0
+  nodecount: 1780
+  edgecount: 1760
+  submission_id: '5'
+  source_bytes: 1868186
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PEDTERM.tar.gz
+- id: PEO
+  status: OK
+  reason: ''
+  name: Parasite Experiment Ontology
+  version: '1'
+  nodecount: 224
+  edgecount: 252
+  submission_id: '5'
+  source_bytes: 106321
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PEO.tar.gz
+- id: PEO_ONTOLOGY
+  status: Failed
+  reason: transform_error
+  name: Prompt Engineering Ontology
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 335597
+- id: PESONT
+  status: OK
+  reason: ''
+  name: Preposition_enabled Spatial Ontology
+  version: NA
+  nodecount: 224
+  edgecount: 157
+  submission_id: '1'
+  source_bytes: 67645
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PESONT.tar.gz
+- id: PGHD-BP
+  status: OK
+  reason: ''
+  name: PGHD Auxillary - BP
+  version: '1.1'
+  nodecount: 35
+  edgecount: 72
+  submission_id: '2'
+  source_bytes: 7901
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PGHD-BP.tar.gz
+- id: PGHDPROV
+  status: OK
+  reason: ''
+  name: 'PGHDProvo: Context and Provenance Based Standardized Patient Generated Health
+    Data Shared with an Electronic Health Record'
+  version: '1.0'
+  nodecount: 163
+  edgecount: 258
+  submission_id: '4'
+  source_bytes: 81404
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PGHDPROV.tar.gz
+- id: PGHD_CONNECT
+  status: OK
+  reason: ''
+  name: PGHD_CONNECT
+  version: '1.0'
+  nodecount: 33
+  edgecount: 57
+  submission_id: '1'
+  source_bytes: 6764
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PGHD_CONNECT.tar.gz
+- id: PGXO
+  status: OK
+  reason: ''
+  name: PGxO
+  version: v0.6.1
+  nodecount: 59
+  edgecount: 64
+  submission_id: '5'
+  source_bytes: 21064
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PGXO.tar.gz
+- id: PHAGE
+  status: OK
+  reason: ''
+  name: Phylogenetics Ontology
+  version: '5.0'
+  nodecount: 153
+  edgecount: 194
+  submission_id: '5'
+  source_bytes: 65486
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHAGE.tar.gz
+- id: PHARE
+  status: OK
+  reason: ''
+  name: Pharmacogenomic Relationships Ontology
+  version: 'version id: 110114'
+  nodecount: 317
+  edgecount: 456
+  submission_id: '2'
+  source_bytes: 200518
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHARE.tar.gz
+- id: PHARMGKB
+  status: Failed
+  reason: no_submission
+  name: PharmGKB Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: PHASES
+  status: OK
+  reason: ''
+  name: Promoting Health Aging through Semantic Enrichment of Solitude Research
+  version: '2026-02-25'
+  nodecount: 314
+  edgecount: 793
+  submission_id: '3'
+  source_bytes: 332882
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHASES.tar.gz
+- id: PHENOMEBLAST
+  status: Failed
+  reason: no_submission
+  name: PhenomeBLAST Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: PHENX
+  status: Failed
+  reason: transform_error
+  name: PhenX Phenotypic Terms
+  version: '1.2'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '16'
+  source_bytes: 576371
+- id: PHFUMIADO
+  status: OK
+  reason: ''
+  name: Phallusia fumigata Anatomy and Development Ontology
+  version: NA
+  nodecount: 899
+  edgecount: 4735
+  submission_id: '2'
+  source_bytes: 353359
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHFUMIADO.tar.gz
+- id: PHIPO
+  status: OK
+  reason: ''
+  name: Pathogen Host Interaction Phenotype Ontology
+  version: '2026-03-12'
+  nodecount: 12086
+  edgecount: 40085
+  submission_id: '33'
+  source_bytes: 31176283
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHIPO.tar.gz
+- id: PHMAMMADO
+  status: OK
+  reason: ''
+  name: Phallusia mammillata Anatomy and Development Ontology
+  version: NA
+  nodecount: 899
+  edgecount: 4735
+  submission_id: '2'
+  source_bytes: 353361
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHMAMMADO.tar.gz
+- id: PHY
+  status: OK
+  reason: ''
+  name: physiotherapy
+  version: 0.0.2
+  nodecount: 44
+  edgecount: 38
+  submission_id: '2'
+  source_bytes: 14412
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHY.tar.gz
+- id: PHYLONT
+  status: OK
+  reason: ''
+  name: Phylogenetic Ontology
+  version: ver8
+  nodecount: 198
+  edgecount: 221
+  submission_id: '7'
+  source_bytes: 139767
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHYLONT.tar.gz
+- id: PICO
+  status: OK
+  reason: ''
+  name: Pathogen-related Informed Consent Ontology
+  version: 1.0.0
+  nodecount: 524
+  edgecount: 656
+  submission_id: '3'
+  source_bytes: 447908
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PICO.tar.gz
+- id: PIERO
+  status: OK
+  reason: ''
+  name: Enzyme Reaction Ontology for annotating Partial Information of chemical transformation
+  version: NA
+  nodecount: 147
+  edgecount: 378
+  submission_id: '10'
+  source_bytes: 69428
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PIERO.tar.gz
+- id: PINO
+  status: OK
+  reason: ''
+  name: Pregnancy Information Needs Ontology
+  version: '1.1'
+  nodecount: 268
+  edgecount: 271
+  submission_id: '2'
+  source_bytes: 121317
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PINO.tar.gz
+- id: PLANA
+  status: OK
+  reason: ''
+  name: Planarian Anatomy and Developmental Stage Ontolgoy
+  version: '2023-03-13'
+  nodecount: 1488
+  edgecount: 4198
+  submission_id: '36'
+  source_bytes: 2529953
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANA.tar.gz
+- id: PLANP
+  status: OK
+  reason: ''
+  name: Planarian Phenotype Ontology
+  version: NA
+  nodecount: 4790
+  edgecount: 12777
+  submission_id: '5'
+  source_bytes: 10529138
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANP.tar.gz
+- id: PLANTSO
+  status: OK
+  reason: ''
+  name: Plant Stress Ontology
+  version: '2026-01-08'
+  nodecount: 5355
+  edgecount: 16147
+  submission_id: '5'
+  source_bytes: 7539745
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANTSO.tar.gz
+- id: PLIO
+  status: OK
+  reason: ''
+  name: Protein-ligand interaction ontology
+  version: '1.0'
+  nodecount: 391
+  edgecount: 1052
+  submission_id: '1'
+  source_bytes: 767315
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLIO.tar.gz
+- id: PLOSTHES
+  status: OK
+  reason: ''
+  name: PLOS Thesaurus
+  version: plosthes.2017-1
+  nodecount: 10736
+  edgecount: 34037
+  submission_id: '10'
+  source_bytes: 6810058
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLOSTHES.tar.gz
+- id: PMA
+  status: OK
+  reason: ''
+  name: Portfolio Management Application
+  version: 0.9.1
+  nodecount: 2087
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 1249373
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PMA.tar.gz
+- id: PMAPP-PMO
+  status: Skipped
+  reason: too_large
+  name: PMO Precision Medicine Ontology
+  version: '4.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 304536613
+- id: PMD
+  status: OK
+  reason: ''
+  name: Persian Medicine Diseases Ontology
+  version: '1.0'
+  nodecount: 577
+  edgecount: 657
+  submission_id: '1'
+  source_bytes: 401303
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PMD.tar.gz
+- id: PMDO
+  status: OK
+  reason: ''
+  name: Parkinson and Movement Disorder Ontology
+  version: '1.1'
+  nodecount: 690
+  edgecount: 709
+  submission_id: '4'
+  source_bytes: 228306
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PMDO.tar.gz
+- id: PMO
+  status: OK
+  reason: ''
+  name: Performed Music Ontology
+  version: '1.0'
+  nodecount: 85
+  edgecount: 66
+  submission_id: '13'
+  source_bytes: 69507
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PMO.tar.gz
+- id: PMO-SPEED
+  status: OK
+  reason: ''
+  name: PMO Playing Speed Vocabulary
+  version: '1.0'
+  nodecount: 24
+  edgecount: 13
+  submission_id: '2'
+  source_bytes: 9817
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PMO-SPEED.tar.gz
+- id: PMR
+  status: OK
+  reason: ''
+  name: Physical Medicine and Rehabilitation
+  version: '1.6'
+  nodecount: 1800
+  edgecount: 1943
+  submission_id: '4'
+  source_bytes: 1356101
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PMR.tar.gz
+- id: PNADO
+  status: OK
+  reason: ''
+  name: Pneumonia Diagnosis Ontology
+  version: Version 2.0, 2024/07/10
+  nodecount: 1535
+  edgecount: 1604
+  submission_id: '3'
+  source_bytes: 1222875
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PNADO.tar.gz
+- id: PO
+  status: OK
+  reason: ''
+  name: Plant Ontology
+  version: releases/2024-04-17
+  nodecount: 2073
+  edgecount: 4425
+  submission_id: '30'
+  source_bytes: 1338438
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PO.tar.gz
+- id: POEM
+  status: OK
+  reason: ''
+  name: Psychometric Ontology of Experiences and Measures
+  version: '1.0'
+  nodecount: 105
+  edgecount: 101
+  submission_id: '8'
+  source_bytes: 55962
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/POEM.tar.gz
+- id: PORO
+  status: OK
+  reason: ''
+  name: Porifera Ontology
+  version: unknown
+  nodecount: 944
+  edgecount: 1163
+  submission_id: '9'
+  source_bytes: 908416
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PORO.tar.gz
+- id: PP
+  status: OK
+  reason: ''
+  name: Pipeline Patterns Ontology
+  version: '1.0'
+  nodecount: 16
+  edgecount: 15
+  submission_id: '1'
+  source_bytes: 9585
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PP.tar.gz
+- id: PPLC
+  status: Failed
+  reason: not_downloadable
+  name: Placental Pathology Lesion Classification
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: PPO
+  status: OK
+  reason: ''
+  name: Plant Phenology Ontology
+  version: '2026-05-06'
+  nodecount: 921
+  edgecount: 1480
+  submission_id: '13'
+  source_bytes: 1363692
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PPO.tar.gz
+- id: PR
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: PREFER
+  status: OK
+  reason: ''
+  name: Precision Fermentation Ontology
+  version: '2026-07-14'
+  nodecount: 7597
+  edgecount: 22849
+  submission_id: '6'
+  source_bytes: 20729099
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PREFER.tar.gz
+- id: PREGONTO
+  status: OK
+  reason: ''
+  name: Pregnancy Ontology
+  version: NA
+  nodecount: 46
+  edgecount: 37
+  submission_id: '1'
+  source_bytes: 14305
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PREGONTO.tar.gz
+- id: PREMEDONTO
+  status: OK
+  reason: ''
+  name: Precision Medicine Ontology
+  version: NA
+  nodecount: 734
+  edgecount: 1782
+  submission_id: '1'
+  source_bytes: 1064059
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PREMEDONTO.tar.gz
+- id: PREO
+  status: OK
+  reason: ''
+  name: Presence Ontology
+  version: 1.0.0
+  nodecount: 311
+  edgecount: 321
+  submission_id: '1'
+  source_bytes: 82074
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PREO.tar.gz
+- id: PROCCHEMICAL
+  status: OK
+  reason: ''
+  name: Chemical Process
+  version: '2.3'
+  nodecount: 66
+  edgecount: 49
+  submission_id: '1'
+  source_bytes: 10352
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PROCCHEMICAL.tar.gz
+- id: PROCO
+  status: OK
+  reason: ''
+  name: Process Chemistry Ontology
+  version: PROCO release 20220414
+  nodecount: 1166
+  edgecount: 2728
+  submission_id: '1'
+  source_bytes: 1418368
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PROCO.tar.gz
+- id: PROJ
+  status: OK
+  reason: ''
+  name: Project ontology
+  version: '2020'
+  nodecount: 215
+  edgecount: 305
+  submission_id: '2'
+  source_bytes: 26306
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PROJ.tar.gz
+- id: PROPREO
+  status: OK
+  reason: ''
+  name: Proteomics Data and Process Provenance Ontology
+  version: '1.1'
+  nodecount: 512
+  edgecount: 593
+  submission_id: '2'
+  source_bytes: 234639
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PROPREO.tar.gz
+- id: PROVO
+  status: OK
+  reason: ''
+  name: Provenance Ontology
+  version: Recommendation version 2013-04-30
+  nodecount: 109
+  edgecount: 368
+  submission_id: '124'
+  source_bytes: 112346
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PROVO.tar.gz
+- id: PSDO
+  status: OK
+  reason: ''
+  name: Performance Summary Display Ontology
+  version: 1.0.1
+  nodecount: 128
+  edgecount: 136
+  submission_id: '9'
+  source_bytes: 76992
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PSDO.tar.gz
+- id: PSDS
+  status: OK
+  reason: ''
+  name: Plant Structure Development Stage
+  version: 'Release #20'
+  nodecount: 403
+  edgecount: 377
+  submission_id: '6'
+  source_bytes: 224469
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PSDS.tar.gz
+- id: PSIMOD
+  status: OK
+  reason: ''
+  name: Protein Modification Ontology
+  version: 1.031.6
+  nodecount: 2154
+  edgecount: 4515
+  submission_id: '34'
+  source_bytes: 1837167
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/PSIMOD.tar.gz
+- id: PSO
+  status: OK
+  reason: ''
+  name: PatientSafetyOntology
+  version: "008:2017-08-04: Einarbeitung der Zust\xE4nde"
+  nodecount: 639
+  edgecount: 1110
+  submission_id: '2'
+  source_bytes: 355245
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PSO.tar.gz
+- id: PSO_2
+  status: OK
+  reason: ''
+  name: PatientSafetyOntologyRevisted
+  version: '005'
+  nodecount: 309
+  edgecount: 440
+  submission_id: '3'
+  source_bytes: 58164
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PSO_2.tar.gz
+- id: PTO
+  status: OK
+  reason: ''
+  name: Plant Trait Ontology
+  version: May 2025
+  nodecount: 1761
+  edgecount: 1989
+  submission_id: '440'
+  source_bytes: 645641
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PTO.tar.gz
+- id: PTRANS
+  status: OK
+  reason: ''
+  name: Pathogen Transmission Ontology
+  version: '2026-03-13'
+  nodecount: 53
+  edgecount: 33
+  submission_id: '20'
+  source_bytes: 51218
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PTRANS.tar.gz
+- id: PTRO
+  status: OK
+  reason: ''
+  name: Preclinical Trials in Radiation Oncology Ontology
+  version: 0.1 alpha
+  nodecount: 154
+  edgecount: 231
+  submission_id: '2'
+  source_bytes: 197993
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PTRO.tar.gz
+- id: PTS
+  status: OK
+  reason: ''
+  name: Pathway Terminology System
+  version: '1.0'
+  nodecount: 6711
+  edgecount: 10306
+  submission_id: '1'
+  source_bytes: 9757941
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PTS.tar.gz
+- id: PU
+  status: OK
+  reason: ''
+  name: Test Dataset
+  version: NA
+  nodecount: 6
+  edgecount: 1
+  submission_id: '1'
+  source_bytes: 2389
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PU.tar.gz
+- id: PVONTO
+  status: OK
+  reason: ''
+  name: Pharmacovigilance Ontology
+  version: '0.1'
+  nodecount: 34
+  edgecount: 24
+  submission_id: '1'
+  source_bytes: 8015
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PVONTO.tar.gz
+- id: PW
+  status: OK
+  reason: ''
+  name: Pathway Ontology
+  version: '2026-05-16'
+  nodecount: 2787
+  edgecount: 3455
+  submission_id: '130'
+  source_bytes: 1347139
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PW.tar.gz
+- id: QUANTUM-MIND
+  status: OK
+  reason: ''
+  name: Quantum Mind Framework
+  version: NA
+  nodecount: 579
+  edgecount: 767
+  submission_id: '4'
+  source_bytes: 930058
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/QUANTUM-MIND.tar.gz
+- id: QUDT
+  status: Failed
+  reason: transform_error
+  name: Quantities, Units, Dimensions, and Types Ontology
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '44'
+  source_bytes: 115706
+- id: QUDT2
+  status: Failed
+  reason: transform_error
+  name: Quantities, Units, Dimensions and Types (QUDT) Schema - Version 2.0
+  version: '2.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 124851
+- id: QUDT2-1
+  status: Failed
+  reason: not_downloadable
+  name: Quantities, Units, Dimensions and Types (QUDT Version 2.1)
+  version: '2.1'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 0
+- id: RADLEX
+  status: OK
+  reason: ''
+  name: Radiology Lexicon
+  version: '4.3'
+  nodecount: 46976
+  edgecount: 130599
+  submission_id: '43'
+  source_bytes: 64938742
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RADLEX.tar.gz
+- id: RADMO
+  status: Failed
+  reason: no_submission
+  name: RADx Metadata Ontology
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: RADXTT-MVREASONS
+  status: OK
+  reason: ''
+  name: RADx Tiger Team Missing Value Reasons
+  version: 0.1.2
+  nodecount: 45
+  edgecount: 79
+  submission_id: '10'
+  source_bytes: 11259
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RADXTT-MVREASONS.tar.gz
+- id: RAO
+  status: OK
+  reason: ''
+  name: Rheumatoid Arthritis ontology
+  version: Version 1.0
+  nodecount: 282
+  edgecount: 350
+  submission_id: '1'
+  source_bytes: 95327
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RAO.tar.gz
+- id: RB
+  status: OK
+  reason: ''
+  name: RegenBase ontology
+  version: '1.0'
+  nodecount: 659
+  edgecount: 637
+  submission_id: '5'
+  source_bytes: 245804
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/RB.tar.gz
+- id: RBO
+  status: Failed
+  reason: transform_error
+  name: Radiation Biology Ontology
+  version: '2026-07-16'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '41'
+  source_bytes: 29260285
+- id: RCD
+  status: Failed
+  reason: not_downloadable
+  name: 'Read Codes, Clinical Terms Version 3 (CTV3) '
+  version: RCD99
+  nodecount: 0
+  edgecount: 0
+  submission_id: '24'
+  source_bytes: 0
+- id: RCTONT
+  status: OK
+  reason: ''
+  name: Randomized Controlled Trials Ontology
+  version: '2.0'
+  nodecount: 219
+  edgecount: 575
+  submission_id: '1'
+  source_bytes: 132075
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/RCTONT.tar.gz
+- id: RCTV2
+  status: OK
+  reason: ''
+  name: Read Clinical Terminology Version 2
+  version: '2015'
+  nodecount: 88855
+  edgecount: 88824
+  submission_id: '1'
+  source_bytes: 31714074
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RCTV2.tar.gz
+- id: RDA-CONTENT
+  status: OK
+  reason: ''
+  name: RDA Content type
+  version: NA
+  nodecount: 63
+  edgecount: 121
+  submission_id: '1'
+  source_bytes: 202975
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RDA-CONTENT.tar.gz
+- id: RDA-ISSUANCE
+  status: OK
+  reason: ''
+  name: RDA Mode of Issuance
+  version: '1.0'
+  nodecount: 31
+  edgecount: 11
+  submission_id: '13'
+  source_bytes: 86816
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RDA-ISSUANCE.tar.gz
+- id: RDAO
+  status: OK
+  reason: ''
+  name: Rare Diseases Awareness Ontology
+  version: '3.2'
+  nodecount: 344
+  edgecount: 551
+  submission_id: '5'
+  source_bytes: 269886
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RDAO.tar.gz
+- id: RDFS
+  status: OK
+  reason: ''
+  name: The RDF Schema vocabulary
+  version: '1.1'
+  nodecount: 20
+  edgecount: 34
+  submission_id: '4'
+  source_bytes: 3790
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RDFS.tar.gz
+- id: RDL
+  status: Skipped
+  reason: too_large
+  name: RDL
+  version: Generated 2013-03-28T19:01:04.897+01:00
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 218143867
+- id: RDO
+  status: OK
+  reason: ''
+  name: Reusable Biodiversity Ontology
+  version: '1.1'
+  nodecount: 386
+  edgecount: 409
+  submission_id: '1'
+  source_bytes: 197765
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RDO.tar.gz
+- id: REGN_BRO
+  status: OK
+  reason: ''
+  name: REGN_BRO
+  version: '1.1'
+  nodecount: 542
+  edgecount: 555
+  submission_id: '1'
+  source_bytes: 328029
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REGN_BRO.tar.gz
+- id: REGN_GO
+  status: Skipped
+  reason: too_large
+  name: REGN_GO
+  version: '2023-01-01'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 132165503
+- id: REHABO
+  status: OK
+  reason: ''
+  name: The Rehabilitation Ontology
+  version: '2026-04-22'
+  nodecount: 316
+  edgecount: 472
+  submission_id: '1'
+  source_bytes: 373001
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REHABO.tar.gz
+- id: REPO
+  status: OK
+  reason: ''
+  name: Reproductive Trait and Phenotype Ontology
+  version: '1.1'
+  nodecount: 109
+  edgecount: 91
+  submission_id: '3'
+  source_bytes: 88980
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REPO.tar.gz
+- id: REPOS
+  status: OK
+  reason: ''
+  name: repository
+  version: NA
+  nodecount: 22
+  edgecount: 21
+  submission_id: '1'
+  source_bytes: 13886
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REPOS.tar.gz
+- id: REPRODUCE-ME
+  status: OK
+  reason: ''
+  name: REPRODUCE-ME
+  version: '1.1'
+  nodecount: 729
+  edgecount: 499
+  submission_id: '7'
+  source_bytes: 235183
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REPRODUCE-ME.tar.gz
+- id: RETO
+  status: Skipped
+  reason: too_large
+  name: Regulation of Transcription Ontology
+  version: '2015'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '8'
+  source_bytes: 119860982
+- id: REX
+  status: OK
+  reason: ''
+  name: Physico-Chemical Process
+  version: '1.13'
+  nodecount: 570
+  edgecount: 734
+  submission_id: '7'
+  source_bytes: 130439
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REX.tar.gz
+- id: REXO
+  status: Skipped
+  reason: too_large
+  name: Regulation of Gene Expression Ontolology
+  version: '2015'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 127071736
+- id: RGD
+  status: Failed
+  reason: no_submission
+  name: RRB Group D
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: RH-MESH
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: RNAO
+  status: OK
+  reason: ''
+  name: RNA Ontology
+  version: r113
+  nodecount: 811
+  edgecount: 1362
+  submission_id: '4'
+  source_bytes: 101924
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RNAO.tar.gz
+- id: RNPRIO
+  status: OK
+  reason: ''
+  name: Research Network and Patient Registry Inventory Ontology
+  version: '1'
+  nodecount: 81
+  edgecount: 76
+  submission_id: '1'
+  source_bytes: 38012
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RNPRIO.tar.gz
+- id: RNRMU
+  status: OK
+  reason: ''
+  name: RNRMU
+  version: '0.1'
+  nodecount: 2310
+  edgecount: 2272
+  submission_id: '1'
+  source_bytes: 663082
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RNRMU.tar.gz
+- id: RO
+  status: OK
+  reason: ''
+  name: Radiomics Ontology
+  version: '2.1'
+  nodecount: 563
+  edgecount: 495
+  submission_id: '6'
+  source_bytes: 228594
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RO.tar.gz
+- id: ROADMAP
+  status: OK
+  reason: ''
+  name: Radiology Ontology of AI Datasets, Models and Projects
+  version: NA
+  nodecount: 929
+  edgecount: 1558
+  submission_id: '7'
+  source_bytes: 441800
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ROADMAP.tar.gz
+- id: ROCKNROLLTEST
+  status: OK
+  reason: ''
+  name: ROCK-N-ROLL-TEST
+  version: NA
+  nodecount: 11
+  edgecount: 1
+  submission_id: '2'
+  source_bytes: 834
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ROCKNROLLTEST.tar.gz
+- id: ROLEO
+  status: OK
+  reason: ''
+  name: Role Ontology
+  version: 'Vision Release: 1.0.16'
+  nodecount: 2188
+  edgecount: 2155
+  submission_id: '3'
+  source_bytes: 912230
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ROLEO.tar.gz
+- id: ROO
+  status: OK
+  reason: ''
+  name: Radiation Oncology Ontology
+  version: '0.5'
+  nodecount: 1534
+  edgecount: 1475
+  submission_id: '8'
+  source_bytes: 1038254
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ROO.tar.gz
+- id: ROR
+  status: Failed
+  reason: transform_error
+  name: Research Organization Registry
+  version: '2.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 14168326
+- id: ROS
+  status: OK
+  reason: ''
+  name: Radiation Oncology Structures Ontology
+  version: 1.2.2
+  nodecount: 426
+  edgecount: 418
+  submission_id: '6'
+  source_bytes: 207062
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ROS.tar.gz
+- id: RPO
+  status: OK
+  reason: ''
+  name: Resource of Asian Primary Immunodeficiency Diseases (RAPID) Phenotype Ontology
+  version: Version 1.0
+  nodecount: 1725
+  edgecount: 1890
+  submission_id: '2'
+  source_bytes: 1642099
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RPO.tar.gz
+- id: RS
+  status: OK
+  reason: ''
+  name: Rat Strain Ontology
+  version: '2026-07-29'
+  nodecount: 5714
+  edgecount: 7580
+  submission_id: '325'
+  source_bytes: 1156146
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RS.tar.gz
+- id: RSA
+  status: OK
+  reason: ''
+  name: Reference Sequence Annotation
+  version: '0.6'
+  nodecount: 32
+  edgecount: 21
+  submission_id: '6'
+  source_bytes: 9974
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RSA.tar.gz
+- id: RVO
+  status: OK
+  reason: ''
+  name: Research Variable Ontology
+  version: '1.0'
+  nodecount: 41
+  edgecount: 38
+  submission_id: '2'
+  source_bytes: 16033
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RVO.tar.gz
+- id: RXNO
+  status: OK
+  reason: ''
+  name: Name Reaction Ontology
+  version: releases/2021-12-16
+  nodecount: 1128
+  edgecount: 1939
+  submission_id: '41'
+  source_bytes: 376426
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RXNO.tar.gz
+- id: RXNORM
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: S4EHAW
+  status: OK
+  reason: ''
+  name: 'SAREF4EHAW: an extension of SAREF for eHealth Ageing Well domain'
+  version: v1.1.1
+  nodecount: 219
+  edgecount: 221
+  submission_id: '1'
+  source_bytes: 53749
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/S4EHAW.tar.gz
+- id: SALMO
+  status: Failed
+  reason: no_submission
+  name: Salmonella Serotype vocabulary
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: SALMON
+  status: Failed
+  reason: transform_error
+  name: Salmon Ontology
+  version: 0.4.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 479675
+- id: SAO
+  status: OK
+  reason: ''
+  name: Subcellular Anatomy Ontology
+  version: Version 1.2
+  nodecount: 863
+  edgecount: 2541
+  submission_id: '3'
+  source_bytes: 877846
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SAO.tar.gz
+- id: SARSMUTONTO
+  status: OK
+  reason: ''
+  name: Ontology for SARS-CoV-2  lineages and mutations
+  version: '1.1'
+  nodecount: 5499
+  edgecount: 2521
+  submission_id: '7'
+  source_bytes: 2615560
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SARSMUTONTO.tar.gz
+- id: SASAP
+  status: OK
+  reason: ''
+  name: The State of Alaska's Salmon and People Ontology
+  version: 0.3.1
+  nodecount: 294
+  edgecount: 314
+  submission_id: '2'
+  source_bytes: 337241
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SASAP.tar.gz
+- id: SATO
+  status: OK
+  reason: ''
+  name: 'SATO (IDEAS expAnded wiTh BCIO): workflow for designers of patient-centered
+    mobile health behaviour change intervention applications'
+  version: v2
+  nodecount: 37
+  edgecount: 31
+  submission_id: '2'
+  source_bytes: 15994
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SATO.tar.gz
+- id: SATUSEHATTHESIS
+  status: OK
+  reason: ''
+  name: SatuSehatThesis
+  version: NA
+  nodecount: 35
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 23501
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SATUSEHATTHESIS.tar.gz
+- id: SBO
+  status: OK
+  reason: ''
+  name: Systems Biology Ontology
+  version: 28:08:2021 03:13
+  nodecount: 697
+  edgecount: 745
+  submission_id: '663'
+  source_bytes: 582599
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SBO.tar.gz
+- id: SBOL
+  status: OK
+  reason: ''
+  name: Synthetic Biology Open Language Visual Ontology
+  version: unknown
+  nodecount: 78
+  edgecount: 80
+  submission_id: '2'
+  source_bytes: 15779
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SBOL.tar.gz
+- id: SCDO
+  status: OK
+  reason: ''
+  name: Sickle Cell Disease Ontology
+  version: '2021-04-15'
+  nodecount: 2870
+  edgecount: 7286
+  submission_id: '21'
+  source_bytes: 3333372
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SCDO.tar.gz
+- id: SCHEMA
+  status: OK
+  reason: ''
+  name: Schema.org core and all extension vocabularies
+  version: 3.4 fixes
+  nodecount: 2398
+  edgecount: 5290
+  submission_id: '4'
+  source_bytes: 1060556
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SCHEMA.tar.gz
+- id: SCIO
+  status: OK
+  reason: ''
+  name: Spinal Cord Injury Ontology
+  version: '1'
+  nodecount: 603
+  edgecount: 435
+  submission_id: '2'
+  source_bytes: 326578
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/SCIO.tar.gz
+- id: SCO
+  status: OK
+  reason: ''
+  name: Study Cohort Ontology
+  version: 1.1.0
+  nodecount: 214
+  edgecount: 278
+  submission_id: '5'
+  source_bytes: 133598
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/SCO.tar.gz
+- id: SCO-U
+  status: Failed
+  reason: transform_error
+  name: Sustainability Core Ontology - Segment U
+  version: Version 1.1.0. ; segment U.
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 596407
+- id: SCO_F23
+  status: Failed
+  reason: no_submission
+  name: Syrian Cinema Ontology - ahmad - F23
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: SCO_V1
+  status: OK
+  reason: ''
+  name: Sustainability Core Ontology
+  version: Version 1.1.0. ; segment B.
+  nodecount: 957
+  edgecount: 754
+  submission_id: '5'
+  source_bytes: 505810
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SCO_V1.tar.gz
+- id: SD3
+  status: OK
+  reason: ''
+  name: Simulation Delivery and Documentation Deviations
+  version: '1.0'
+  nodecount: 59
+  edgecount: 57
+  submission_id: '1'
+  source_bytes: 39390
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SD3.tar.gz
+- id: SDO
+  status: OK
+  reason: ''
+  name: Sleep Domain Ontology
+  version: 'Last modification: Feb. 11, 2013 Sivaram Arabandi'
+  nodecount: 1678
+  edgecount: 2706
+  submission_id: '4'
+  source_bytes: 1174403
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SDO.tar.gz
+- id: SDOED
+  status: OK
+  reason: ''
+  name: Social Determinants of Education Ontology
+  version: V1
+  nodecount: 232
+  edgecount: 236
+  submission_id: '1'
+  source_bytes: 103332
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SDOED.tar.gz
+- id: SDOHO
+  status: OK
+  reason: ''
+  name: social determinants of health ontology-TaoLab
+  version: SDoHO_1216
+  nodecount: 470
+  edgecount: 518
+  submission_id: '2'
+  source_bytes: 291533
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/SDOHO.tar.gz
+- id: SEDI
+  status: OK
+  reason: ''
+  name: Semantic DICOM Ontology
+  version: 0.6 alpha
+  nodecount: 6033
+  edgecount: 8853
+  submission_id: '6'
+  source_bytes: 4423969
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SEDI.tar.gz
+- id: SENSO
+  status: OK
+  reason: ''
+  name: Sensitive Data Ontology
+  version: Version 0.1.0
+  nodecount: 29
+  edgecount: 15
+  submission_id: '1'
+  source_bytes: 7275
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SENSO.tar.gz
+- id: SEP
+  status: Failed
+  reason: transform_error
+  name: Sample Processing and Separation Techniques Ontology
+  version: '1.070708'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 77640
+- id: SEPIO
+  status: OK
+  reason: ''
+  name: Scientific Evidence and Provenance Information Ontology
+  version: '2023-06-13'
+  nodecount: 529
+  edgecount: 878
+  submission_id: '7'
+  source_bytes: 574859
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/SEPIO.tar.gz
+- id: SEPON
+  status: OK
+  reason: ''
+  name: Sepsis Ontology
+  version: V1.0.0
+  nodecount: 1939
+  edgecount: 2372
+  submission_id: '2'
+  source_bytes: 1610190
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SEPON.tar.gz
+- id: SHEDDING-HUB
+  status: Failed
+  reason: transform_error
+  name: Pathogen and Biomarker Shedding
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '2'
+  source_bytes: 20615
+- id: SHR
+  status: OK
+  reason: ''
+  name: Student Health Record Ontology
+  version: '1.1'
+  nodecount: 336
+  edgecount: 340
+  submission_id: '3'
+  source_bytes: 77024
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SHR.tar.gz
+- id: SIBO
+  status: OK
+  reason: ''
+  name: Social Insect Behavior Ontology
+  version: NA
+  nodecount: 547
+  edgecount: 1103
+  submission_id: '2'
+  source_bytes: 514573
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SIBO.tar.gz
+- id: SIMM
+  status: OK
+  reason: ''
+  name: In Silico Methodologies Ontology for MAATrica metric
+  version: NA
+  nodecount: 313
+  edgecount: 236
+  submission_id: '1'
+  source_bytes: 46577
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SIMM.tar.gz
+- id: SIMON
+  status: Failed
+  reason: not_downloadable
+  name: Simple Measurement Ontology
+  version: '1.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: SIO
+  status: OK
+  reason: ''
+  name: Semanticscience Integrated Ontology
+  version: '1.61'
+  nodecount: 1897
+  edgecount: 4185
+  submission_id: '95'
+  source_bytes: 1478858
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SIO.tar.gz
+- id: SITBAC
+  status: OK
+  reason: ''
+  name: Situation-Based Access Control Ontology
+  version: '1.3'
+  nodecount: 495
+  edgecount: 546
+  submission_id: '3'
+  source_bytes: 388726
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SITBAC.tar.gz
+- id: SK
+  status: OK
+  reason: ''
+  name: Digital Forensic
+  version: NA
+  nodecount: 73
+  edgecount: 78
+  submission_id: '1'
+  source_bytes: 28358
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SK.tar.gz
+- id: SLEEP
+  status: OK
+  reason: ''
+  name: SLEEP ontology
+  version: '1.0'
+  nodecount: 111
+  edgecount: 103
+  submission_id: '1'
+  source_bytes: 91303
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SLEEP.tar.gz
+- id: SLSO
+  status: OK
+  reason: ''
+  name: Space Life Sciences Ontology
+  version: '2025-12-11'
+  nodecount: 6111
+  edgecount: 8853
+  submission_id: '16'
+  source_bytes: 6078809
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SLSO.tar.gz
+- id: SL_DIS
+  status: OK
+  reason: ''
+  name: 'Sleep Disorders '
+  version: '2.0'
+  nodecount: 371
+  edgecount: 497
+  submission_id: '2'
+  source_bytes: 318304
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SL_DIS.tar.gz
+- id: SMASH
+  status: Failed
+  reason: not_downloadable
+  name: SMASH Ontology
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '6'
+  source_bytes: 0
+- id: SMO
+  status: Failed
+  reason: not_downloadable
+  name: Syrian Movies Ontology
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: SNMI
+  status: OK
+  reason: ''
+  name: Systematized Nomenclature of Medicine, International Version
+  version: 2024AA
+  nodecount: 109164
+  edgecount: 109032
+  submission_id: '24'
+  source_bytes: 67538878
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SNMI.tar.gz
+- id: SNOMEDCT
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: SNPO
+  status: OK
+  reason: ''
+  name: Single-Nucleotide Polymorphism (SNP) Ontology
+  version: 'version: full 1.6
+
+    release: 14/03/2017'
+  nodecount: 170
+  edgecount: 283
+  submission_id: '4'
+  source_bytes: 128384
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/SNPO.tar.gz
+- id: SO
+  status: OK
+  reason: ''
+  name: Sequence Types and Features Ontology
+  version: unknown
+  nodecount: 2842
+  edgecount: 3924
+  submission_id: '314'
+  source_bytes: 3967865
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SO.tar.gz
+- id: SOCMEDIA
+  status: OK
+  reason: ''
+  name: Sercan Kiyak
+  version: NA
+  nodecount: 23
+  edgecount: 31
+  submission_id: '3'
+  source_bytes: 9272
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOCMEDIA.tar.gz
+- id: SOCPRES
+  status: OK
+  reason: ''
+  name: Social Prescribing Ontology
+  version: NA
+  nodecount: 56
+  edgecount: 55
+  submission_id: '1'
+  source_bytes: 20855
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOCPRES.tar.gz
+- id: SOHO
+  status: OK
+  reason: ''
+  name: Social Determinants of Health Ontology
+  version: '4'
+  nodecount: 177
+  edgecount: 176
+  submission_id: '5'
+  source_bytes: 102117
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOHO.tar.gz
+- id: SOIL-PROF
+  status: Failed
+  reason: not_downloadable
+  name: Soil Profile classifiers
+  version: 3rd edition
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 0
+- id: SOLO
+  status: OK
+  reason: ''
+  name: Solitude Ontology
+  version: '2026-02-25'
+  nodecount: 166
+  edgecount: 389
+  submission_id: '2'
+  source_bytes: 174388
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOLO.tar.gz
+- id: SOPHARM
+  status: OK
+  reason: ''
+  name: Suggested Ontology for Pharmacogenomics
+  version: 'Version: SO-Pharm 2.2
+
+    Release: 02 Mar 2017'
+  nodecount: 232
+  edgecount: 294
+  submission_id: '18'
+  source_bytes: 160511
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOPHARM.tar.gz
+- id: SOS
+  status: OK
+  reason: ''
+  name: "emerg\xEAncia"
+  version: NA
+  nodecount: 65
+  edgecount: 58
+  submission_id: '1'
+  source_bytes: 14432
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOS.tar.gz
+- id: SOY
+  status: OK
+  reason: ''
+  name: Soy Ontology
+  version: unknown
+  nodecount: 1854
+  edgecount: 1832
+  submission_id: '2'
+  source_bytes: 460671
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOY.tar.gz
+- id: SP
+  status: OK
+  reason: ''
+  name: SMART Protocols
+  version: '4.0'
+  nodecount: 624
+  edgecount: 780
+  submission_id: '6'
+  source_bytes: 520481
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SP.tar.gz
+- id: SPD
+  status: OK
+  reason: ''
+  name: Spider Anatomy Ontology
+  version: '1.1'
+  nodecount: 853
+  edgecount: 1214
+  submission_id: '24'
+  source_bytes: 224049
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SPD.tar.gz
+- id: SPO
+  status: OK
+  reason: ''
+  name: Skin Physiology Ontology
+  version: '2'
+  nodecount: 397
+  edgecount: 674
+  submission_id: '1'
+  source_bytes: 246210
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SPO.tar.gz
+- id: SPTO
+  status: OK
+  reason: ''
+  name: Solanaceae Phenotype Ontology
+  version: unknown
+  nodecount: 533
+  edgecount: 685
+  submission_id: '9'
+  source_bytes: 119560
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SPTO.tar.gz
+- id: SP_ONTOLOGY
+  status: OK
+  reason: ''
+  name: SmartPITeS Proyect Ontology for Complex Chronic Patients
+  version: NA
+  nodecount: 359
+  edgecount: 704
+  submission_id: '1'
+  source_bytes: 232790
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SP_ONTOLOGY.tar.gz
+- id: SSBD
+  status: OK
+  reason: ''
+  name: SSBD Ontology
+  version: '2025-05-12'
+  nodecount: 2464
+  edgecount: 4070
+  submission_id: '4'
+  source_bytes: 1664132
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SSBD.tar.gz
+- id: SSE
+  status: OK
+  reason: ''
+  name: Surgical Secondary Events
+  version: '1.1'
+  nodecount: 1462
+  edgecount: 352
+  submission_id: '2'
+  source_bytes: 425024
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SSE.tar.gz
+- id: SSN
+  status: OK
+  reason: ''
+  name: Semantic Sensor Network Ontology
+  version: "New modular version of the SSN ontology. \n\nThis ontology was originally\
+    \ developed in 2009-2011 by the W3C Semantic Sensor Networks Incubator Group (SSN-XG).\
+    \ For more information on the group's activities see: http://www.w3.org/2005/Incubator/ssn/.\
+    \ The ontology was revised and modularized in 2015-2017 by the W3C/OGC Spatial\
+    \ Data on the Web Working Group, see: https://www.w3.org/2015/spatial/wiki/Semantic_Sensor_Network_Ontology.\
+    \ \n\nIn particular, (a) the scope is extended to include actuation and sampling;\
+    \ (b) the core concepts and properties are factored out into the SOSA ontology.\
+    \ The SSN ontology imports SOSA and adds formal axiomatization consistent with\
+    \ the text definitions in SOSA, and adds classes and properties to accommodate\
+    \ the scope of the original SSN ontology. "
+  nodecount: 73
+  edgecount: 119
+  submission_id: '2'
+  source_bytes: 53909
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SSN.tar.gz
+- id: SSO
+  status: OK
+  reason: ''
+  name: Syndromic Surveillance Ontology
+  version: '1'
+  nodecount: 211
+  edgecount: 203
+  submission_id: '1'
+  source_bytes: 215799
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SSO.tar.gz
+- id: SST
+  status: OK
+  reason: ''
+  name: SATUSEHAT Thesis
+  version: '1'
+  nodecount: 18
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 3733
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SST.tar.gz
+- id: SSTIM
+  status: OK
+  reason: ''
+  name: Sensory Stimulation Ontology
+  version: 0.12.0
+  nodecount: 1004
+  edgecount: 2410
+  submission_id: '10'
+  source_bytes: 913195
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/SSTIM.tar.gz
+- id: STATO
+  status: OK
+  reason: ''
+  name: Statistics Ontology
+  version: '2026-04-20'
+  nodecount: 1446
+  edgecount: 3999
+  submission_id: '19'
+  source_bytes: 2213239
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STATO.tar.gz
+- id: STMSO
+  status: OK
+  reason: ''
+  name: symptomatic treatment of multiple sclerosis ontology
+  version: NA
+  nodecount: 766
+  edgecount: 1140
+  submission_id: '1'
+  source_bytes: 716671
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STMSO.tar.gz
+- id: STO-DRAFT
+  status: OK
+  reason: ''
+  name: The Stroke Ontology
+  version: '2017-11-01'
+  nodecount: 1839
+  edgecount: 4006
+  submission_id: '1'
+  source_bytes: 2541188
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STO-DRAFT.tar.gz
+- id: STRONG
+  status: OK
+  reason: ''
+  name: Mental Stress Ontology
+  version: NA
+  nodecount: 198
+  edgecount: 201
+  submission_id: '2'
+  source_bytes: 121262
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/STRONG.tar.gz
+- id: STY
+  status: OK
+  reason: ''
+  name: Semantic Types Ontology
+  version: 2025AB
+  nodecount: 130
+  edgecount: 127
+  submission_id: '26'
+  source_bytes: 32612
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STY.tar.gz
+- id: STY1
+  status: Failed
+  reason: not_downloadable
+  name: STY1
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 0
+- id: SUGARBIND
+  status: OK
+  reason: ''
+  name: SugarBind
+  version: '2023-06-20'
+  nodecount: 58
+  edgecount: 31
+  submission_id: '1'
+  source_bytes: 17464
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/SUGARBIND.tar.gz
+- id: SURGICAL
+  status: OK
+  reason: ''
+  name: Nurse Surgical
+  version: NA
+  nodecount: 141
+  edgecount: 77
+  submission_id: '1'
+  source_bytes: 109295
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SURGICAL.tar.gz
+- id: SVU_MWS_WSM
+  status: OK
+  reason: ''
+  name: Syrian Cinema Ontology
+  version: '1.0'
+  nodecount: 137
+  edgecount: 36
+  submission_id: '1'
+  source_bytes: 98764
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SVU_MWS_WSM.tar.gz
+- id: SVU_MWS_WSM_F23
+  status: OK
+  reason: ''
+  name: MWS-WSM-F23 Syrian Cinema Ontology
+  version: '1.0'
+  nodecount: 137
+  edgecount: 36
+  submission_id: '1'
+  source_bytes: 98744
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SVU_MWS_WSM_F23.tar.gz
+- id: SWEET
+  status: OK
+  reason: ''
+  name: Semantic Web for Earth and Environment Technology Ontology
+  version: 3.6.0
+  nodecount: 1273
+  edgecount: 221
+  submission_id: '13'
+  source_bytes: 22451
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SWEET.tar.gz
+- id: SWO
+  status: OK
+  reason: ''
+  name: Software Ontology
+  version: '2023-03-05'
+  nodecount: 3542
+  edgecount: 5783
+  submission_id: '32'
+  source_bytes: 3132540
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SWO.tar.gz
+- id: SYMP
+  status: OK
+  reason: ''
+  name: Symptom Ontology
+  version: '2024-05-17'
+  nodecount: 1044
+  edgecount: 916
+  submission_id: '35'
+  source_bytes: 831655
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SYMP.tar.gz
+- id: SYRIAN-CINEMA
+  status: Failed
+  reason: not_downloadable
+  name: Syrian Cinema
+  version: 1.0.0
+  nodecount: 0
+  edgecount: 0
+  submission_id: '3'
+  source_bytes: 0
+- id: SYRIANDRUGS
+  status: OK
+  reason: ''
+  name: Syrian Drugs and medicines
+  version: '0.01'
+  nodecount: 14554
+  edgecount: 28
+  submission_id: '1'
+  source_bytes: 15089139
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SYRIANDRUGS.tar.gz
+- id: T4FS
+  status: OK
+  reason: ''
+  name: terms4FAIRskills
+  version: '2025-02-09'
+  nodecount: 675
+  edgecount: 768
+  submission_id: '2'
+  source_bytes: 862626
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/T4FS.tar.gz
+- id: TADS
+  status: OK
+  reason: ''
+  name: Tick Gross Anatomy Ontology
+  version: '1.21'
+  nodecount: 644
+  edgecount: 948
+  submission_id: '17'
+  source_bytes: 259092
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TADS.tar.gz
+- id: TAO
+  status: OK
+  reason: ''
+  name: Teleost Anatomy Ontology
+  version: '2012-08-10'
+  nodecount: 3487
+  edgecount: 5423
+  submission_id: '135'
+  source_bytes: 903285
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TAO.tar.gz
+- id: TAON
+  status: OK
+  reason: ''
+  name: Therapeutic Antibody Ontology
+  version: '1.1'
+  nodecount: 2170
+  edgecount: 4488
+  submission_id: '2'
+  source_bytes: 2610589
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/TAON.tar.gz
+- id: TARA
+  status: OK
+  reason: ''
+  name: TARA Acupoints Ontology
+  version: 1.5.0
+  nodecount: 3675
+  edgecount: 9592
+  submission_id: '6'
+  source_bytes: 2377144
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TARA.tar.gz
+- id: TAXRANK
+  status: OK
+  reason: ''
+  name: Taxonomic Rank Vocabulary
+  version: unknown
+  nodecount: 96
+  edgecount: 80
+  submission_id: '12'
+  source_bytes: 54031
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TAXRANK.tar.gz
+- id: TCDO
+  status: OK
+  reason: ''
+  name: Traditional Chinese Drug Ontology
+  version: '0.05'
+  nodecount: 2177
+  edgecount: 7694
+  submission_id: '3'
+  source_bytes: 2524570
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/TCDO.tar.gz
+- id: TCO
+  status: OK
+  reason: ''
+  name: Thyroid Cancer Ontology
+  version: '1.0'
+  nodecount: 589
+  edgecount: 1163
+  submission_id: '2'
+  source_bytes: 1264736
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TCO.tar.gz
+- id: TDWGSPEC
+  status: OK
+  reason: ''
+  name: TDWG Specimen LSID Ontology
+  version: '0.3'
+  nodecount: 48
+  edgecount: 81
+  submission_id: '1'
+  source_bytes: 27414
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TDWGSPEC.tar.gz
+- id: TEDDY
+  status: OK
+  reason: ''
+  name: Terminology for the Description of Dynamics
+  version: rel-2014-04-24 (inferred)
+  nodecount: 190
+  edgecount: 12485
+  submission_id: '11'
+  source_bytes: 1342502
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TEDDY.tar.gz
+- id: TEMPO
+  status: OK
+  reason: ''
+  name: TempO
+  version: '0.2'
+  nodecount: 26
+  edgecount: 18
+  submission_id: '4'
+  source_bytes: 16729
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TEMPO.tar.gz
+- id: TEO
+  status: OK
+  reason: ''
+  name: Time Event Ontology
+  version: 1.0.8
+  nodecount: 168
+  edgecount: 194
+  submission_id: '4'
+  source_bytes: 123391
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/TEO.tar.gz
+- id: TEPHRAM4MEXAMPLE
+  status: OK
+  reason: ''
+  name: Tephra M4M Example
+  version: 0.1.1
+  nodecount: 27
+  edgecount: 26
+  submission_id: '1'
+  source_bytes: 3257
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TEPHRAM4MEXAMPLE.tar.gz
+- id: TEST-M4M20-PAV
+  status: OK
+  reason: ''
+  name: test-m4m20-subjects-pav
+  version: 0.1.0
+  nodecount: 18
+  edgecount: 3
+  submission_id: '1'
+  source_bytes: 1002
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TEST-M4M20-PAV.tar.gz
+- id: TESTEX
+  status: OK
+  reason: ''
+  name: test1
+  version: 0.0.1
+  nodecount: 103
+  edgecount: 124
+  submission_id: '1'
+  source_bytes: 21473
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TESTEX.tar.gz
+- id: TESTLEARN
+  status: OK
+  reason: ''
+  name: testontologyforlearning
+  version: NA
+  nodecount: 5
+  edgecount: 1
+  submission_id: '1'
+  source_bytes: 1951
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TESTLEARN.tar.gz
+- id: TESTONTOLO
+  status: Failed
+  reason: no_submission
+  name: Test_data
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: TEST_A
+  status: OK
+  reason: ''
+  name: TEST_A
+  version: NA
+  nodecount: 103
+  edgecount: 124
+  submission_id: '1'
+  source_bytes: 21473
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TEST_A.tar.gz
+- id: TEST_CBI
+  status: OK
+  reason: ''
+  name: test_cbi
+  version: NA
+  nodecount: 10
+  edgecount: 5
+  submission_id: '1'
+  source_bytes: 4656
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TEST_CBI.tar.gz
+- id: TGMA
+  status: OK
+  reason: ''
+  name: Mosquito Gross Anatomy Ontology
+  version: releases/2013-06-03
+  nodecount: 1887
+  edgecount: 2733
+  submission_id: '17'
+  source_bytes: 970910
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TGMA.tar.gz
+- id: THESISDEMO
+  status: OK
+  reason: ''
+  name: thesisdemo
+  version: '1.0'
+  nodecount: 23
+  edgecount: 20
+  submission_id: '1'
+  source_bytes: 11730
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/THESISDEMO.tar.gz
+- id: THREE-ST
+  status: OK
+  reason: ''
+  name: 3-Step Theory of suicide
+  version: 1.0.1
+  nodecount: 8537
+  edgecount: 46
+  submission_id: '4'
+  source_bytes: 9515878
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/THREE-ST.tar.gz
+- id: TIME
+  status: OK
+  reason: ''
+  name: OWL-Time
+  version: '2017'
+  nodecount: 135
+  edgecount: 167
+  submission_id: '4'
+  source_bytes: 101486
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TIME.tar.gz
+- id: TIMEBANK
+  status: OK
+  reason: ''
+  name: Timebank Ontology
+  version: '0.3'
+  nodecount: 219
+  edgecount: 526
+  submission_id: '2'
+  source_bytes: 123194
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TIMEBANK.tar.gz
+- id: TM-CONST
+  status: OK
+  reason: ''
+  name: Traditional Medicine Constitution Value Set
+  version: '1'
+  nodecount: 31
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 9243
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TM-CONST.tar.gz
+- id: TM-MER
+  status: OK
+  reason: ''
+  name: Traditional Medicine Meridian Value Sets
+  version: '1'
+  nodecount: 32
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 18741
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TM-MER.tar.gz
+- id: TM-OTHER-FACTORS
+  status: OK
+  reason: ''
+  name: Traditional Medicine Other Factors Value Set
+  version: '1'
+  nodecount: 23
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 6652
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TM-OTHER-FACTORS.tar.gz
+- id: TM-SIGNS-AND-SYMPTS
+  status: OK
+  reason: ''
+  name: Traditional Medicine Signs and Symptoms Value Set
+  version: '1'
+  nodecount: 336
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 246226
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TM-SIGNS-AND-SYMPTS.tar.gz
+- id: TMA
+  status: OK
+  reason: ''
+  name: Tissue Microarray Ontology
+  version: 1.0.0
+  nodecount: 35
+  edgecount: 60
+  submission_id: '1'
+  source_bytes: 11670
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TMA.tar.gz
+- id: TML
+  status: OK
+  reason: ''
+  name: trasformative machine learning metadata
+  version: '0.1'
+  nodecount: 16
+  edgecount: 1
+  submission_id: '1'
+  source_bytes: 9749
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TML.tar.gz
+- id: TMO
+  status: OK
+  reason: ''
+  name: Translational Medicine Ontology
+  version: 1.0.2
+  nodecount: 276
+  edgecount: 283
+  submission_id: '13'
+  source_bytes: 135280
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/TMO.tar.gz
+- id: TOK
+  status: OK
+  reason: ''
+  name: Terminological and Ontological Knowledge Resources Ontology
+  version: 0.2.1
+  nodecount: 354
+  edgecount: 393
+  submission_id: '3'
+  source_bytes: 367213
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TOK.tar.gz
+- id: TOP-MENELAS
+  status: OK
+  reason: ''
+  name: Menelas Project Top-Level Ontology
+  version: '1.0'
+  nodecount: 776
+  edgecount: 1322
+  submission_id: '8'
+  source_bytes: 568977
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TOP-MENELAS.tar.gz
+- id: TP4
+  status: Failed
+  reason: not_downloadable
+  name: Oualid
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: TPOTEST
+  status: OK
+  reason: ''
+  name: Pizza Ontology
+  version: version 1.5
+  nodecount: 114
+  edgecount: 628
+  submission_id: '5'
+  source_bytes: 184932
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TPOTEST.tar.gz
+- id: TP_REL_FAM
+  status: OK
+  reason: ''
+  name: Relation familiales
+  version: NA
+  nodecount: 53
+  edgecount: 34
+  submission_id: '2'
+  source_bytes: 23762
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TP_REL_FAM.tar.gz
+- id: TRAK
+  status: OK
+  reason: ''
+  name: Taxonomy for Rehabilitation of Knee Conditions
+  version: unknown
+  nodecount: 1650
+  edgecount: 2206
+  submission_id: '5'
+  source_bytes: 452765
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TRAK.tar.gz
+- id: TRANS
+  status: OK
+  reason: ''
+  name: Nurse Transitional
+  version: NA
+  nodecount: 159
+  edgecount: 122
+  submission_id: '1'
+  source_bytes: 127799
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TRANS.tar.gz
+- id: TRIAGE
+  status: OK
+  reason: ''
+  name: Nurse triage
+  version: NA
+  nodecount: 62
+  edgecount: 103
+  submission_id: '2'
+  source_bytes: 31533
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TRIAGE.tar.gz
+- id: TRON
+  status: OK
+  reason: ''
+  name: Tribolium Ontology
+  version: unknown
+  nodecount: 990
+  edgecount: 3080
+  submission_id: '2'
+  source_bytes: 396280
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TRON.tar.gz
+- id: TST7
+  status: OK
+  reason: ''
+  name: FIELDLAB3_2023
+  version: NA
+  nodecount: 23
+  edgecount: 24
+  submission_id: '3'
+  source_bytes: 9307
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TST7.tar.gz
+- id: TTO
+  status: OK
+  reason: ''
+  name: Teleost Taxonomy Ontology
+  version: unknown
+  nodecount: 38743
+  edgecount: 77538
+  submission_id: '44'
+  source_bytes: 70851141
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TTO.tar.gz
+- id: TXPO
+  status: OK
+  reason: ''
+  name: Toxic Process Ontology
+  version: 2022/12/07
+  nodecount: 10304
+  edgecount: 23316
+  submission_id: '31'
+  source_bytes: 18381443
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TXPO.tar.gz
+- id: TYPON
+  status: OK
+  reason: ''
+  name: Microbial Typing Ontology
+  version: '20140929'
+  nodecount: 91
+  edgecount: 154
+  submission_id: '11'
+  source_bytes: 47161
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TYPON.tar.gz
+- id: UBERON
+  status: OK
+  reason: ''
+  name: Uber Anatomy Ontology
+  version: '2023-07-25'
+  nodecount: 31219
+  edgecount: 134094
+  submission_id: '355'
+  source_bytes: 95887167
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UBERON.tar.gz
+- id: UCVA
+  status: OK
+  reason: ''
+  name: Unwarranted Clinical Variation Analysis With Local Healthcare Contextual Factors
+  version: '1.2'
+  nodecount: 310
+  edgecount: 217
+  submission_id: '4'
+  source_bytes: 188306
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UCVA.tar.gz
+- id: UGANDA_DISEASES
+  status: OK
+  reason: ''
+  name: Uganda_diseases
+  version: '7'
+  nodecount: 345
+  edgecount: 922
+  submission_id: '17'
+  source_bytes: 84455
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UGANDA_DISEASES.tar.gz
+- id: UHC-METADATA
+  status: OK
+  reason: ''
+  name: UHC Metadata
+  version: v0.0.1
+  nodecount: 171
+  edgecount: 225
+  submission_id: '1'
+  source_bytes: 84480
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UHC-METADATA.tar.gz
+- id: UMLS
+  status: Skipped
+  reason: skiplist
+  name: ''
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: UMMS
+  status: OK
+  reason: ''
+  name: FirstOntologyForUMMS
+  version: '0.3'
+  nodecount: 67
+  edgecount: 79
+  submission_id: '3'
+  source_bytes: 26926
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UMMS.tar.gz
+- id: UNIPROT
+  status: OK
+  reason: ''
+  name: Uniprot Core Ontology
+  version: v2012-10-03
+  nodecount: 364
+  edgecount: 396
+  submission_id: '1'
+  source_bytes: 120507
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UNIPROT.tar.gz
+- id: UNITSONT
+  status: OK
+  reason: ''
+  name: Units Ontology
+  version: '1.0'
+  nodecount: 70
+  edgecount: 62
+  submission_id: '1'
+  source_bytes: 34218
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UNITSONT.tar.gz
+- id: UO
+  status: OK
+  reason: ''
+  name: Units of Measurement Ontology
+  version: '2026-07-31'
+  nodecount: 587
+  edgecount: 676
+  submission_id: '223'
+  source_bytes: 647954
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/UO.tar.gz
+- id: UPA
+  status: OK
+  reason: ''
+  name: Unipathway
+  version: UniPathway Release 2015_03
+  nodecount: 4861
+  edgecount: 19767
+  submission_id: '2'
+  source_bytes: 19447142
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UPA.tar.gz
+- id: UPHENO
+  status: Skipped
+  reason: too_large
+  name: Combined Phenotype Ontology
+  version: '2025-10-12'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '9'
+  source_bytes: 416269865
+- id: URL
+  status: OK
+  reason: ''
+  name: URL ONTOLOGY
+  version: '1.0'
+  nodecount: 179
+  edgecount: 258
+  submission_id: '2'
+  source_bytes: 56877
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/URL.tar.gz
+- id: VALUESETS
+  status: Failed
+  reason: transform_error
+  name: valuesets
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 3380392
+- id: VANDF
+  status: OK
+  reason: ''
+  name: Veterans Health Administration National Drug File
+  version: '2025_07_31'
+  nodecount: 31362
+  edgecount: 126
+  submission_id: '27'
+  source_bytes: 68645797
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VANDF.tar.gz
+- id: VARIO
+  status: OK
+  reason: ''
+  name: Variation Ontology
+  version: '2018-11-09'
+  nodecount: 532
+  edgecount: 518
+  submission_id: '16'
+  source_bytes: 110673
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VARIO.tar.gz
+- id: VBO
+  status: OK
+  reason: ''
+  name: Vertebrate Breed Ontology
+  version: '2026-04-15'
+  nodecount: 20885
+  edgecount: 114284
+  submission_id: '8'
+  source_bytes: 64844775
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VBO.tar.gz
+- id: VDOT
+  status: OK
+  reason: ''
+  name: Viral Disease Ontology Trunk
+  version: 'Initial Version
+
+    release date 28/02/2017'
+  nodecount: 237
+  edgecount: 223
+  submission_id: '35'
+  source_bytes: 117704
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VDOT.tar.gz
+- id: VEMO
+  status: OK
+  reason: ''
+  name: Veterinary Epidemiology Metadata Ontology
+  version: '0.2'
+  nodecount: 166
+  edgecount: 168
+  submission_id: '1'
+  source_bytes: 41527
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VEMO.tar.gz
+- id: VEO
+  status: OK
+  reason: ''
+  name: Visualized Emotion Ontology
+  version: '0.5'
+  nodecount: 171
+  edgecount: 83
+  submission_id: '1'
+  source_bytes: 100251
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VEO.tar.gz
+- id: VFB_DRIVERS
+  status: OK
+  reason: ''
+  name: vfb_drivers
+  version: '2026-07-27'
+  nodecount: 21242
+  edgecount: 28555
+  submission_id: '229'
+  source_bytes: 10048427
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VFB_DRIVERS.tar.gz
+- id: VHOG
+  status: OK
+  reason: ''
+  name: Vertebrate Homologous Organ Group Ontology
+  version: unknown
+  nodecount: 1200
+  edgecount: 1687
+  submission_id: '13'
+  source_bytes: 270799
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VHOG.tar.gz
+- id: VICO
+  status: OK
+  reason: ''
+  name: Vaccination Informed Consent Ontology
+  version: Arbor version; 1.0.52
+  nodecount: 1085
+  edgecount: 3017
+  submission_id: '10'
+  source_bytes: 1264526
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VICO.tar.gz
+- id: VIDO
+  status: OK
+  reason: ''
+  name: Virus Infectious Disease Ontology
+  version: 10-27-2022
+  nodecount: 581
+  edgecount: 893
+  submission_id: '3'
+  source_bytes: 569999
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VIDO.tar.gz
+- id: VIMM
+  status: OK
+  reason: ''
+  name: In Vitro Methodologies Ontology for MAATrica metric
+  version: NA
+  nodecount: 268
+  edgecount: 119
+  submission_id: '1'
+  source_bytes: 45470
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VIMM.tar.gz
+- id: VIO
+  status: OK
+  reason: ''
+  name: Vaccine Investigation Ontology
+  version: 'Vision Release: 1.0.01'
+  nodecount: 210
+  edgecount: 570
+  submission_id: '1'
+  source_bytes: 284221
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VIO.tar.gz
+- id: VIVO
+  status: OK
+  reason: ''
+  name: VIVO Ontology for Researcher Discovery
+  version: version 1.7
+  nodecount: 891
+  edgecount: 1156
+  submission_id: '3'
+  source_bytes: 729930
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VIVO.tar.gz
+- id: VIVO-ISF
+  status: OK
+  reason: ''
+  name: VIVO-Integrated Semantic Framework
+  version: '1.6'
+  nodecount: 943
+  edgecount: 1147
+  submission_id: '1'
+  source_bytes: 746182
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VIVO-ISF.tar.gz
+- id: VO
+  status: OK
+  reason: ''
+  name: Vaccine Ontology
+  version: '2026-06-12'
+  nodecount: 15915
+  edgecount: 105299
+  submission_id: '309'
+  source_bytes: 40505456
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VO.tar.gz
+- id: VODANA-GENERAL
+  status: OK
+  reason: ''
+  name: VODANATERMS
+  version: '8'
+  nodecount: 217
+  edgecount: 565
+  submission_id: '12'
+  source_bytes: 54027
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANA-GENERAL.tar.gz
+- id: VODANA-MI
+  status: OK
+  reason: ''
+  name: VODANA-MIGRANTS-INTERVIEWS
+  version: '2.0'
+  nodecount: 92
+  edgecount: 211
+  submission_id: '3'
+  source_bytes: 25350
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANA-MI.tar.gz
+- id: VODANA-MIGRANTS
+  status: OK
+  reason: ''
+  name: VODANA MIGRANTS VOCABULARY
+  version: '1'
+  nodecount: 347
+  edgecount: 1137
+  submission_id: '1'
+  source_bytes: 92326
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANA-MIGRANTS.tar.gz
+- id: VODANA-MPA
+  status: OK
+  reason: ''
+  name: VODANA-MIGRANTS-PRESS ARTICLES
+  version: '2'
+  nodecount: 220
+  edgecount: 559
+  submission_id: '3'
+  source_bytes: 58514
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANA-MPA.tar.gz
+- id: VODANACOVID
+  status: OK
+  reason: ''
+  name: VODANA-COVIDTERMS
+  version: '3.0'
+  nodecount: 77
+  edgecount: 168
+  submission_id: '4'
+  source_bytes: 24923
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANACOVID.tar.gz
+- id: VODANADISEASES
+  status: OK
+  reason: ''
+  name: VODANADiseases
+  version: 2.0.1
+  nodecount: 534
+  edgecount: 1615
+  submission_id: '3'
+  source_bytes: 128253
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANADISEASES.tar.gz
+- id: VODANAKENYA
+  status: OK
+  reason: ''
+  name: VODANA KENYA
+  version: 0.1.1
+  nodecount: 70
+  edgecount: 82
+  submission_id: '4'
+  source_bytes: 12559
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANAKENYA.tar.gz
+- id: VODANAMFLCODE
+  status: OK
+  reason: ''
+  name: VODANAFACILITIESLIST
+  version: '4.0'
+  nodecount: 116
+  edgecount: 291
+  submission_id: '4'
+  source_bytes: 19049
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANAMFLCODE.tar.gz
+- id: VODANANIGERIA
+  status: OK
+  reason: ''
+  name: VODANANIGERIA
+  version: '2.0'
+  nodecount: 83
+  edgecount: 211
+  submission_id: '3'
+  source_bytes: 27248
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANANIGERIA.tar.gz
+- id: VODANAUGANDA
+  status: OK
+  reason: ''
+  name: VODANAUGANDA
+  version: '2.0'
+  nodecount: 70
+  edgecount: 121
+  submission_id: '2'
+  source_bytes: 14410
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODANAUGANDA.tar.gz
+- id: VODANETHIOPIA_OR
+  status: Failed
+  reason: not_downloadable
+  name: ETHIOPIA_OUTPATIENT
+  version: '2'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 0
+- id: VODAN_ANC
+  status: OK
+  reason: ''
+  name: 'VODAN ANC Vocabulary '
+  version: VI
+  nodecount: 394
+  edgecount: 1237
+  submission_id: '2'
+  source_bytes: 91393
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VODAN_ANC.tar.gz
+- id: VRD
+  status: OK
+  reason: ''
+  name: Vaccineresearchdata
+  version: '2.0'
+  nodecount: 29
+  edgecount: 11
+  submission_id: '1'
+  source_bytes: 14104
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VRD.tar.gz
+- id: VSAO
+  status: OK
+  reason: ''
+  name: Vertebrate Skeletal Anatomy Ontology
+  version: '2012-11-06'
+  nodecount: 358
+  edgecount: 438
+  submission_id: '21'
+  source_bytes: 600603
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VSAO.tar.gz
+- id: VSO
+  status: OK
+  reason: ''
+  name: Vital Sign Ontology
+  version: '2012-04-25'
+  nodecount: 132
+  edgecount: 109
+  submission_id: '1'
+  source_bytes: 51705
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/VSO.tar.gz
+- id: VT
+  status: OK
+  reason: ''
+  name: Vertebrate Trait Ontology
+  version: '2026-07-23'
+  nodecount: 4116
+  edgecount: 4953
+  submission_id: '208'
+  source_bytes: 1779506
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VT.tar.gz
+- id: VTO
+  status: Skipped
+  reason: too_large
+  name: Vertebrate Taxonomy Ontology
+  version: unknown
+  nodecount: 0
+  edgecount: 0
+  submission_id: '14'
+  source_bytes: 152582746
+- id: VVMM
+  status: OK
+  reason: ''
+  name: In Vivo Methodologies Ontology for MAATrica metric
+  version: NA
+  nodecount: 133
+  edgecount: 61
+  submission_id: '1'
+  source_bytes: 20707
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VVMM.tar.gz
+- id: VVO
+  status: OK
+  reason: ''
+  name: Vitis Vinifera Ontology
+  version: 2-007
+  nodecount: 3483
+  edgecount: 7473
+  submission_id: '5'
+  source_bytes: 16628577
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VVO.tar.gz
+- id: WB-BT
+  status: OK
+  reason: ''
+  name: C. elegans Gross Anatomy Vocabulary
+  version: releases/2025-03-26
+  nodecount: 7830
+  edgecount: 16334
+  submission_id: '147'
+  source_bytes: 1612935
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WB-BT.tar.gz
+- id: WB-LS
+  status: OK
+  reason: ''
+  name: C. elegans Development Vocabulary
+  version: unknown
+  nodecount: 779
+  edgecount: 1458
+  submission_id: '50'
+  source_bytes: 333728
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WB-LS.tar.gz
+- id: WB-PHENOTYPE
+  status: OK
+  reason: ''
+  name: C. elegans Phenotype Vocabulary
+  version: '2026-04-15'
+  nodecount: 2753
+  edgecount: 3577
+  submission_id: '421'
+  source_bytes: 1008213
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WB-PHENOTYPE.tar.gz
+- id: WC
+  status: OK
+  reason: ''
+  name: Whole-cell modeling ontology
+  version: 0.0.1
+  nodecount: 283
+  edgecount: 272
+  submission_id: '13'
+  source_bytes: 32908
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WC.tar.gz
+- id: WEAR
+  status: OK
+  reason: ''
+  name: 'WEAR: Wind Energy mAteRials Taxonomy'
+  version: v0.1.0
+  nodecount: 43
+  edgecount: 85
+  submission_id: '1'
+  source_bytes: 6292
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WEAR.tar.gz
+- id: WEAVE
+  status: OK
+  reason: ''
+  name: 'WEAVE: Wind Energy ActiVitiEs'
+  version: v0.1.0
+  nodecount: 36
+  edgecount: 59
+  submission_id: '2'
+  source_bytes: 5057
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WEAVE.tar.gz
+- id: WETAXTOPICS
+  status: OK
+  reason: ''
+  name: 'NEAT: wiNd Energy tAxonomy of Topics'
+  version: v0.1.1
+  nodecount: 135
+  edgecount: 350
+  submission_id: '6'
+  source_bytes: 30780
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WETAXTOPICS.tar.gz
+- id: WHO-ART
+  status: Failed
+  reason: not_downloadable
+  name: World Health Organization (WHO) Adverse Reaction Terminology
+  version: WHO97
+  nodecount: 0
+  edgecount: 0
+  submission_id: '23'
+  source_bytes: 0
+- id: WIKIPATHWAYS
+  status: OK
+  reason: ''
+  name: WikiPathways
+  version: 2013a
+  nodecount: 65
+  edgecount: 95
+  submission_id: '230'
+  source_bytes: 13467
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WIKIPATHWAYS.tar.gz
+- id: WSIO
+  status: OK
+  reason: ''
+  name: Web-Service Interaction Ontology
+  version: beta2
+  nodecount: 83
+  edgecount: 108
+  submission_id: '4'
+  source_bytes: 55695
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WSIO.tar.gz
+- id: WSM-LIBRARY
+  status: Failed
+  reason: no_submission
+  name: MWS
+  version: ''
+  nodecount: 0
+  edgecount: 0
+  submission_id: NA
+  source_bytes: 0
+- id: WWECA
+  status: Failed
+  reason: transform_error
+  name: Women with Epilepsy of Child-bearing Age Ontology
+  version: '3.0'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '4'
+  source_bytes: 2439829
+- id: XAO
+  status: OK
+  reason: ''
+  name: Xenopus Anatomy Ontology
+  version: releases/2024-09-03
+  nodecount: 1891
+  edgecount: 7240
+  submission_id: '33'
+  source_bytes: 860637
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XAO.tar.gz
+- id: XCO
+  status: OK
+  reason: ''
+  name: Experimental Conditions Ontology
+  version: '2026-07-29'
+  nodecount: 1896
+  edgecount: 2514
+  submission_id: '251'
+  source_bytes: 1134086
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XCO.tar.gz
+- id: XEO
+  status: OK
+  reason: ''
+  name: XEML Environment Ontology
+  version: '1.6'
+  nodecount: 160
+  edgecount: 243
+  submission_id: '4'
+  source_bytes: 16571
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XEO.tar.gz
+- id: XLMOD
+  status: OK
+  reason: ''
+  name: mass spectrometry cross-linking and derivatization reagents
+  version: release/2019-10-28
+  nodecount: 1149
+  edgecount: 2970
+  submission_id: '4'
+  source_bytes: 430570
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XLMOD.tar.gz
+- id: XPO
+  status: OK
+  reason: ''
+  name: Xenopus Phenotype Ontology
+  version: '2025-07-25'
+  nodecount: 52063
+  edgecount: 87933
+  submission_id: '12'
+  source_bytes: 97539811
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XPO.tar.gz
+- id: XREF-FUNDER-REG
+  status: OK
+  reason: ''
+  name: CrossRef Funder Registry
+  version: NA
+  nodecount: 204864
+  edgecount: 382413
+  submission_id: '33'
+  source_bytes: 90099734
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XREF-FUNDER-REG.tar.gz
+- id: YOGA
+  status: OK
+  reason: ''
+  name: Yoga Ontology
+  version: '0.1'
+  nodecount: 32
+  edgecount: 46
+  submission_id: '1'
+  source_bytes: 6485
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/YOGA.tar.gz
+- id: YUNPING
+  status: Failed
+  reason: not_downloadable
+  name: yunping
+  version: NA
+  nodecount: 0
+  edgecount: 0
+  submission_id: '1'
+  source_bytes: 0
+- id: ZEA
+  status: OK
+  reason: ''
+  name: Maize Gross Anatomy Ontology
+  version: '1.2'
+  nodecount: 195
+  edgecount: 217
+  submission_id: '2'
+  source_bytes: 101498
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZEA.tar.gz
+- id: ZECO
+  status: OK
+  reason: ''
+  name: Zebrafish Experimental Conditions Ontology
+  version: '2022-02-14'
+  nodecount: 220
+  edgecount: 222
+  submission_id: '10'
+  source_bytes: 90975
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZECO.tar.gz
+- id: ZFA
+  status: OK
+  reason: ''
+  name: Zebrafish Anatomy and Development Ontology
+  version: '2026-07-16'
+  nodecount: 3341
+  edgecount: 13190
+  submission_id: '255'
+  source_bytes: 1656680
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZFA.tar.gz
+- id: ZFS
+  status: OK
+  reason: ''
+  name: Zebrafish Developmental Stages
+  version: '2026-07-16'
+  nodecount: 3340
+  edgecount: 13189
+  submission_id: '171'
+  source_bytes: 7361558
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZFS.tar.gz
+- id: ZONMW-ADMIN-MD
+  status: OK
+  reason: ''
+  name: ZonMW Administrative Metadata Vocabulary
+  version: 1.2.0a
+  nodecount: 247
+  edgecount: 699
+  submission_id: '13'
+  source_bytes: 60417
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZONMW-ADMIN-MD.tar.gz
+- id: ZONMW-CONTENT
+  status: OK
+  reason: ''
+  name: ZonMW COVID-19
+  version: 2.4.0
+  nodecount: 401
+  edgecount: 998
+  submission_id: '37'
+  source_bytes: 83818
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZONMW-CONTENT.tar.gz
+- id: ZONMW-GENERIC
+  status: OK
+  reason: ''
+  name: ZonMw Generic Terms
+  version: 1.5.0
+  nodecount: 244
+  edgecount: 571
+  submission_id: '21'
+  source_bytes: 42354
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZONMW-GENERIC.tar.gz
+- id: ZP
+  status: Skipped
+  reason: too_large
+  name: Zebrafish Phenotype Ontology
+  version: '2024-04-18'
+  nodecount: 0
+  edgecount: 0
+  submission_id: '5'
+  source_bytes: 170306263
+- id: pseudo
+  status: OK
+  reason: ''
+  name: Pseudogene
+  version: '0.1'
+  nodecount: 36
+  edgecount: 19
+  submission_id: '1'
+  source_bytes: 2419
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/pseudo.tar.gz
+- id: suicideo
+  status: OK
+  reason: ''
+  name: suicideonto
+  version: '2'
+  nodecount: 357
+  edgecount: 331
+  submission_id: '1'
+  source_bytes: 245227
+  download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/suicideo.tar.gz
+totals:
+  totalcount: 1108
+  skippedcount: 43
+  failedcount: 141
+  totalnodecount: 4318491
+  totaledgecount: 8112853
+  transform_date: 2026-08-02

--- a/docs/external-syncs.md
+++ b/docs/external-syncs.md
@@ -8,6 +8,7 @@ KG-Registry includes a small set of scripted metadata syncs that pull structured
 | --- | --- | --- | --- | --- |
 | FRINK OKN registry | `util/sync_frink.py` | `make sync-frink` | Creates or updates OKN resource pages and FRINK endpoint products | `https://raw.githubusercontent.com/frink-okn/okn-registry/main/docs/registry/kgs.yaml` |
 | OBO Foundry registry | `util/sync_obo_foundry.py` | `make sync-obo-foundry` | Creates or updates OBO Foundry resource pages | `https://obofoundry.org/registry/ontologies.yml` |
+| KG-Bioportal transforms | `util/sync_kg_bioportal.py` | `make sync-kg-bioportal` | Adds a KGX graph product to existing resources whose ontology KG-Bioportal transformed; never creates resources | `https://github.com/ncbo/kg-bioportal/releases/latest/download/onto_stats.yaml` |
 | Translator release feed | `util/sync_translator.py` | `make sync-translator` | Updates the [`translator`](../resource/translator/translator.html) resource with the current Translator KGX release products | `https://kgx-storage.rtx.ai/releases/latest-release-summary.json` plus per-release `graph-metadata.json` files under `https://kgx-storage.rtx.ai/releases/<release>/latest/` |
 
 ## Notes
@@ -15,3 +16,4 @@ KG-Registry includes a small set of scripted metadata syncs that pull structured
 - These syncs update source `resource/*.md` files in the repository. They do not write directly to `registry/`, which remains generated output.
 - Product detail pages under `resource/<resource-id>/` are generated from resource frontmatter during metadata extraction.
 - The OBO Foundry sync has additional documentation in [OBO Foundry Synchronization](obo-foundry-sync.html).
+- The KG-Bioportal sync has additional documentation in [KG-Bioportal Synchronization](kg-bioportal-sync.html). Unlike the others it is an annotation pass over existing pages: KG-Bioportal covers all ~1300 BioPortal ontologies, so the [`kg-bioportal`](../resource/kg-bioportal/kg-bioportal.html) resource links to its graph browser instead of listing them.

--- a/docs/kg-bioportal-sync.md
+++ b/docs/kg-bioportal-sync.md
@@ -1,0 +1,149 @@
+# KG-Bioportal Synchronization
+
+This document describes how KG-Registry picks up graph transforms from
+[KG-Bioportal](https://ncbo.github.io/kg-bioportal/graphs/).
+
+## Overview
+
+KG-Bioportal transforms BioPortal ontologies into KGX node/edge TSVs and publishes
+each result as a GitHub release asset. Its manifest currently covers about 1300
+ontologies, of which roughly 1100 transform successfully.
+
+That is far more than belongs in a product inventory on a single registry page, and
+most of those ontologies have no KG-Registry resource at all. So this sync is not
+shaped like `sync_obo_foundry.py`, which mints and maintains whole resources. It is
+an annotation pass: for each successfully transformed ontology that *already* has a
+KG-Registry resource page, it adds one `GraphProduct` to that page pointing at the
+KGX archive. The `kg-bioportal` resource itself is a hand-written page that links to
+the graph browser rather than listing the transforms.
+
+## Files
+
+- `util/sync_kg_bioportal.py` — the sync script
+- `util/kg_bioportal_sync_map.yaml` — curated acronym-to-resource decisions
+- `resource/kg-bioportal/kg-bioportal.md` — the KG-Bioportal resource page
+- `reports/kg_bioportal_unmatched.tsv` — worklist written after every run
+- `cache/kg_bioportal_cache.yaml` — cached manifest (24 h TTL by default)
+
+## Usage
+
+```bash
+# Full sync
+make sync-kg-bioportal
+
+# Preview without writing files
+make sync-kg-bioportal-dry-run
+
+# First 50 manifest entries only
+make sync-kg-bioportal-test
+```
+
+The script takes the same flags as the other sync scripts: `--dry-run`, `--limit`,
+`--verbose`, `--no-cache`, `--cache-ttl`, and `--registry-root`. It also runs as part
+of `make all`, after `sync-obo-foundry`.
+
+## Data source
+
+The manifest is `onto_stats.yaml`, attached to the latest KG-Bioportal release:
+
+```
+https://github.com/ncbo/kg-bioportal/releases/latest/download/onto_stats.yaml
+```
+
+Each entry gives the BioPortal acronym, transform status, failure reason, source
+name and version, node and edge counts, and the download URL of the KGX archive.
+`total_stats.yaml` alongside it carries the site-wide counts and transform date, used
+only for logging.
+
+## What gets written
+
+For each entry with `status: OK` that resolves to an existing resource, the resource
+page gets a product with id `<resource>.kg-bioportal`:
+
+```yaml
+- id: agro.kg-bioportal
+  name: AGRO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of AGRonomy Ontology (AGRO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains AGRO_nodes.tsv and AGRO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/AGRO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: agro
+    relation_type: prov:hadPrimarySource
+  node_count: 5102
+  edge_count: 8691
+```
+
+On re-runs, only the fields the sync owns (see `MANAGED_PRODUCT_FIELDS`) are
+rewritten; `product_file_size` and anything a curator added are preserved. A
+`product_file_size` recorded against a superseded release URL is dropped, since it no
+longer describes the file. If an ontology stops transforming successfully, its
+product is removed.
+
+## What deliberately does not get written
+
+**Failed and skipped transforms.** KG-Bioportal records these so its own site can
+explain the gap — sources that are too large for GitHub-hosted runners, ontologies
+with no current BioPortal submission, transform errors. There is no artifact, so
+there is nothing for KG-Registry to list.
+
+**New resources.** KG-Bioportal's graph browser draws part of its listing from
+KG-Registry's own JSON-LD dump. Creating registry resources from its manifest would
+be a circular sync, so an entry with no matching resource is skipped.
+
+**A source association back to `kg-bioportal`.** `propagate_products` (in
+`util/extract-metadata.py`) copies each product onto the page of every resource it
+names as a source. Naming the aggregator in `original_source` or `secondary_source`
+would therefore rebuild the thousand-entry inventory this design exists to avoid.
+The KG-Bioportal provenance lives in the product's name, description, and release
+URL instead.
+
+## Matching acronyms to resources
+
+BioPortal acronyms are not KG-Registry ids, and they collide in both directions.
+BioPortal's `RO` is the Radiomics Ontology, while the OBO Relation Ontology is
+`OBOREL`; `PSO` is a patient-safety ontology, while the Plant Stress Ontology that
+KG-Registry calls `pso` is `PLANTSO`. Matching on the lowercased acronym alone would
+attach the wrong graph to a dozen or so resources.
+
+The script resolves each entry in this order:
+
+1. **The sync map.** `util/kg_bioportal_sync_map.yaml` holds `confirmed` pairs
+   (acronym → resource id) and a `rejected` list. Curated decisions win outright.
+2. **Acronym plus name check.** The lowercased acronym must be an existing resource
+   id, *and* the two names must be similar enough to rule out a collision. Similarity
+   is token coverage in the better direction, with fuzzy per-token matching so
+   "Phenotypic Quality Ontology" still matches "Phenotype And Trait Ontology".
+   Non-OK entries skip the name check, since all they can do is remove a product this
+   sync itself wrote.
+3. **Otherwise, no write.** Entries with an OK status that either failed the name
+   check or have no resource but whose name exactly matches one are recorded in
+   `reports/kg_bioportal_unmatched.tsv` with a suggested resource. That report is the
+   worklist for extending the sync map.
+
+When several manifest entries resolve to the same resource — BioPortal hosts some
+ontologies under two acronyms — only one can supply the resource's single
+`<resource>.kg-bioportal` product. Successful transforms beat unsuccessful ones,
+curated matches beat heuristic ones, and the rest is alphabetical, so the choice does
+not depend on manifest order.
+
+## Frontmatter formatting
+
+Resource pages exist in two YAML shapes, split roughly evenly across the registry:
+`yaml.safe_dump` writes top-level list items flush at column zero, while the ruamel
+handler in `util/common.py` indents them. The sync detects which shape a page uses
+and writes it back the same way, so adding one product does not reflow every list on
+the page.
+
+## Adding a decision to the sync map
+
+1. Run the sync and read `reports/kg_bioportal_unmatched.tsv`.
+2. Check the BioPortal entry (`https://bioportal.bioontology.org/ontologies/<ACRONYM>`)
+   against the KG-Registry resource. They are frequently different ontologies that
+   happen to share an acronym.
+3. Add the pair under `confirmed:` if they are the same ontology, or the acronym
+   under `rejected:` if they are not. Both sections take a trailing comment; say
+   which ontology the acronym actually names.
+4. Re-run the sync; the entry should drop off the report.

--- a/reports/kg_bioportal_unmatched.tsv
+++ b/reports/kg_bioportal_unmatched.tsv
@@ -1,0 +1,1 @@
+acronym	kg_bioportal_name	reason	suggested_resource

--- a/resource/ado/ado.kg-bioportal.md
+++ b/resource/ado/ado.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Alzheimer's Disease Ontology (ADO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains ADO_nodes.tsv and
+  ADO_edges.tsv.
+edge_count: 6185
+format: kgx
+id: ado.kg-bioportal
+latest_version: 2.0.1
+name: ADO KGX graph (KG-Bioportal)
+node_count: 2729
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ado
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ADO.tar.gz
+layout: product_detail
+---

--- a/resource/ado/ado.md
+++ b/resource/ado/ado.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/Fraunhofer-SCAI-Applied-Semantics/ADO
 id: "ado"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "https://creativecommons.org/licenses/by/4.0/"
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: ado
         relation_type: prov:hadPrimarySource
+  - id: ado.kg-bioportal
+    name: ADO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Alzheimer's Disease Ontology (ADO), produced by KG-Bioportal from the BioPortal submission. The archive contains ADO_nodes.tsv and ADO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ADO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ado
+        relation_type: prov:hadPrimarySource
+    node_count: 2729
+    edge_count: 6185
+    latest_version: 2.0.1
 repository: https://github.com/Fraunhofer-SCAI-Applied-Semantics/ADO
 publications:
   - authors:

--- a/resource/adw/adw.kg-bioportal.md
+++ b/resource/adw/adw.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Animal Natural History and Life History Ontology
+  (ADW), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  ADW_nodes.tsv and ADW_edges.tsv.
+edge_count: 463
+format: kgx
+id: adw.kg-bioportal
+latest_version: 10/11/04
+name: ADW KGX graph (KG-Bioportal)
+node_count: 445
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: adw
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ADW.tar.gz
+layout: product_detail
+---

--- a/resource/adw/adw.md
+++ b/resource/adw/adw.md
@@ -16,7 +16,7 @@ domains:
 - organisms
 homepage_url: http://www.animaldiversity.org
 id: adw
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -33,10 +33,23 @@ products:
     source: adw
   product_url: http://purl.obolibrary.org/obo/adw.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
   - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Animal Natural History and Life History Ontology
+    (ADW), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    ADW_nodes.tsv and ADW_edges.tsv.
+  edge_count: 463
+  format: kgx
+  id: adw.kg-bioportal
+  latest_version: 10/11/04
+  name: ADW KGX graph (KG-Bioportal)
+  node_count: 445
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: adw
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/ADW.tar.gz
 publications: []
 ---
 ## Description

--- a/resource/aeo/aeo.kg-bioportal.md
+++ b/resource/aeo/aeo.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Anatomical Entity Ontology (AEO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains AEO_nodes.tsv and AEO_edges.tsv.
+edge_count: 728
+format: kgx
+id: aeo.kg-bioportal
+name: AEO KGX graph (KG-Bioportal)
+node_count: 461
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: aeo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AEO.tar.gz
+layout: product_detail
+---

--- a/resource/aeo/aeo.md
+++ b/resource/aeo/aeo.md
@@ -15,7 +15,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/human-developmental-anatomy-ontology/
 id: aeo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -33,6 +33,18 @@ products:
     original_source:
       - source: aeo
         relation_type: prov:hadPrimarySource
+  - id: aeo.kg-bioportal
+    name: AEO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Anatomical Entity Ontology (AEO), produced by KG-Bioportal from the BioPortal submission. The archive contains AEO_nodes.tsv and AEO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AEO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: aeo
+        relation_type: prov:hadPrimarySource
+    node_count: 461
+    edge_count: 728
 repository: https://github.com/obophenotype/human-developmental-anatomy-ontology
 publications: []
 ---

--- a/resource/aero/aero.kg-bioportal.md
+++ b/resource/aero/aero.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Adverse Event Reporting Ontology (AERO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains AERO_nodes.tsv
+  and AERO_edges.tsv.
+edge_count: 1047
+format: kgx
+id: aero.kg-bioportal
+latest_version: unknown
+name: AERO KGX graph (KG-Bioportal)
+node_count: 261
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: aero
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/AERO.tar.gz
+layout: product_detail
+---

--- a/resource/aero/aero.md
+++ b/resource/aero/aero.md
@@ -16,7 +16,7 @@ domains:
   - biomedical
 homepage_url: http://purl.obolibrary.org/obo/aero
 id: aero
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -34,6 +34,19 @@ products:
     original_source:
       - source: aero
         relation_type: prov:hadPrimarySource
+  - id: aero.kg-bioportal
+    name: AERO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Adverse Event Reporting Ontology (AERO), produced by KG-Bioportal from the BioPortal submission. The archive contains AERO_nodes.tsv and AERO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/AERO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: aero
+        relation_type: prov:hadPrimarySource
+    node_count: 261
+    edge_count: 1047
+    latest_version: unknown
 publications: []
 ---
 

--- a/resource/afo/afo.kg-bioportal.md
+++ b/resource/afo/afo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Allotrope Merged Ontology Suite (AFO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains AFO_nodes.tsv
+  and AFO_edges.tsv.
+edge_count: 11298
+format: kgx
+id: afo.kg-bioportal
+latest_version: REC/2026/06
+name: AFO KGX graph (KG-Bioportal)
+node_count: 4854
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: afo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AFO.tar.gz
+layout: product_detail
+---

--- a/resource/afo/afo.md
+++ b/resource/afo/afo.md
@@ -16,7 +16,7 @@ domains:
 - information technology
 homepage_url: https://www.allotrope.org/product-releases
 id: afo
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -130,6 +130,21 @@ products:
     source: dcat
   - relation_type: prov:wasInformedBy
     source: afo
+- id: afo.kg-bioportal
+  name: AFO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Allotrope Merged Ontology Suite (AFO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains AFO_nodes.tsv
+    and AFO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AFO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: afo
+    relation_type: prov:hadPrimarySource
+  node_count: 4854
+  edge_count: 11298
+  latest_version: REC/2026/06
 synonyms:
 - AFO
 warnings:

--- a/resource/agro/agro.kg-bioportal.md
+++ b/resource/agro/agro.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of AGRonomy Ontology (AGRO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains AGRO_nodes.tsv and AGRO_edges.tsv.
+edge_count: 8691
+format: kgx
+id: agro.kg-bioportal
+name: AGRO KGX graph (KG-Bioportal)
+node_count: 5102
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: agro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/AGRO.tar.gz
+layout: product_detail
+---

--- a/resource/agro/agro.md
+++ b/resource/agro/agro.md
@@ -20,7 +20,7 @@ domains:
 - agriculture
 homepage_url: https://github.com/AgriculturalSemantics/agro
 id: agro
-last_modified_date: '2026-06-13T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -38,6 +38,19 @@ products:
   original_source:
   - source: agro
     relation_type: prov:hadPrimarySource
+- id: agro.kg-bioportal
+  name: AGRO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of AGRonomy Ontology (AGRO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains AGRO_nodes.tsv and AGRO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/AGRO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: agro
+    relation_type: prov:hadPrimarySource
+  node_count: 5102
+  edge_count: 8691
 repository: https://github.com/AgriculturalSemantics/agro
 publications:
 - id: url:http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf

--- a/resource/aism/aism.kg-bioportal.md
+++ b/resource/aism/aism.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for the Anatomy of the Insect SkeletoMuscular
+  system (AISM), produced by KG-Bioportal from the BioPortal submission. The archive
+  contains AISM_nodes.tsv and AISM_edges.tsv.
+edge_count: 31372
+format: kgx
+id: aism.kg-bioportal
+latest_version: '2023-04-14'
+name: AISM KGX graph (KG-Bioportal)
+node_count: 8584
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: aism
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AISM.tar.gz
+layout: product_detail
+---

--- a/resource/aism/aism.md
+++ b/resource/aism/aism.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/insect-morphology/aism
 id: aism
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -56,6 +56,19 @@ products:
     original_source:
       - source: aism
         relation_type: prov:hadPrimarySource
+  - id: aism.kg-bioportal
+    name: AISM KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology for the Anatomy of the Insect SkeletoMuscular system (AISM), produced by KG-Bioportal from the BioPortal submission. The archive contains AISM_nodes.tsv and AISM_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AISM.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: aism
+        relation_type: prov:hadPrimarySource
+    node_count: 8584
+    edge_count: 31372
+    latest_version: '2023-04-14'
 repository: https://github.com/insect-morphology/aism
 publications:
   - authors:

--- a/resource/amphx/amphx.kg-bioportal.md
+++ b/resource/amphx/amphx.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of The Amphioxus Development and Anatomy Ontology (AMPHX),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains AMPHX_nodes.tsv
+  and AMPHX_edges.tsv.
+edge_count: 1721
+format: kgx
+id: amphx.kg-bioportal
+name: AMPHX KGX graph (KG-Bioportal)
+node_count: 418
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: amphx
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AMPHX.tar.gz
+layout: product_detail
+---

--- a/resource/amphx/amphx.md
+++ b/resource/amphx/amphx.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/EBISPOT/amphx_ontology
 id: "amphx"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/3.0/"
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: amphx
         relation_type: prov:hadPrimarySource
+  - id: amphx.kg-bioportal
+    name: AMPHX KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of The Amphioxus Development and Anatomy Ontology (AMPHX), produced by KG-Bioportal from the BioPortal submission. The archive contains AMPHX_nodes.tsv and AMPHX_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AMPHX.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: amphx
+        relation_type: prov:hadPrimarySource
+    node_count: 418
+    edge_count: 1721
 repository: https://github.com/EBISPOT/amphx_ontology
 publications:
   - authors:

--- a/resource/apo/apo.kg-bioportal.md
+++ b/resource/apo/apo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ascomycete Phenotype Ontology (APO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains APO_nodes.tsv and
+  APO_edges.tsv.
+edge_count: 2042
+format: kgx
+id: apo.kg-bioportal
+latest_version: '2026-06-16'
+name: APO KGX graph (KG-Bioportal)
+node_count: 656
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: apo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/APO.tar.gz
+layout: product_detail
+---

--- a/resource/apo/apo.md
+++ b/resource/apo/apo.md
@@ -19,7 +19,7 @@ domains:
 - phenotype
 homepage_url: http://www.yeastgenome.org/
 id: apo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -47,6 +47,21 @@ products:
   original_source:
   - source: apo
     relation_type: prov:hadPrimarySource
+- id: apo.kg-bioportal
+  name: APO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ascomycete Phenotype Ontology (APO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains APO_nodes.tsv
+    and APO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/APO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: apo
+    relation_type: prov:hadPrimarySource
+  node_count: 656
+  edge_count: 2042
+  latest_version: '2026-06-16'
 repository: https://github.com/obophenotype/ascomycete-phenotype-ontology
 taxon:
 - NCBITaxon:4890

--- a/resource/apollo_sv/apollo_sv.kg-bioportal.md
+++ b/resource/apollo_sv/apollo_sv.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Apollo Structured Vocabulary (APOLLO-SV), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains APOLLO-SV_nodes.tsv
+  and APOLLO-SV_edges.tsv.
+edge_count: 3597
+format: kgx
+id: apollo_sv.kg-bioportal
+latest_version: '2026-07-19'
+name: APOLLO-SV KGX graph (KG-Bioportal)
+node_count: 2334
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: apollo_sv
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/APOLLO-SV.tar.gz
+layout: product_detail
+---

--- a/resource/apollo_sv/apollo_sv.md
+++ b/resource/apollo_sv/apollo_sv.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/ApolloDev/apollo-sv
 id: apollo_sv
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: apollo_sv
         relation_type: prov:hadPrimarySource
+  - id: apollo_sv.kg-bioportal
+    name: APOLLO-SV KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Apollo Structured Vocabulary (APOLLO-SV), produced by KG-Bioportal from the BioPortal submission. The archive contains APOLLO-SV_nodes.tsv and APOLLO-SV_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/APOLLO-SV.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: apollo_sv
+        relation_type: prov:hadPrimarySource
+    node_count: 2334
+    edge_count: 3597
+    latest_version: '2026-07-19'
 repository: https://github.com/ApolloDev/apollo-sv
 publications:
   - authors:

--- a/resource/aro/aro.kg-bioportal.md
+++ b/resource/aro/aro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Antibiotic Resistance Ontology (ARO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains ARO_nodes.tsv and
+  ARO_edges.tsv.
+edge_count: 14883
+format: kgx
+id: aro.kg-bioportal
+name: ARO KGX graph (KG-Bioportal)
+node_count: 8608
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: aro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ARO.tar.gz
+layout: product_detail
+---

--- a/resource/aro/aro.md
+++ b/resource/aro/aro.md
@@ -18,7 +18,7 @@ domains:
   - biological systems
 homepage_url: https://github.com/arpcard/aro
 id: aro
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,18 @@ products:
     original_source:
       - source: aro
         relation_type: prov:hadPrimarySource
+  - id: aro.kg-bioportal
+    name: ARO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Antibiotic Resistance Ontology (ARO), produced by KG-Bioportal from the BioPortal submission. The archive contains ARO_nodes.tsv and ARO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ARO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: aro
+        relation_type: prov:hadPrimarySource
+    node_count: 8608
+    edge_count: 14883
 repository: https://github.com/arpcard/aro
 publications:
   - authors:

--- a/resource/atc/atc.kg-bioportal.md
+++ b/resource/atc/atc.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Anatomical Therapeutic Chemical Classification (ATC),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains ATC_nodes.tsv
+  and ATC_edges.tsv.
+edge_count: 7023
+format: kgx
+id: atc.kg-bioportal
+latest_version: '2025_02_10'
+name: ATC KGX graph (KG-Bioportal)
+node_count: 7033
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: atc
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATC.tar.gz
+layout: product_detail
+---

--- a/resource/atc/atc.md
+++ b/resource/atc/atc.md
@@ -26,7 +26,7 @@ domains:
 - biomedical
 homepage_url: https://atcddd.fhi.no/atc_ddd_index/
 id: atc
-last_modified_date: '2026-06-01T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 name: Anatomical Therapeutic Chemical Classification System
 products:
@@ -673,13 +673,26 @@ products:
     source: tcrd
   product_url: https://kg-hub.berkeleybop.io/kg-idg/current/kg-idg.tar.gz
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
   - 'File was not able to be retrieved when checked on 2026-07-01: HTTP 404 error.
     The kg-hub.berkeleybop.io host is being reorganized and KG-IDG downloads are pending
     relocation to a new home; no live download is currently available.'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Anatomical Therapeutic Chemical Classification
+    (ATC), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    ATC_nodes.tsv and ATC_edges.tsv.
+  edge_count: 7023
+  format: kgx
+  id: atc.kg-bioportal
+  latest_version: '2025_02_10'
+  name: ATC KGX graph (KG-Bioportal)
+  node_count: 7033
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: atc
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATC.tar.gz
 synonyms:
 - ATC
 - ATC/DDD

--- a/resource/ato/ato.kg-bioportal.md
+++ b/resource/ato/ato.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Amphibian Taxonomy Ontology (ATO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains ATO_nodes.tsv and ATO_edges.tsv.
+edge_count: 12163
+format: kgx
+id: ato.kg-bioportal
+latest_version: See Remote Site
+name: ATO KGX graph (KG-Bioportal)
+node_count: 6147
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ato
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATO.tar.gz
+layout: product_detail
+---

--- a/resource/ato/ato.md
+++ b/resource/ato/ato.md
@@ -17,7 +17,7 @@ domains:
 - biological systems
 homepage_url: http://www.amphibanat.org
 id: ato
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -35,6 +35,21 @@ products:
     source: ato
   product_url: http://purl.obolibrary.org/obo/ato.owl
   warnings: []
+- id: ato.kg-bioportal
+  name: ATO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Amphibian Taxonomy Ontology (ATO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains ATO_nodes.tsv
+    and ATO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ATO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ato
+    relation_type: prov:hadPrimarySource
+  node_count: 6147
+  edge_count: 12163
+  latest_version: See Remote Site
 publications: []
 taxon:
 - NCBITaxon:8292

--- a/resource/bao/bao.kg-bioportal.md
+++ b/resource/bao/bao.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of BioAssay Ontology (BAO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains BAO_nodes.tsv and BAO_edges.tsv.
+edge_count: 7517
+format: kgx
+id: bao.kg-bioportal
+latest_version: 2.8.19
+name: BAO KGX graph (KG-Bioportal)
+node_count: 6088
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BAO.tar.gz
+layout: product_detail
+---

--- a/resource/bao/bao.md
+++ b/resource/bao/bao.md
@@ -15,7 +15,7 @@ domains:
 - biomedical
 homepage_url: http://bioassayontology.org/
 id: bao
-last_modified_date: '2026-06-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -363,6 +363,20 @@ products:
   - biolink:translates_to
   - biolink:treats_or_applied_or_studied_to_treat
   product_url: https://zenodo.org/records/20816742
+- id: bao.kg-bioportal
+  name: BAO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of BioAssay Ontology (BAO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains BAO_nodes.tsv and BAO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BAO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: bao
+    relation_type: prov:hadPrimarySource
+  node_count: 6088
+  edge_count: 7517
+  latest_version: 2.8.19
 publications:
 - authors:
   - Ubbo Visser
@@ -370,7 +384,7 @@ publications:
   - Uma Vempati
   - Robin P Smith
   - Vance Lemmon
-  - "Stephan C Sch\xFCrer"
+  - Stephan C Schürer
   doi: doi:10.1186/1471-2105-12-257
   id: doi:10.1186/1471-2105-12-257
   journal: BMC Bioinformatics
@@ -381,7 +395,7 @@ publications:
 - authors:
   - Saminda Abeyruwan
   - Uma D Vempati
-  - "Hande K\xFC\xE7\xFCk-McGinty"
+  - Hande Küçük-McGinty
   - Ubbo Visser
   - Amar Koleti
   - Ahsan Mir
@@ -396,7 +410,7 @@ publications:
   - David Twomey
   - Svetlana Bureeva
   - Vance Lemmon
-  - "Stephan C Sch\xFCrer"
+  - Stephan C Schürer
   doi: doi:10.1186/2041-1480-5-S1-S5
   id: doi:10.1186/2041-1480-5-S1-S5
   journal: Journal of Biomedical Semantics

--- a/resource/bcgo/bcgo.kg-bioportal.md
+++ b/resource/bcgo/bcgo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Beta Cell Genomics Ontology (OBI_BCGO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OBI_BCGO_nodes.tsv
+  and OBI_BCGO_edges.tsv.
+edge_count: 6407
+format: kgx
+id: bcgo.kg-bioportal
+latest_version: '2015-07-08'
+name: OBI_BCGO KGX graph (KG-Bioportal)
+node_count: 2743
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bcgo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBI_BCGO.tar.gz
+layout: product_detail
+---

--- a/resource/bcgo/bcgo.md
+++ b/resource/bcgo/bcgo.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obi-bcgo/bcgo
 id: bcgo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: bcgo
         relation_type: prov:hadPrimarySource
+  - id: bcgo.kg-bioportal
+    name: OBI_BCGO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Beta Cell Genomics Ontology (OBI_BCGO), produced by KG-Bioportal from the BioPortal submission. The archive contains OBI_BCGO_nodes.tsv and OBI_BCGO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBI_BCGO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: bcgo
+        relation_type: prov:hadPrimarySource
+    node_count: 2743
+    edge_count: 6407
+    latest_version: '2015-07-08'
 repository: https://github.com/obi-bcgo/bcgo
 publications: []
 ---

--- a/resource/bco/bco.kg-bioportal.md
+++ b/resource/bco/bco.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Biological Collections Ontology (BCO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains BCO_nodes.tsv
+  and BCO_edges.tsv.
+edge_count: 1287
+format: kgx
+id: bco.kg-bioportal
+latest_version: '2021-11-14'
+name: BCO KGX graph (KG-Bioportal)
+node_count: 860
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bco
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCO.tar.gz
+layout: product_detail
+---

--- a/resource/bco/bco.md
+++ b/resource/bco/bco.md
@@ -21,7 +21,7 @@ domains:
 - organisms
 homepage_url: https://github.com/BiodiversityOntologies/bco
 id: bco
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -39,6 +39,21 @@ products:
   original_source:
   - source: bco
     relation_type: prov:hadPrimarySource
+- id: bco.kg-bioportal
+  name: BCO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Biological Collections Ontology (BCO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains BCO_nodes.tsv
+    and BCO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BCO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: bco
+    relation_type: prov:hadPrimarySource
+  node_count: 860
+  edge_count: 1287
+  latest_version: '2021-11-14'
 repository: https://github.com/BiodiversityOntologies/bco
 publications:
 - authors:

--- a/resource/bfo/bfo.kg-bioportal.md
+++ b/resource/bfo/bfo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Basic Formal Ontology (BFO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains BFO_nodes.tsv and BFO_edges.tsv.
+edge_count: 115
+format: kgx
+id: bfo.kg-bioportal
+latest_version: '2.0'
+name: BFO KGX graph (KG-Bioportal)
+node_count: 75
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bfo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BFO.tar.gz
+layout: product_detail
+---

--- a/resource/bfo/bfo.md
+++ b/resource/bfo/bfo.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://ifomis.org/bfo/
 id: bfo
 infores_id: bfo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -386,6 +386,20 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: bfo.kg-bioportal
+  name: BFO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Basic Formal Ontology (BFO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains BFO_nodes.tsv and BFO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BFO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: bfo
+    relation_type: prov:hadPrimarySource
+  node_count: 75
+  edge_count: 115
+  latest_version: '2.0'
 publications: []
 repository: https://github.com/BFO-ontology/BFO
 ---

--- a/resource/bio101/bio101.kg-bioportal.md
+++ b/resource/bio101/bio101.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of KB_Bio_101 (AURA), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains AURA_nodes.tsv and AURA_edges.tsv.
+edge_count: 55725
+format: kgx
+id: bio101.kg-bioportal
+latest_version: '1.0'
+name: AURA KGX graph (KG-Bioportal)
+node_count: 28396
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bio101
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AURA.tar.gz
+layout: product_detail
+---

--- a/resource/bio101/bio101.md
+++ b/resource/bio101/bio101.md
@@ -11,7 +11,7 @@ domains:
 layout: resource_detail
 category: KnowledgeGraph
 creation_date: '2026-06-12T00:00:00Z'
-last_modified_date: '2026-07-03T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 contacts:
 - category: Organization
   contact_details:
@@ -36,6 +36,20 @@ products:
     source: bio101
   - relation_type: prov:wasDerivedFrom
     source: campbell-biology
+- id: bio101.kg-bioportal
+  name: AURA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of KB_Bio_101 (AURA), produced by KG-Bioportal from
+    the BioPortal submission. The archive contains AURA_nodes.tsv and AURA_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/AURA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: bio101
+    relation_type: prov:hadPrimarySource
+  node_count: 28396
+  edge_count: 55725
+  latest_version: '1.0'
 license:
   id: https://creativecommons.org/licenses/by-nc-sa/3.0/
   label: CC BY-NC-SA 3.0

--- a/resource/biolink/biolink.kg-bioportal.md
+++ b/resource/biolink/biolink.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Biolink Model (BIOLINK), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains BIOLINK_nodes.tsv and BIOLINK_edges.tsv.
+edge_count: 812
+format: kgx
+id: biolink.kg-bioportal
+latest_version: 4.4.3
+name: BIOLINK KGX graph (KG-Bioportal)
+node_count: 329
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: biolink
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIOLINK.tar.gz
+layout: product_detail
+---

--- a/resource/biolink/biolink.md
+++ b/resource/biolink/biolink.md
@@ -16,7 +16,7 @@ domains:
   - general
 homepage_url: https://biolink.github.io/biolink-model/
 id: biolink
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -432,6 +432,19 @@ products:
         source: mesh
       - relation_type: prov:used
         source: omim
+  - id: biolink.kg-bioportal
+    name: BIOLINK KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Biolink Model (BIOLINK), produced by KG-Bioportal from the BioPortal submission. The archive contains BIOLINK_nodes.tsv and BIOLINK_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BIOLINK.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: biolink
+        relation_type: prov:hadPrimarySource
+    node_count: 329
+    edge_count: 812
+    latest_version: 4.4.3
 publications:
   - authors:
       - Unni DR

--- a/resource/bioportal/bioportal.md
+++ b/resource/bioportal/bioportal.md
@@ -211,6 +211,51 @@ products:
   secondary_source:
   - relation_type: prov:wasInfluencedBy
     source: bioportal
+- category: GraphicalInterface
+  description: Browsable listing of every KG-Bioportal graph, with node and edge counts,
+    transform status, and a download link for each. This is the canonical index of
+    the transforms; KG-Registry does not mirror the full inventory.
+  format: http
+  id: kg-bioportal.browser
+  name: KG-Bioportal Graph Browser
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: kg-bioportal
+  product_url: https://ncbo.github.io/kg-bioportal/graphs/
+  secondary_source:
+  - relation_type: prov:wasDerivedFrom
+    source: bioportal
+- category: Product
+  description: Manifest of every transform attempt, giving the BioPortal acronym,
+    status, node and edge counts, source submission, and release download URL for
+    each ontology. Refreshed with each monthly transform run.
+  format: yaml
+  id: kg-bioportal.manifest
+  name: KG-Bioportal Transform Manifest
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: kg-bioportal
+  product_url: https://github.com/ncbo/kg-bioportal/releases/latest/download/onto_stats.yaml
+  secondary_source:
+  - relation_type: prov:wasDerivedFrom
+    source: bioportal
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV graphs for all successfully transformed BioPortal ontologies,
+    published as one gzipped tar archive per ontology on the latest release. Individual
+    archives are at https://github.com/ncbo/kg-bioportal/releases/latest/download/<ACRONYM>.tar.gz
+    and contain <ACRONYM>_nodes.tsv and <ACRONYM>_edges.tsv.
+  format: kgx
+  id: kg-bioportal.graphs
+  latest_version: latest
+  name: KG-Bioportal KGX Graphs
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: kg-bioportal
+  product_url: https://github.com/ncbo/kg-bioportal/releases/latest
+  secondary_source:
+  - relation_type: prov:wasDerivedFrom
+    source: bioportal
 publications:
 - authors:
   - Jennifer Vendetti
@@ -230,12 +275,12 @@ publications:
   title: 'BioPortal: an open community resource for sharing, searching, and utilizing
     biomedical ontologies'
   year: '2025'
+repository: https://github.com/ncbo
 taxon:
 - NCBITaxon:9606
 warnings:
 - Some ontologies have distinct licenses; review individual ontology license metadata
   before reuse.
-repository: https://github.com/ncbo
 ---
 # BioPortal
 

--- a/resource/bmont/bmont.kg-bioportal.md
+++ b/resource/bmont/bmont.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of The Biomarker Ontology (BMONT), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains BMONT_nodes.tsv and BMONT_edges.tsv.
+edge_count: 2215
+format: kgx
+id: bmont.kg-bioportal
+latest_version: 'Version Release: 0.5.8'
+name: BMONT KGX graph (KG-Bioportal)
+node_count: 1222
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bmont
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BMONT.tar.gz
+layout: product_detail
+---

--- a/resource/bmont/bmont.md
+++ b/resource/bmont/bmont.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/SCAI-BIO/BiomarkerOntology
 id: bmont
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: bmont
         relation_type: prov:hadPrimarySource
+  - id: bmont.kg-bioportal
+    name: BMONT KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of The Biomarker Ontology (BMONT), produced by KG-Bioportal from the BioPortal submission. The archive contains BMONT_nodes.tsv and BMONT_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BMONT.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: bmont
+        relation_type: prov:hadPrimarySource
+    node_count: 1222
+    edge_count: 2215
+    latest_version: 'Version Release: 0.5.8'
 repository: https://github.com/SCAI-BIO/BiomarkerOntology
 publications: []
 ---

--- a/resource/bspo/bspo.kg-bioportal.md
+++ b/resource/bspo/bspo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Spatial Ontology (BSPO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains BSPO_nodes.tsv and BSPO_edges.tsv.
+edge_count: 905
+format: kgx
+id: bspo.kg-bioportal
+latest_version: '2023-05-27'
+name: BSPO KGX graph (KG-Bioportal)
+node_count: 505
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bspo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BSPO.tar.gz
+layout: product_detail
+---

--- a/resource/bspo/bspo.md
+++ b/resource/bspo/bspo.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://github.com/obophenotype/biological-spatial-ontology
 id: bspo
 infores_id: bspo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -198,6 +198,20 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: bspo.kg-bioportal
+  name: BSPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Spatial Ontology (BSPO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains BSPO_nodes.tsv and BSPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BSPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: bspo
+    relation_type: prov:hadPrimarySource
+  node_count: 505
+  edge_count: 905
+  latest_version: '2023-05-27'
 publications:
 - authors:
   - Dahdul WM

--- a/resource/bto/bto.kg-bioportal.md
+++ b/resource/bto/bto.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of BRENDA Tissue and Enzyme Source Ontology (BTO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains BTO_nodes.tsv
+  and BTO_edges.tsv.
+edge_count: 7657
+format: kgx
+id: bto.kg-bioportal
+latest_version: releases/2021-10-26
+name: BTO KGX graph (KG-Bioportal)
+node_count: 6612
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: bto
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BTO.tar.gz
+layout: product_detail
+---

--- a/resource/bto/bto.md
+++ b/resource/bto/bto.md
@@ -19,7 +19,7 @@ domains:
 - anatomy and development
 homepage_url: http://www.brenda-enzymes.org
 id: bto
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -633,6 +633,21 @@ products:
   - relation_type: prov:hadPrimarySource
     source: motifmap
   product_url: https://available-inventions.umich.edu/product/genomickb-a-knowledgebase-for-the-human-genome
+- id: bto.kg-bioportal
+  name: BTO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of BRENDA Tissue and Enzyme Source Ontology (BTO),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains BTO_nodes.tsv
+    and BTO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/BTO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: bto
+    relation_type: prov:hadPrimarySource
+  node_count: 6612
+  edge_count: 7657
+  latest_version: releases/2021-10-26
 publications:
 - authors:
   - Gremse M

--- a/resource/caro/caro.kg-bioportal.md
+++ b/resource/caro/caro.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Common Anatomy Reference Ontology (CARO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains CARO_nodes.tsv
+  and CARO_edges.tsv.
+edge_count: 10155
+format: kgx
+id: caro.kg-bioportal
+latest_version: '2023-03-15'
+name: CARO KGX graph (KG-Bioportal)
+node_count: 8891
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: caro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CARO.tar.gz
+layout: product_detail
+---

--- a/resource/caro/caro.md
+++ b/resource/caro/caro.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/caro/
 id: caro
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: caro
         relation_type: prov:hadPrimarySource
+  - id: caro.kg-bioportal
+    name: CARO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Common Anatomy Reference Ontology (CARO), produced by KG-Bioportal from the BioPortal submission. The archive contains CARO_nodes.tsv and CARO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CARO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: caro
+        relation_type: prov:hadPrimarySource
+    node_count: 8891
+    edge_count: 10155
+    latest_version: '2023-03-15'
 repository: https://github.com/obophenotype/caro
 publications: []
 ---

--- a/resource/ccf/ccf.kg-bioportal.md
+++ b/resource/ccf/ccf.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Human Reference Atlas Common Coordinate Framework
+  Ontology (CCF), produced by KG-Bioportal from the BioPortal submission. The archive
+  contains CCF_nodes.tsv and CCF_edges.tsv.
+edge_count: 23
+format: kgx
+id: ccf.kg-bioportal
+latest_version: 3.0.0
+name: CCF KGX graph (KG-Bioportal)
+node_count: 140
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ccf
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CCF.tar.gz
+layout: product_detail
+---

--- a/resource/ccf/ccf.md
+++ b/resource/ccf/ccf.md
@@ -23,7 +23,7 @@ domains:
 - biomedical
 homepage_url: https://humanatlas.io/ccf-ontology
 id: ccf
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -197,6 +197,21 @@ products:
     source: vccf
   product_file_size: 376981902
   product_url: https://cdn.humanatlas.io/digital-objects/collection/hra/v2.2/graph.nq
+- id: ccf.kg-bioportal
+  name: CCF KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Human Reference Atlas Common Coordinate Framework
+    Ontology (CCF), produced by KG-Bioportal from the BioPortal submission. The archive
+    contains CCF_nodes.tsv and CCF_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CCF.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ccf
+    relation_type: prov:hadPrimarySource
+  node_count: 140
+  edge_count: 23
+  latest_version: 3.0.0
 publications:
 - authors:
   - Börner K

--- a/resource/cdao/cdao.kg-bioportal.md
+++ b/resource/cdao/cdao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Comparative Data Analysis Ontology (CDAO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains CDAO_nodes.tsv
+  and CDAO_edges.tsv.
+edge_count: 346
+format: kgx
+id: cdao.kg-bioportal
+latest_version: $Revision$
+name: CDAO KGX graph (KG-Bioportal)
+node_count: 238
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cdao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDAO.tar.gz
+layout: product_detail
+---

--- a/resource/cdao/cdao.md
+++ b/resource/cdao/cdao.md
@@ -20,7 +20,7 @@ domains:
 - organisms
 homepage_url: https://github.com/evoinfo/cdao
 id: cdao
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -38,6 +38,21 @@ products:
   original_source:
   - source: cdao
     relation_type: prov:hadPrimarySource
+- id: cdao.kg-bioportal
+  name: CDAO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Comparative Data Analysis Ontology (CDAO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains CDAO_nodes.tsv
+    and CDAO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDAO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: cdao
+    relation_type: prov:hadPrimarySource
+  node_count: 238
+  edge_count: 346
+  latest_version: $Revision$
 repository: https://github.com/evoinfo/cdao
 publications:
 - authors:

--- a/resource/cdno/cdno.kg-bioportal.md
+++ b/resource/cdno/cdno.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Compositional Dietary Nutrition Ontology (CDNO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains CDNO_nodes.tsv
+  and CDNO_edges.tsv.
+edge_count: 5886
+format: kgx
+id: cdno.kg-bioportal
+name: CDNO KGX graph (KG-Bioportal)
+node_count: 3507
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cdno
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDNO.tar.gz
+layout: product_detail
+---

--- a/resource/cdno/cdno.md
+++ b/resource/cdno/cdno.md
@@ -20,7 +20,7 @@ domains:
 - nutrition
 homepage_url: https://cdno.info/
 id: cdno
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -48,6 +48,20 @@ products:
   original_source:
   - source: cdno
     relation_type: prov:hadPrimarySource
+- id: cdno.kg-bioportal
+  name: CDNO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Compositional Dietary Nutrition Ontology (CDNO),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains CDNO_nodes.tsv
+    and CDNO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CDNO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: cdno
+    relation_type: prov:hadPrimarySource
+  node_count: 3507
+  edge_count: 5886
 repository: https://github.com/CompositionalDietaryNutritionOntology/cdno
 publications:
 - authors:

--- a/resource/ceph/ceph.kg-bioportal.md
+++ b/resource/ceph/ceph.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Cephalopod Ontology (CEPH), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains CEPH_nodes.tsv and CEPH_edges.tsv.
+edge_count: 583
+format: kgx
+id: ceph.kg-bioportal
+name: CEPH KGX graph (KG-Bioportal)
+node_count: 484
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ceph
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CEPH.tar.gz
+layout: product_detail
+---

--- a/resource/ceph/ceph.md
+++ b/resource/ceph/ceph.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/cephalopod-ontology
 id: ceph
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: ceph
         relation_type: prov:hadPrimarySource
+  - id: ceph.kg-bioportal
+    name: CEPH KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Cephalopod Ontology (CEPH), produced by KG-Bioportal from the BioPortal submission. The archive contains CEPH_nodes.tsv and CEPH_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CEPH.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ceph
+        relation_type: prov:hadPrimarySource
+    node_count: 484
+    edge_count: 583
 repository: https://github.com/obophenotype/cephalopod-ontology
 taxon:
   - NCBITaxon:6605

--- a/resource/cheminf/cheminf.kg-bioportal.md
+++ b/resource/cheminf/cheminf.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Chemical Information Ontology (CHEMINF), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains CHEMINF_nodes.tsv
+  and CHEMINF_edges.tsv.
+edge_count: 639
+format: kgx
+id: cheminf.kg-bioportal
+latest_version: 2.1.0
+name: CHEMINF KGX graph (KG-Bioportal)
+node_count: 625
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cheminf
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHEMINF.tar.gz
+layout: product_detail
+---

--- a/resource/cheminf/cheminf.md
+++ b/resource/cheminf/cheminf.md
@@ -19,7 +19,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: https://github.com/semanticchemistry/semanticchemistry
 id: cheminf
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -69,6 +69,21 @@ products:
   - relation_type: prov:hadPrimarySource
     source: skos
   product_url: https://forum.semantic-metabolomics.fr/sparql
+- id: cheminf.kg-bioportal
+  name: CHEMINF KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Chemical Information Ontology (CHEMINF), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains CHEMINF_nodes.tsv
+    and CHEMINF_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHEMINF.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: cheminf
+    relation_type: prov:hadPrimarySource
+  node_count: 625
+  edge_count: 639
+  latest_version: 2.1.0
 publications:
 - authors:
   - Hastings J

--- a/resource/chiro/chiro.kg-bioportal.md
+++ b/resource/chiro/chiro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of CHEBI Integrated Role Ontology (CHIRO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains CHIRO_nodes.tsv
+  and CHIRO_edges.tsv.
+edge_count: 466
+format: kgx
+id: chiro.kg-bioportal
+name: CHIRO KGX graph (KG-Bioportal)
+node_count: 429
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: chiro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHIRO.tar.gz
+layout: product_detail
+---

--- a/resource/chiro/chiro.md
+++ b/resource/chiro/chiro.md
@@ -18,7 +18,7 @@ domains:
   - chemistry and biochemistry
 homepage_url: https://github.com/obophenotype/chiro
 id: chiro
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: chiro
         relation_type: prov:hadPrimarySource
+  - id: chiro.kg-bioportal
+    name: CHIRO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of CHEBI Integrated Role Ontology (CHIRO), produced by KG-Bioportal from the BioPortal submission. The archive contains CHIRO_nodes.tsv and CHIRO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHIRO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: chiro
+        relation_type: prov:hadPrimarySource
+    node_count: 429
+    edge_count: 466
 repository: https://github.com/obophenotype/chiro
 publications:
   - authors:

--- a/resource/chmo/chmo.kg-bioportal.md
+++ b/resource/chmo/chmo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Chemical Methods Ontology (CHMO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains CHMO_nodes.tsv and CHMO_edges.tsv.
+edge_count: 4437
+format: kgx
+id: chmo.kg-bioportal
+latest_version: '2026-05-28'
+name: CHMO KGX graph (KG-Bioportal)
+node_count: 3656
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: chmo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHMO.tar.gz
+layout: product_detail
+---

--- a/resource/chmo/chmo.md
+++ b/resource/chmo/chmo.md
@@ -18,7 +18,7 @@ domains:
 - biomedical
 homepage_url: https://github.com/rsc-ontologies/rsc-cmo
 id: chmo
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -123,6 +123,21 @@ products:
     source: dcat
   - relation_type: prov:wasInformedBy
     source: afo
+- id: chmo.kg-bioportal
+  name: CHMO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Chemical Methods Ontology (CHMO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains CHMO_nodes.tsv
+    and CHMO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHMO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: chmo
+    relation_type: prov:hadPrimarySource
+  node_count: 3656
+  edge_count: 4437
+  latest_version: '2026-05-28'
 publications: []
 repository: https://github.com/rsc-ontologies/rsc-cmo
 ---

--- a/resource/chr/chr.kg-bioportal.md
+++ b/resource/chr/chr.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Monochrom (CHR), produced by KG-Bioportal from the
+  BioPortal submission. The archive contains CHR_nodes.tsv and CHR_edges.tsv.
+edge_count: 5154
+format: kgx
+id: chr.kg-bioportal
+latest_version: '2025-10-15'
+name: CHR KGX graph (KG-Bioportal)
+node_count: 3115
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: chr
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHR.tar.gz
+layout: product_detail
+---

--- a/resource/chr/chr.md
+++ b/resource/chr/chr.md
@@ -45,9 +45,22 @@ products:
         relation_type: prov:hadPrimarySource
     product_file_size: 102365
     product_url: https://raw.githubusercontent.com/monarch-initiative/monochrom/refs/heads/master/chr.owl
+  - id: chr.kg-bioportal
+    name: CHR KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Monochrom (CHR), produced by KG-Bioportal from the BioPortal submission. The archive contains CHR_nodes.tsv and CHR_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CHR.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: chr
+        relation_type: prov:hadPrimarySource
+    node_count: 3115
+    edge_count: 5154
+    latest_version: '2025-10-15'
 repository: https://github.com/monarch-initiative/monochrom/
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2025-10-06T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 ---
 
 Automatic translation of UCSC chromosome bands to OWL classes

--- a/resource/cido/cido.kg-bioportal.md
+++ b/resource/cido/cido.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Coronavirus Infectious Disease Ontology (CIDO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains CIDO_nodes.tsv
+  and CIDO_edges.tsv.
+edge_count: 104133
+format: kgx
+id: cido.kg-bioportal
+latest_version: '2024-02-16'
+name: CIDO KGX graph (KG-Bioportal)
+node_count: 32946
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cido
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIDO.tar.gz
+layout: product_detail
+---

--- a/resource/cido/cido.md
+++ b/resource/cido/cido.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/cido-ontology/cido
 id: cido
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: cido
         relation_type: prov:hadPrimarySource
+  - id: cido.kg-bioportal
+    name: CIDO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Coronavirus Infectious Disease Ontology (CIDO), produced by KG-Bioportal from the BioPortal submission. The archive contains CIDO_nodes.tsv and CIDO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIDO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: cido
+        relation_type: prov:hadPrimarySource
+    node_count: 32946
+    edge_count: 104133
+    latest_version: '2024-02-16'
 repository: https://github.com/cido-ontology/cido
 publications:
   - authors:

--- a/resource/cio/cio.kg-bioportal.md
+++ b/resource/cio/cio.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Confidence Information Ontology (CIO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains CIO_nodes.tsv
+  and CIO_edges.tsv.
+edge_count: 129
+format: kgx
+id: cio.kg-bioportal
+name: CIO KGX graph (KG-Bioportal)
+node_count: 64
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cio
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIO.tar.gz
+layout: product_detail
+---

--- a/resource/cio/cio.md
+++ b/resource/cio/cio.md
@@ -19,7 +19,7 @@ domains:
 - information technology
 homepage_url: https://github.com/BgeeDB/confidence-information-ontology
 id: cio
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -47,6 +47,20 @@ products:
   original_source:
   - source: cio
     relation_type: prov:hadPrimarySource
+- id: cio.kg-bioportal
+  name: CIO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Confidence Information Ontology (CIO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains CIO_nodes.tsv
+    and CIO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CIO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: cio
+    relation_type: prov:hadPrimarySource
+  node_count: 64
+  edge_count: 129
 repository: https://github.com/BgeeDB/confidence-information-ontology
 publications:
 - authors:

--- a/resource/cl/cl.kg-bioportal.md
+++ b/resource/cl/cl.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Cell Ontology (CL), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains CL_nodes.tsv and CL_edges.tsv.
+edge_count: 85215
+format: kgx
+id: cl.kg-bioportal
+latest_version: '2026-06-08'
+name: CL KGX graph (KG-Bioportal)
+node_count: 20178
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cl
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CL.tar.gz
+layout: product_detail
+---

--- a/resource/cl/cl.md
+++ b/resource/cl/cl.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://obophenotype.github.io/cell-ontology/
 id: cl
 infores_id: cl
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -909,8 +909,8 @@ products:
   compatibility:
   - standard: biolink
   compression: zip
-  description: "Curated mechanistic drug\u2013disease paths comprising the DrugMechDB\
-    \ dataset packaged as a downloadable archive."
+  description: Curated mechanistic drug–disease paths comprising the DrugMechDB dataset
+    packaged as a downloadable archive.
   dump_format: other
   format: mixed
   id: drugmechdb.graph
@@ -2476,6 +2476,20 @@ products:
     source: uniprot
   - relation_type: prov:wasInfluencedBy
     source: wikipathways
+- id: cl.kg-bioportal
+  name: CL KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Cell Ontology (CL), produced by KG-Bioportal from
+    the BioPortal submission. The archive contains CL_nodes.tsv and CL_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CL.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: cl
+    relation_type: prov:hadPrimarySource
+  node_count: 20178
+  edge_count: 85215
+  latest_version: '2026-06-08'
 publications:
 - authors:
   - Diehl AD

--- a/resource/clao/clao.kg-bioportal.md
+++ b/resource/clao/clao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Collembola Anatomy Ontology (CLAO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains CLAO_nodes.tsv
+  and CLAO_edges.tsv.
+edge_count: 2653
+format: kgx
+id: clao.kg-bioportal
+latest_version: '2021-09-27'
+name: CLAO KGX graph (KG-Bioportal)
+node_count: 1565
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: clao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLAO.tar.gz
+layout: product_detail
+---

--- a/resource/clao/clao.md
+++ b/resource/clao/clao.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/luis-gonzalez-m/Collembola
 id: clao
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: clao
         relation_type: prov:hadPrimarySource
+  - id: clao.kg-bioportal
+    name: CLAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Collembola Anatomy Ontology (CLAO), produced by KG-Bioportal from the BioPortal submission. The archive contains CLAO_nodes.tsv and CLAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: clao
+        relation_type: prov:hadPrimarySource
+    node_count: 1565
+    edge_count: 2653
+    latest_version: '2021-09-27'
 repository: https://github.com/luis-gonzalez-m/Collembola
 publications: []
 ---

--- a/resource/clo/clo.kg-bioportal.md
+++ b/resource/clo/clo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Cell Line Ontology (CLO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains CLO_nodes.tsv and CLO_edges.tsv.
+edge_count: 69409
+format: kgx
+id: clo.kg-bioportal
+latest_version: '2026-06-19'
+name: CLO KGX graph (KG-Bioportal)
+node_count: 48410
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: clo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLO.tar.gz
+layout: product_detail
+---

--- a/resource/clo/clo.md
+++ b/resource/clo/clo.md
@@ -19,7 +19,7 @@ domains:
 - anatomy and development
 homepage_url: https://github.com/CLO-Ontology/CLO
 id: clo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -435,6 +435,20 @@ products:
     source: uberon
   product_file_size: 936065236
   product_url: https://zenodo.org/records/12536780/files/NP-KG_v3.0.0.gpickle?download=1
+- id: clo.kg-bioportal
+  name: CLO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Cell Line Ontology (CLO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains CLO_nodes.tsv and CLO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: clo
+    relation_type: prov:hadPrimarySource
+  node_count: 48410
+  edge_count: 69409
+  latest_version: '2026-06-19'
 publications:
 - authors:
   - Sarntivijai S
@@ -443,7 +457,7 @@ publications:
   - Meehan TF
   - Diehl AD
   - Vempati UD
-  - "Sch\xFCrer SC"
+  - Schürer SC
   - Pang C
   - Malone J
   - Parkinson H

--- a/resource/clyh/clyh.kg-bioportal.md
+++ b/resource/clyh/clyh.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Clytia hemisphaerica Development and Anatomy Ontology
+  (CLYH), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  CLYH_nodes.tsv and CLYH_edges.tsv.
+edge_count: 746
+format: kgx
+id: clyh.kg-bioportal
+name: CLYH KGX graph (KG-Bioportal)
+node_count: 279
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: clyh
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLYH.tar.gz
+layout: product_detail
+---

--- a/resource/clyh/clyh.md
+++ b/resource/clyh/clyh.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/EBISPOT/clyh_ontology
 id: clyh
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: clyh
         relation_type: prov:hadPrimarySource
+  - id: clyh.kg-bioportal
+    name: CLYH KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Clytia hemisphaerica Development and Anatomy Ontology (CLYH), produced by KG-Bioportal from the BioPortal submission. The archive contains CLYH_nodes.tsv and CLYH_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CLYH.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: clyh
+        relation_type: prov:hadPrimarySource
+    node_count: 279
+    edge_count: 746
 repository: https://github.com/EBISPOT/clyh_ontology
 publications: []
 ---

--- a/resource/cmo/cmo.kg-bioportal.md
+++ b/resource/cmo/cmo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Clinical Measurement Ontology (CMO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains CMO_nodes.tsv and
+  CMO_edges.tsv.
+edge_count: 5013
+format: kgx
+id: cmo.kg-bioportal
+latest_version: '2026-07-25'
+name: CMO KGX graph (KG-Bioportal)
+node_count: 4186
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cmo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CMO.tar.gz
+layout: product_detail
+---

--- a/resource/cmo/cmo.md
+++ b/resource/cmo/cmo.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: http://rgd.mcw.edu/rgdweb/ontology/search.html
 id: cmo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -46,41 +46,54 @@ products:
     original_source:
       - source: cmo
         relation_type: prov:hadPrimarySource
+  - id: cmo.kg-bioportal
+    name: CMO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Clinical Measurement Ontology (CMO), produced by KG-Bioportal from the BioPortal submission. The archive contains CMO_nodes.tsv and CMO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CMO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: cmo
+        relation_type: prov:hadPrimarySource
+    node_count: 4186
+    edge_count: 5013
+    latest_version: '2026-07-25'
 repository: https://github.com/rat-genome-database/CMO-Clinical-Measurement-Ontology
 publications:
-- authors:
-  - Shimoyama M
-  - Nigam R
-  - McIntosh LS
-  - Nagarajan R
-  - Rice T
-  - Rao DC
-  - Dwinell MR
-  doi: 10.3389/fgene.2012.00087
-  id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
-  journal: Front Genet
-  title: Three ontologies to define phenotype measurement data.
-  year: '2012'
-- authors:
-  - Smith JR
-  - Park CA
-  - Nigam R
-  - Laulederkind SJ
-  - Hayman GT
-  - Wang SJ
-  - Lowry TF
-  - Petri V
-  - Pons JD
-  - Tutaj M
-  - Liu W
-  - Worthey EA
-  - Shimoyama M
-  - Dwinell MR
-  doi: 10.1186/2041-1480-4-26
-  id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
-  journal: J Biomed Semantics
-  title: 'The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications.'
-  year: '2013'
+  - authors:
+      - Shimoyama M
+      - Nigam R
+      - McIntosh LS
+      - Nagarajan R
+      - Rice T
+      - Rao DC
+      - Dwinell MR
+    doi: 10.3389/fgene.2012.00087
+    id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
+    journal: Front Genet
+    title: Three ontologies to define phenotype measurement data.
+    year: '2012'
+  - authors:
+      - Smith JR
+      - Park CA
+      - Nigam R
+      - Laulederkind SJ
+      - Hayman GT
+      - Wang SJ
+      - Lowry TF
+      - Petri V
+      - Pons JD
+      - Tutaj M
+      - Liu W
+      - Worthey EA
+      - Shimoyama M
+      - Dwinell MR
+    doi: 10.1186/2041-1480-4-26
+    id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
+    journal: J Biomed Semantics
+    title: 'The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications.'
+    year: '2013'
 ---
 
 ## Description

--- a/resource/cob/cob.kg-bioportal.md
+++ b/resource/cob/cob.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Core Ontology for Biology and Biomedicine (COB),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains COB_nodes.tsv
+  and COB_edges.tsv.
+edge_count: 106
+format: kgx
+id: cob.kg-bioportal
+latest_version: '2025-12-15'
+name: COB KGX graph (KG-Bioportal)
+node_count: 126
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cob
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COB.tar.gz
+layout: product_detail
+---

--- a/resource/cob/cob.md
+++ b/resource/cob/cob.md
@@ -19,7 +19,7 @@ domains:
   - general
 homepage_url: https://obofoundry.org/COB/
 id: cob
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -255,6 +255,19 @@ products:
         source: zfa
     product_file_size: 64058275
     product_url: https://www.ebi.ac.uk/efo/efo.obo
+  - id: cob.kg-bioportal
+    name: COB KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Core Ontology for Biology and Biomedicine (COB), produced by KG-Bioportal from the BioPortal submission. The archive contains COB_nodes.tsv and COB_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COB.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: cob
+        relation_type: prov:hadPrimarySource
+    node_count: 126
+    edge_count: 106
+    latest_version: '2025-12-15'
 publications: []
 repository: https://github.com/OBOFoundry/COB
 ---

--- a/resource/colao/colao.kg-bioportal.md
+++ b/resource/colao/colao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Coleoptera Anatomy Ontology (COLAO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains COLAO_nodes.tsv
+  and COLAO_edges.tsv.
+edge_count: 2691
+format: kgx
+id: colao.kg-bioportal
+latest_version: '2024-06-21'
+name: COLAO KGX graph (KG-Bioportal)
+node_count: 1319
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: colao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COLAO.tar.gz
+layout: product_detail
+---

--- a/resource/colao/colao.md
+++ b/resource/colao/colao.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/insect-morphology/colao
 id: colao
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: colao
         relation_type: prov:hadPrimarySource
+  - id: colao.kg-bioportal
+    name: COLAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Coleoptera Anatomy Ontology (COLAO), produced by KG-Bioportal from the BioPortal submission. The archive contains COLAO_nodes.tsv and COLAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/COLAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: colao
+        relation_type: prov:hadPrimarySource
+    node_count: 1319
+    edge_count: 2691
+    latest_version: '2024-06-21'
 repository: https://github.com/insect-morphology/colao
 publications: []
 ---

--- a/resource/cro/cro.kg-bioportal.md
+++ b/resource/cro/cro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Contributor Role Ontology (CRO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains CRO_nodes.tsv and CRO_edges.tsv.
+edge_count: 237
+format: kgx
+id: cro.kg-bioportal
+latest_version: v2019-08-16
+name: CRO KGX graph (KG-Bioportal)
+node_count: 138
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CRO.tar.gz
+layout: product_detail
+---

--- a/resource/cro/cro.md
+++ b/resource/cro/cro.md
@@ -22,7 +22,7 @@ domains:
 - information technology
 homepage_url: https://github.com/data2health/contributor-role-ontology
 id: cro
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/2.0/
@@ -40,6 +40,20 @@ products:
   original_source:
   - source: cro
     relation_type: prov:hadPrimarySource
+- id: cro.kg-bioportal
+  name: CRO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Contributor Role Ontology (CRO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains CRO_nodes.tsv and CRO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CRO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: cro
+    relation_type: prov:hadPrimarySource
+  node_count: 138
+  edge_count: 237
+  latest_version: v2019-08-16
 repository: https://github.com/data2health/contributor-role-ontology
 publications:
 - authors:

--- a/resource/cteno/cteno.kg-bioportal.md
+++ b/resource/cteno/cteno.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ctenophore Ontology (CTENO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains CTENO_nodes.tsv and CTENO_edges.tsv.
+edge_count: 950
+format: kgx
+id: cteno.kg-bioportal
+name: CTENO KGX graph (KG-Bioportal)
+node_count: 680
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cteno
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTENO.tar.gz
+layout: product_detail
+---

--- a/resource/cteno/cteno.md
+++ b/resource/cteno/cteno.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/ctenophore-ontology
 id: cteno
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,18 @@ products:
     original_source:
       - source: cteno
         relation_type: prov:hadPrimarySource
+  - id: cteno.kg-bioportal
+    name: CTENO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ctenophore Ontology (CTENO), produced by KG-Bioportal from the BioPortal submission. The archive contains CTENO_nodes.tsv and CTENO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTENO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: cteno
+        relation_type: prov:hadPrimarySource
+    node_count: 680
+    edge_count: 950
 repository: https://github.com/obophenotype/ctenophore-ontology
 taxon:
   - NCBITaxon:10197

--- a/resource/cto/cto.kg-bioportal.md
+++ b/resource/cto/cto.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Clinical Trials Ontology (CTO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains CTO_nodes.tsv and CTO_edges.tsv.
+edge_count: 904
+format: kgx
+id: cto.kg-bioportal
+latest_version: 'Version Release: 1.0.0'
+name: CTO KGX graph (KG-Bioportal)
+node_count: 447
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cto
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTO.tar.gz
+layout: product_detail
+---

--- a/resource/cto/cto.md
+++ b/resource/cto/cto.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/ClinicalTrialOntology/CTO/
 id: cto
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: cto
         relation_type: prov:hadPrimarySource
+  - id: cto.kg-bioportal
+    name: CTO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Clinical Trials Ontology (CTO), produced by KG-Bioportal from the BioPortal submission. The archive contains CTO_nodes.tsv and CTO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CTO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: cto
+        relation_type: prov:hadPrimarySource
+    node_count: 447
+    edge_count: 904
+    latest_version: 'Version Release: 1.0.0'
 repository: https://github.com/ClinicalTrialOntology/CTO
 publications: []
 ---

--- a/resource/cvdo/cvdo.kg-bioportal.md
+++ b/resource/cvdo/cvdo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Cardiovascular Disease Ontology (CVDO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains CVDO_nodes.tsv
+  and CVDO_edges.tsv.
+edge_count: 1865
+format: kgx
+id: cvdo.kg-bioportal
+latest_version: '2024-05-17'
+name: CVDO KGX graph (KG-Bioportal)
+node_count: 1023
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: cvdo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CVDO.tar.gz
+layout: product_detail
+---

--- a/resource/cvdo/cvdo.md
+++ b/resource/cvdo/cvdo.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/OpenLHS/CVDO
 id: cvdo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: cvdo
         relation_type: prov:hadPrimarySource
+  - id: cvdo.kg-bioportal
+    name: CVDO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Cardiovascular Disease Ontology (CVDO), produced by KG-Bioportal from the BioPortal submission. The archive contains CVDO_nodes.tsv and CVDO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/CVDO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: cvdo
+        relation_type: prov:hadPrimarySource
+    node_count: 1023
+    edge_count: 1865
+    latest_version: '2024-05-17'
 repository: https://github.com/OpenLHS/CVDO
 publications: []
 ---

--- a/resource/dc/dc.kg-bioportal.md
+++ b/resource/dc/dc.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Dublin Core (DC), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains DC_nodes.tsv and DC_edges.tsv.
+edge_count: 37
+format: kgx
+id: dc.kg-bioportal
+name: DC KGX graph (KG-Bioportal)
+node_count: 38
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: dc
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DC.tar.gz
+layout: product_detail
+---

--- a/resource/dc/dc.md
+++ b/resource/dc/dc.md
@@ -21,7 +21,7 @@ domains:
 - literature
 homepage_url: https://www.dublincore.org/
 id: dc
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -364,15 +364,28 @@ products:
     source: skos
   product_file_size: 1977072
   product_url: https://edamontology.org/EDAM.csv
+- id: dc.kg-bioportal
+  name: DC KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Dublin Core (DC), produced by KG-Bioportal from
+    the BioPortal submission. The archive contains DC_nodes.tsv and DC_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DC.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: dc
+    relation_type: prov:hadPrimarySource
+  node_count: 38
+  edge_count: 37
 publications:
 - id: https://www.iso.org/standard/71339.html
   preferred: true
-  title: "ISO 15836-1:2017 Information and documentation \u2014 The Dublin Core metadata\
-    \ element set \u2014 Part 1: Core elements"
+  title: 'ISO 15836-1:2017 Information and documentation — The Dublin Core metadata
+    element set — Part 1: Core elements'
   year: '2017'
 - id: https://www.iso.org/standard/71341.html
-  title: "ISO 15836-2:2019 Information and documentation \u2014 The Dublin Core metadata\
-    \ element set \u2014 Part 2: DCMI Properties and classes"
+  title: 'ISO 15836-2:2019 Information and documentation — The Dublin Core metadata
+    element set — Part 2: DCMI Properties and classes'
   year: '2019'
 repository: https://github.com/dcmi/
 ---

--- a/resource/dcat/dcat.kg-bioportal.md
+++ b/resource/dcat/dcat.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Data Catalog Vocabulary (DCAT), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains DCAT_nodes.tsv and DCAT_edges.tsv.
+edge_count: 64
+format: kgx
+id: dcat.kg-bioportal
+name: DCAT KGX graph (KG-Bioportal)
+node_count: 51
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: dcat
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCAT.tar.gz
+layout: product_detail
+---

--- a/resource/dcat/dcat.md
+++ b/resource/dcat/dcat.md
@@ -15,7 +15,7 @@ domains:
 - general
 homepage_url: https://www.w3.org/TR/vocab-dcat-3/
 id: dcat
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 name: Data Catalog Vocabulary
 products:
@@ -126,6 +126,19 @@ products:
     source: dcat
   - relation_type: prov:wasInformedBy
     source: afo
+- id: dcat.kg-bioportal
+  name: DCAT KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Data Catalog Vocabulary (DCAT), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains DCAT_nodes.tsv and DCAT_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCAT.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: dcat
+    relation_type: prov:hadPrimarySource
+  node_count: 51
+  edge_count: 64
 publications:
 - authors:
   - Riccardo Albertoni

--- a/resource/dct/dct.kg-bioportal.md
+++ b/resource/dct/dct.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of DC Terms (DCT), produced by KG-Bioportal from the
+  BioPortal submission. The archive contains DCT_nodes.tsv and DCT_edges.tsv.
+edge_count: 360
+format: kgx
+id: dct.kg-bioportal
+name: DCT KGX graph (KG-Bioportal)
+node_count: 240
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: dct
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCT.tar.gz
+layout: product_detail
+---

--- a/resource/dct/dct.md
+++ b/resource/dct/dct.md
@@ -10,7 +10,7 @@ domains:
 - literature
 homepage_url: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/
 id: dct
-last_modified_date: '2026-05-30T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -267,6 +267,19 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
+- id: dct.kg-bioportal
+  name: DCT KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of DC Terms (DCT), produced by KG-Bioportal from
+    the BioPortal submission. The archive contains DCT_nodes.tsv and DCT_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DCT.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: dct
+    relation_type: prov:hadPrimarySource
+  node_count: 240
+  edge_count: 360
 synonyms:
 - DCT
 - DCMI Terms

--- a/resource/ddanat/ddanat.kg-bioportal.md
+++ b/resource/ddanat/ddanat.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Dictyostelium Discoideum Anatomy Ontology (DDANAT),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains DDANAT_nodes.tsv
+  and DDANAT_edges.tsv.
+edge_count: 360
+format: kgx
+id: ddanat.kg-bioportal
+latest_version: '1.19'
+name: DDANAT KGX graph (KG-Bioportal)
+node_count: 163
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ddanat
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DDANAT.tar.gz
+layout: product_detail
+---

--- a/resource/ddanat/ddanat.md
+++ b/resource/ddanat/ddanat.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://dictybase.org/
 id: ddanat
 infores_id: dda
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -198,6 +198,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: ddanat.kg-bioportal
+  name: DDANAT KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Dictyostelium Discoideum Anatomy Ontology (DDANAT),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains DDANAT_nodes.tsv
+    and DDANAT_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DDANAT.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ddanat
+    relation_type: prov:hadPrimarySource
+  node_count: 163
+  edge_count: 360
+  latest_version: '1.19'
 publications:
 - authors:
   - Gaudet P

--- a/resource/ddpheno/ddpheno.kg-bioportal.md
+++ b/resource/ddpheno/ddpheno.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Dictyostelium Discoideum Phenotype Ontology (DDPHENO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains DDPHENO_nodes.tsv
+  and DDPHENO_edges.tsv.
+edge_count: 1435
+format: kgx
+id: ddpheno.kg-bioportal
+name: DDPHENO KGX graph (KG-Bioportal)
+node_count: 1399
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ddpheno
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DDPHENO.tar.gz
+layout: product_detail
+---

--- a/resource/ddpheno/ddpheno.md
+++ b/resource/ddpheno/ddpheno.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://dictybase.org/
 id: ddpheno
 infores_id: ddpheno
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -198,6 +198,20 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: ddpheno.kg-bioportal
+  name: DDPHENO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Dictyostelium Discoideum Phenotype Ontology (DDPHENO),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains DDPHENO_nodes.tsv
+    and DDPHENO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DDPHENO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ddpheno
+    relation_type: prov:hadPrimarySource
+  node_count: 1399
+  edge_count: 1435
 publications:
 - authors:
   - Fey P

--- a/resource/dideo/dideo.kg-bioportal.md
+++ b/resource/dideo/dideo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Drug Interaction and Evidence Ontology (DIDEO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains DIDEO_nodes.tsv
+  and DIDEO_edges.tsv.
+edge_count: 822
+format: kgx
+id: dideo.kg-bioportal
+latest_version: release version 2017-11-17
+name: DIDEO KGX graph (KG-Bioportal)
+node_count: 675
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: dideo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DIDEO.tar.gz
+layout: product_detail
+---

--- a/resource/dideo/dideo.md
+++ b/resource/dideo/dideo.md
@@ -19,7 +19,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: https://github.com/DIDEO/DIDEO
 id: dideo
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -145,6 +145,21 @@ products:
     source: uberon
   product_file_size: 936065236
   product_url: https://zenodo.org/records/12536780/files/NP-KG_v3.0.0.gpickle?download=1
+- id: dideo.kg-bioportal
+  name: DIDEO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Drug Interaction and Evidence Ontology (DIDEO),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains DIDEO_nodes.tsv
+    and DIDEO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DIDEO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: dideo
+    relation_type: prov:hadPrimarySource
+  node_count: 675
+  edge_count: 822
+  latest_version: release version 2017-11-17
 publications:
 - authors:
   - John Judkins

--- a/resource/disdriv/disdriv.kg-bioportal.md
+++ b/resource/disdriv/disdriv.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Disease Drivers Ontology (DISDRIV), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains DISDRIV_nodes.tsv
+  and DISDRIV_edges.tsv.
+edge_count: 84
+format: kgx
+id: disdriv.kg-bioportal
+latest_version: '2026-03-31'
+name: DISDRIV KGX graph (KG-Bioportal)
+node_count: 99
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: disdriv
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DISDRIV.tar.gz
+layout: product_detail
+---

--- a/resource/disdriv/disdriv.md
+++ b/resource/disdriv/disdriv.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://disease-ontology.org/
 id: disdriv
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: disdriv
         relation_type: prov:hadPrimarySource
+  - id: disdriv.kg-bioportal
+    name: DISDRIV KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Disease Drivers Ontology (DISDRIV), produced by KG-Bioportal from the BioPortal submission. The archive contains DISDRIV_nodes.tsv and DISDRIV_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DISDRIV.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: disdriv
+        relation_type: prov:hadPrimarySource
+    node_count: 99
+    edge_count: 84
+    latest_version: '2026-03-31'
 repository: https://github.com/DiseaseOntology/DiseaseDriversOntology
 taxon:
   - NCBITaxon:9606

--- a/resource/doid/doid.kg-bioportal.md
+++ b/resource/doid/doid.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Human Disease Ontology (DOID), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains DOID_nodes.tsv and DOID_edges.tsv.
+edge_count: 39169
+format: kgx
+id: doid.kg-bioportal
+latest_version: '2026-07-31'
+name: DOID KGX graph (KG-Bioportal)
+node_count: 16717
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: doid
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/DOID.tar.gz
+layout: product_detail
+---

--- a/resource/doid/doid.md
+++ b/resource/doid/doid.md
@@ -19,7 +19,7 @@ domains:
 - biomedical
 homepage_url: https://disease-ontology.org
 id: doid
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -2805,6 +2805,20 @@ products:
     source: uniprot
   - relation_type: prov:wasInfluencedBy
     source: wikipathways
+- id: doid.kg-bioportal
+  name: DOID KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Human Disease Ontology (DOID), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains DOID_nodes.tsv and DOID_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/DOID.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: doid
+    relation_type: prov:hadPrimarySource
+  node_count: 16717
+  edge_count: 39169
+  latest_version: '2026-07-31'
 publications:
 - authors:
   - Kibbe WA

--- a/resource/dpo/dpo.kg-bioportal.md
+++ b/resource/dpo/dpo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Drosophila Phenotype Ontology (DPO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains DPO_nodes.tsv and
+  DPO_edges.tsv.
+edge_count: 5184
+format: kgx
+id: dpo.kg-bioportal
+latest_version: '2026-07-10'
+name: DPO KGX graph (KG-Bioportal)
+node_count: 2172
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: dpo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DPO.tar.gz
+layout: product_detail
+---

--- a/resource/dpo/dpo.md
+++ b/resource/dpo/dpo.md
@@ -19,7 +19,7 @@ domains:
 - phenotype
 homepage_url: http://purl.obolibrary.org/obo/fbcv
 id: dpo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -207,6 +207,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: dpo.kg-bioportal
+  name: DPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Drosophila Phenotype Ontology (DPO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains DPO_nodes.tsv
+    and DPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: dpo
+    relation_type: prov:hadPrimarySource
+  node_count: 2172
+  edge_count: 5184
+  latest_version: '2026-07-10'
 publications:
 - authors:
   - Osumi-Sutherland D

--- a/resource/duo/duo.kg-bioportal.md
+++ b/resource/duo/duo.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of The Data Use Ontology (DUO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains DUO_nodes.tsv and DUO_edges.tsv.
+edge_count: 311
+format: kgx
+id: duo.kg-bioportal
+name: DUO KGX graph (KG-Bioportal)
+node_count: 316
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: duo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DUO.tar.gz
+layout: product_detail
+---

--- a/resource/duo/duo.md
+++ b/resource/duo/duo.md
@@ -19,7 +19,7 @@ domains:
 - information technology
 homepage_url: https://github.com/EBISPOT/DUO
 id: duo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,19 @@ products:
   original_source:
   - source: duo
     relation_type: prov:hadPrimarySource
+- id: duo.kg-bioportal
+  name: DUO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of The Data Use Ontology (DUO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains DUO_nodes.tsv and DUO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/DUO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: duo
+    relation_type: prov:hadPrimarySource
+  node_count: 316
+  edge_count: 311
 publications:
 - authors:
   - Lawson J

--- a/resource/ecao/ecao.kg-bioportal.md
+++ b/resource/ecao/ecao.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of The Echinoderm Anatomy and Development Ontology
+  (ECAO), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  ECAO_nodes.tsv and ECAO_edges.tsv.
+edge_count: 35290
+format: kgx
+id: ecao.kg-bioportal
+name: ECAO KGX graph (KG-Bioportal)
+node_count: 8222
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ecao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECAO.tar.gz
+layout: product_detail
+---

--- a/resource/ecao/ecao.md
+++ b/resource/ecao/ecao.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/echinoderm-ontology/ecao_ontology
 id: "ecao"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/3.0/"
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: ecao
         relation_type: prov:hadPrimarySource
+  - id: ecao.kg-bioportal
+    name: ECAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of The Echinoderm Anatomy and Development Ontology (ECAO), produced by KG-Bioportal from the BioPortal submission. The archive contains ECAO_nodes.tsv and ECAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ecao
+        relation_type: prov:hadPrimarySource
+    node_count: 8222
+    edge_count: 35290
 repository: https://github.com/echinoderm-ontology/ecao_ontology
 publications:
   - authors:

--- a/resource/eco/eco.kg-bioportal.md
+++ b/resource/eco/eco.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Evidence and Conclusion Ontology (ECO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains ECO_nodes.tsv
+  and ECO_edges.tsv.
+edge_count: 5362
+format: kgx
+id: eco.kg-bioportal
+latest_version: releases/2025-06-23
+name: ECO KGX graph (KG-Bioportal)
+node_count: 2351
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eco
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECO.tar.gz
+layout: product_detail
+---

--- a/resource/eco/eco.md
+++ b/resource/eco/eco.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://www.evidenceontology.org
 id: eco
 infores_id: eco
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -555,13 +555,28 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: eco.kg-bioportal
+  name: ECO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Evidence and Conclusion Ontology (ECO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains ECO_nodes.tsv
+    and ECO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: eco
+    relation_type: prov:hadPrimarySource
+  node_count: 2351
+  edge_count: 5362
+  latest_version: releases/2025-06-23
 publications:
 - authors:
   - Nadendla S
   - Jackson R
   - Munro J
   - Quaglia F
-  - "M\xE9sz\xE1ros B"
+  - Mészáros B
   - Olley D
   - Hobbs ET
   - Goralski SM

--- a/resource/ecocore/ecocore.kg-bioportal.md
+++ b/resource/ecocore/ecocore.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of An ontology of core ecological entities (ECOCORE),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains ECOCORE_nodes.tsv
+  and ECOCORE_edges.tsv.
+edge_count: 23306
+format: kgx
+id: ecocore.kg-bioportal
+latest_version: '2022-03-09'
+name: ECOCORE KGX graph (KG-Bioportal)
+node_count: 7497
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ecocore
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECOCORE.tar.gz
+layout: product_detail
+---

--- a/resource/ecocore/ecocore.md
+++ b/resource/ecocore/ecocore.md
@@ -19,7 +19,7 @@ domains:
   - environment
 homepage_url: https://github.com/EcologicalSemantics/ecocore
 id: ecocore
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -47,6 +47,19 @@ products:
     original_source:
       - source: ecocore
         relation_type: prov:hadPrimarySource
+  - id: ecocore.kg-bioportal
+    name: ECOCORE KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of An ontology of core ecological entities (ECOCORE), produced by KG-Bioportal from the BioPortal submission. The archive contains ECOCORE_nodes.tsv and ECOCORE_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECOCORE.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ecocore
+        relation_type: prov:hadPrimarySource
+    node_count: 7497
+    edge_count: 23306
+    latest_version: '2022-03-09'
 repository: https://github.com/EcologicalSemantics/ecocore
 publications: []
 ---

--- a/resource/ecosim/ecosim.kg-bioportal.md
+++ b/resource/ecosim/ecosim.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of ecosim ontology (ECOSIM), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains ECOSIM_nodes.tsv and ECOSIM_edges.tsv.
+edge_count: 1
+format: kgx
+id: ecosim.kg-bioportal
+latest_version: '2025-05-29'
+name: ECOSIM KGX graph (KG-Bioportal)
+node_count: 6
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ecosim
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECOSIM.tar.gz
+layout: product_detail
+---

--- a/resource/ecosim/ecosim.md
+++ b/resource/ecosim/ecosim.md
@@ -28,9 +28,22 @@ products:
     original_source:
       - source: ecosim
         relation_type: prov:hadPrimarySource
+  - id: ecosim.kg-bioportal
+    name: ECOSIM KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of ecosim ontology (ECOSIM), produced by KG-Bioportal from the BioPortal submission. The archive contains ECOSIM_nodes.tsv and ECOSIM_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECOSIM.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ecosim
+        relation_type: prov:hadPrimarySource
+    node_count: 6
+    edge_count: 1
+    latest_version: '2025-05-29'
 category: Resource
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 ---
 
 Ontology rendering of the EcoSIM Land System Model

--- a/resource/ecto/ecto.kg-bioportal.md
+++ b/resource/ecto/ecto.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Environmental conditions, treatments and exposures
+  ontology (ECTO), produced by KG-Bioportal from the BioPortal submission. The archive
+  contains ECTO_nodes.tsv and ECTO_edges.tsv.
+edge_count: 61849
+format: kgx
+id: ecto.kg-bioportal
+latest_version: '2026-07-28'
+name: ECTO KGX graph (KG-Bioportal)
+node_count: 21399
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ecto
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECTO.tar.gz
+layout: product_detail
+---

--- a/resource/ecto/ecto.md
+++ b/resource/ecto/ecto.md
@@ -27,7 +27,7 @@ domains:
 homepage_url: https://github.com/EnvironmentOntology/environmental-exposure-ontology
 id: ecto
 infores_id: ecto
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -289,6 +289,21 @@ products:
     source: zfa
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
+- id: ecto.kg-bioportal
+  name: ECTO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Environmental conditions, treatments and exposures
+    ontology (ECTO), produced by KG-Bioportal from the BioPortal submission. The archive
+    contains ECTO_nodes.tsv and ECTO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ECTO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ecto
+    relation_type: prov:hadPrimarySource
+  node_count: 21399
+  edge_count: 61849
+  latest_version: '2026-07-28'
 publications: []
 repository: https://github.com/EnvironmentOntology/environmental-exposure-ontology
 ---

--- a/resource/edam/edam.kg-bioportal.md
+++ b/resource/edam/edam.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of EDAM - The ontology of data analysis and management
+  (EDAM), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  EDAM_nodes.tsv and EDAM_edges.tsv.
+edge_count: 15464
+format: kgx
+id: edam.kg-bioportal
+latest_version: 1.25-20260626T1230Z
+name: EDAM KGX graph (KG-Bioportal)
+node_count: 4613
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: edam
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EDAM.tar.gz
+layout: product_detail
+---

--- a/resource/edam/edam.md
+++ b/resource/edam/edam.md
@@ -11,12 +11,12 @@ contacts:
   contact_details:
   - contact_type: github
     value: matuskalas
-  label: "Mat\xFA\u0161 Kala\u0161"
+  label: Matúš Kalaš
 - category: Individual
   contact_details:
   - contact_type: github
     value: hmenager
-  label: "Herv\xE9 M\xE9nager"
+  label: Hervé Ménager
 creation_date: '2025-06-04T00:00:00Z'
 description: EDAM is an ontology of bioscientific data analysis and data management,
   covering topics, operations, data, identifiers, and formats. It supports semantic
@@ -26,7 +26,7 @@ domains:
 - biological systems
 homepage_url: https://edamontology.org/
 id: edam
-last_modified_date: '2025-10-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by-sa/4.0/
@@ -305,10 +305,25 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
+- id: edam.kg-bioportal
+  name: EDAM KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of EDAM - The ontology of data analysis and management
+    (EDAM), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    EDAM_nodes.tsv and EDAM_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EDAM.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: edam
+    relation_type: prov:hadPrimarySource
+  node_count: 4613
+  edge_count: 15464
+  latest_version: 1.25-20260626T1230Z
 publications:
 - authors:
   - Ison J
-  - "Kala\u0161 M"
+  - Kalaš M
   - Jonassen I
   - Bolser D
   - Uludag M

--- a/resource/ehda/ehda.kg-bioportal.md
+++ b/resource/ehda/ehda.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Human Developmental Anatomy Ontology, timed version
+  (EHDA), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  EHDA_nodes.tsv and EHDA_edges.tsv.
+edge_count: 8339
+format: kgx
+id: ehda.kg-bioportal
+latest_version: unknown
+name: EHDA KGX graph (KG-Bioportal)
+node_count: 8353
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ehda
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDA.tar.gz
+layout: product_detail
+---

--- a/resource/ehda/ehda.md
+++ b/resource/ehda/ehda.md
@@ -15,13 +15,28 @@ domains:
 - anatomy and development
 homepage_url: http://genex.hgu.mrc.ac.uk/
 id: ehda
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
   label: Not specified
 name: Human developmental anatomy, timed version
-products: []
+products:
+- id: ehda.kg-bioportal
+  name: EHDA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Human Developmental Anatomy Ontology, timed version
+    (EHDA), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    EHDA_nodes.tsv and EHDA_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ehda
+    relation_type: prov:hadPrimarySource
+  node_count: 8353
+  edge_count: 8339
+  latest_version: unknown
 publications:
 - authors:
   - Hunter A

--- a/resource/ehdaa/ehdaa.kg-bioportal.md
+++ b/resource/ehdaa/ehdaa.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Human Developmental Anatomy Ontology, abstract version
+  1 (EHDAA), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  EHDAA_nodes.tsv and EHDAA_edges.tsv.
+edge_count: 2335
+format: kgx
+id: ehdaa.kg-bioportal
+latest_version: unknown
+name: EHDAA KGX graph (KG-Bioportal)
+node_count: 2326
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ehdaa
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDAA.tar.gz
+layout: product_detail
+---

--- a/resource/ehdaa/ehdaa.md
+++ b/resource/ehdaa/ehdaa.md
@@ -15,7 +15,7 @@ domains:
 - anatomy and development
 homepage_url: https://obofoundry.org/ontology/ehdaa
 id: ehdaa
-last_modified_date: '2026-06-01T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -42,6 +42,21 @@ products:
     source: ehdaa
   product_url: http://purl.obolibrary.org/obo/ehdaa.obo
   warnings: []
+- id: ehdaa.kg-bioportal
+  name: EHDAA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Human Developmental Anatomy Ontology, abstract
+    version 1 (EHDAA), produced by KG-Bioportal from the BioPortal submission. The
+    archive contains EHDAA_nodes.tsv and EHDAA_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDAA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ehdaa
+    relation_type: prov:hadPrimarySource
+  node_count: 2326
+  edge_count: 2335
+  latest_version: unknown
 publications: []
 taxon:
 - NCBITaxon:9606

--- a/resource/ehdaa2/ehdaa2.kg-bioportal.md
+++ b/resource/ehdaa2/ehdaa2.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Human Developmental Anatomy Ontology, abstract version
+  2 (EHDAA2), produced by KG-Bioportal from the BioPortal submission. The archive
+  contains EHDAA2_nodes.tsv and EHDAA2_edges.tsv.
+edge_count: 11768
+format: kgx
+id: ehdaa2.kg-bioportal
+latest_version: releases/2024-01-11
+name: EHDAA2 KGX graph (KG-Bioportal)
+node_count: 2776
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ehdaa2
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDAA2.tar.gz
+layout: product_detail
+---

--- a/resource/ehdaa2/ehdaa2.md
+++ b/resource/ehdaa2/ehdaa2.md
@@ -16,7 +16,7 @@ domains:
 homepage_url: https://github.com/obophenotype/human-developmental-anatomy-ontology
 id: ehdaa2
 infores_id: ehdaa2
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -44,6 +44,19 @@ products:
     original_source:
       - source: ehdaa2
         relation_type: prov:hadPrimarySource
+  - id: ehdaa2.kg-bioportal
+    name: EHDAA2 KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Human Developmental Anatomy Ontology, abstract version 2 (EHDAA2), produced by KG-Bioportal from the BioPortal submission. The archive contains EHDAA2_nodes.tsv and EHDAA2_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EHDAA2.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ehdaa2
+        relation_type: prov:hadPrimarySource
+    node_count: 2776
+    edge_count: 11768
+    latest_version: releases/2024-01-11
 repository: https://github.com/obophenotype/human-developmental-anatomy-ontology
 taxon:
   - NCBITaxon:9606

--- a/resource/emap/emap.kg-bioportal.md
+++ b/resource/emap/emap.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mouse Gross Anatomy and Development Ontology (EMAP),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains EMAP_nodes.tsv
+  and EMAP_edges.tsv.
+edge_count: 21721
+format: kgx
+id: emap.kg-bioportal
+latest_version: unknown
+name: EMAP KGX graph (KG-Bioportal)
+node_count: 19455
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: emap
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMAP.tar.gz
+layout: product_detail
+---

--- a/resource/emap/emap.md
+++ b/resource/emap/emap.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: http://emouseatlas.org
 id: emap
-last_modified_date: '2026-04-16T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -35,11 +35,24 @@ products:
     original_source:
       - source: emap
         relation_type: prov:hadPrimarySource
+  - id: emap.kg-bioportal
+    name: EMAP KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Mouse Gross Anatomy and Development Ontology (EMAP), produced by KG-Bioportal from the BioPortal submission. The archive contains EMAP_nodes.tsv and EMAP_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMAP.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: emap
+        relation_type: prov:hadPrimarySource
+    node_count: 19455
+    edge_count: 21721
+    latest_version: unknown
 taxon:
   - NCBITaxon:10088
 publications: []
 use_instead:
-- emapa
+  - emapa
 ---
 
 ## Description

--- a/resource/emapa/emapa.kg-bioportal.md
+++ b/resource/emapa/emapa.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mouse gross anatomy and development, timed (EMAPA),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains EMAPA_nodes.tsv
+  and EMAPA_edges.tsv.
+edge_count: 23289
+format: kgx
+id: emapa.kg-bioportal
+name: EMAPA KGX graph (KG-Bioportal)
+node_count: 8797
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: emapa
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMAPA.tar.gz
+layout: product_detail
+---

--- a/resource/emapa/emapa.md
+++ b/resource/emapa/emapa.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://www.informatics.jax.org/expression.shtml
 id: emapa
 infores_id: emapa
-last_modified_date: '2026-06-24T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -198,6 +198,20 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: emapa.kg-bioportal
+  name: EMAPA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Mouse gross anatomy and development, timed (EMAPA),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains EMAPA_nodes.tsv
+    and EMAPA_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EMAPA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: emapa
+    relation_type: prov:hadPrimarySource
+  node_count: 8797
+  edge_count: 23289
 publications:
 - authors:
   - Bard JL

--- a/resource/envo/envo.kg-bioportal.md
+++ b/resource/envo/envo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Environment Ontology (ENVO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains ENVO_nodes.tsv and ENVO_edges.tsv.
+edge_count: 15406
+format: kgx
+id: envo.kg-bioportal
+latest_version: '2026-06-26'
+name: ENVO KGX graph (KG-Bioportal)
+node_count: 8323
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: envo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ENVO.tar.gz
+layout: product_detail
+---

--- a/resource/envo/envo.md
+++ b/resource/envo/envo.md
@@ -19,7 +19,7 @@ domains:
 - environment
 homepage_url: http://environmentontology.org/
 id: envo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -379,6 +379,20 @@ products:
     source: dcat
   - relation_type: prov:wasInformedBy
     source: afo
+- id: envo.kg-bioportal
+  name: ENVO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Environment Ontology (ENVO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains ENVO_nodes.tsv and ENVO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ENVO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: envo
+    relation_type: prov:hadPrimarySource
+  node_count: 8323
+  edge_count: 15406
+  latest_version: '2026-06-26'
 publications:
 - authors:
   - Pier Buttigieg

--- a/resource/epio/epio.kg-bioportal.md
+++ b/resource/epio/epio.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of EpilepsyOntology (EPIO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains EPIO_nodes.tsv and EPIO_edges.tsv.
+edge_count: 5472
+format: kgx
+id: epio.kg-bioportal
+latest_version: 'Version Release: 1.0.0'
+name: EPIO KGX graph (KG-Bioportal)
+node_count: 3100
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: epio
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPIO.tar.gz
+layout: product_detail
+---

--- a/resource/epio/epio.md
+++ b/resource/epio/epio.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/SCAI-BIO/EpilepsyOntology
 id: epio
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
         source: epio
     product_file_size: 415175
     product_url: http://purl.obolibrary.org/obo/epio.owl
+  - id: epio.kg-bioportal
+    name: EPIO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of EpilepsyOntology (EPIO), produced by KG-Bioportal from the BioPortal submission. The archive contains EPIO_nodes.tsv and EPIO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EPIO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: epio
+        relation_type: prov:hadPrimarySource
+    node_count: 3100
+    edge_count: 5472
+    latest_version: 'Version Release: 1.0.0'
 publications: []
 repository: https://github.com/SCAI-BIO/EpilepsyOntology
 ---

--- a/resource/ero/ero.kg-bioportal.md
+++ b/resource/ero/ero.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Eagle-I Research Resource Ontology (ERO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains ERO_nodes.tsv
+  and ERO_edges.tsv.
+edge_count: 9033
+format: kgx
+id: ero.kg-bioportal
+latest_version: '2013-08-02'
+name: ERO KGX graph (KG-Bioportal)
+node_count: 4384
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ero
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ERO.tar.gz
+layout: product_detail
+---

--- a/resource/ero/ero.md
+++ b/resource/ero/ero.md
@@ -17,7 +17,7 @@ domains:
 - information technology
 homepage_url: https://open.med.harvard.edu/wiki/display/eaglei/Ontology
 id: ero
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/2.0/
@@ -35,6 +35,21 @@ products:
     source: ero
   product_url: http://purl.obolibrary.org/obo/ero.owl
   warnings: []
+- id: ero.kg-bioportal
+  name: ERO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Eagle-I Research Resource Ontology (ERO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains ERO_nodes.tsv
+    and ERO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ERO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ero
+    relation_type: prov:hadPrimarySource
+  node_count: 4384
+  edge_count: 9033
+  latest_version: '2013-08-02'
 publications: []
 ---
 ## Description

--- a/resource/eupath/eupath.kg-bioportal.md
+++ b/resource/eupath/eupath.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of VEuPathDB Ontology (EUPATH), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains EUPATH_nodes.tsv and EUPATH_edges.tsv.
+edge_count: 13057
+format: kgx
+id: eupath.kg-bioportal
+latest_version: '2023-05-30'
+name: EUPATH KGX graph (KG-Bioportal)
+node_count: 6164
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: eupath
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EUPATH.tar.gz
+layout: product_detail
+---

--- a/resource/eupath/eupath.md
+++ b/resource/eupath/eupath.md
@@ -20,7 +20,7 @@ domains:
 - organisms
 homepage_url: https://github.com/VEuPathDB-ontology/VEuPathDB-ontology
 id: eupath
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -38,24 +38,38 @@ products:
   original_source:
   - source: eupath
     relation_type: prov:hadPrimarySource
+- id: eupath.kg-bioportal
+  name: EUPATH KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of VEuPathDB Ontology (EUPATH), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains EUPATH_nodes.tsv and EUPATH_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EUPATH.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: eupath
+    relation_type: prov:hadPrimarySource
+  node_count: 6164
+  edge_count: 13057
+  latest_version: '2023-05-30'
 repository: https://github.com/VEuPathDB-ontology/VEuPathDB-ontology
 publications:
 - authors:
-  - "Zheng, Jie"
-  - "Cade, JasShon"
-  - "Brunk, Brian"
-  - "Roos, David"
-  - "Stoeckert, Christian"
-  - "James, San"
-  - "Arinaitwe, Emmanuel"
-  - "Greenhouse, Bryan"
-  - "Dorsey, Grant"
-  - "Sullivan, Steven"
-  - "Carlton, Jane"
-  - "Carrasco-Escobar, Gabriel"
-  - "Gamboa, Dionicia"
-  - "Maguina-Mercedes, Paula"
-  - "Vinetz, Joseph"
+  - Zheng, Jie
+  - Cade, JasShon
+  - Brunk, Brian
+  - Roos, David
+  - Stoeckert, Christian
+  - James, San
+  - Arinaitwe, Emmanuel
+  - Greenhouse, Bryan
+  - Dorsey, Grant
+  - Sullivan, Steven
+  - Carlton, Jane
+  - Carrasco-Escobar, Gabriel
+  - Gamboa, Dionicia
+  - Maguina-Mercedes, Paula
+  - Vinetz, Joseph
   doi: 10.5281/zenodo.6685957
   id: https://doi.org/10.5281/zenodo.6685957
   journal: Zenodo

--- a/resource/exmo/exmo.kg-bioportal.md
+++ b/resource/exmo/exmo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Exercise Medicine Ontology (EXMO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains EXMO_nodes.tsv and EXMO_edges.tsv.
+edge_count: 3466
+format: kgx
+id: exmo.kg-bioportal
+latest_version: '2025-06-05'
+name: EXMO KGX graph (KG-Bioportal)
+node_count: 1732
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: exmo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXMO.tar.gz
+layout: product_detail
+---

--- a/resource/exmo/exmo.md
+++ b/resource/exmo/exmo.md
@@ -14,7 +14,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 domains:
   - biomedical
 contacts:
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: exmo
         relation_type: prov:hadPrimarySource
+  - id: exmo.kg-bioportal
+    name: EXMO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Exercise Medicine Ontology (EXMO), produced by KG-Bioportal from the BioPortal submission. The archive contains EXMO_nodes.tsv and EXMO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXMO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: exmo
+        relation_type: prov:hadPrimarySource
+    node_count: 1732
+    edge_count: 3466
+    latest_version: '2025-06-05'
 publications:
   - authors:
       - Liu X

--- a/resource/exo/exo.kg-bioportal.md
+++ b/resource/exo/exo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Exposure Ontology (EXO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains EXO_nodes.tsv and EXO_edges.tsv.
+edge_count: 222
+format: kgx
+id: exo.kg-bioportal
+latest_version: '2025-08-29'
+name: EXO KGX graph (KG-Bioportal)
+node_count: 198
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: exo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXO.tar.gz
+layout: product_detail
+---

--- a/resource/exo/exo.md
+++ b/resource/exo/exo.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/CTDbase/exposure-ontology
 id: exo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: exo
         relation_type: prov:hadPrimarySource
+  - id: exo.kg-bioportal
+    name: EXO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Exposure Ontology (EXO), produced by KG-Bioportal from the BioPortal submission. The archive contains EXO_nodes.tsv and EXO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/EXO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: exo
+        relation_type: prov:hadPrimarySource
+    node_count: 198
+    edge_count: 222
+    latest_version: '2025-08-29'
 repository: https://github.com/CTDbase/exposure-ontology
 publications:
   - authors:

--- a/resource/faldo/faldo.kg-bioportal.md
+++ b/resource/faldo/faldo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Feature Annotation Location Description Ontology
+  (FALDO), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  FALDO_nodes.tsv and FALDO_edges.tsv.
+edge_count: 46
+format: kgx
+id: faldo.kg-bioportal
+latest_version: Created at the Biohackathon 2012 and 2013
+name: FALDO KGX graph (KG-Bioportal)
+node_count: 40
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: faldo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FALDO.tar.gz
+layout: product_detail
+---

--- a/resource/faldo/faldo.md
+++ b/resource/faldo/faldo.md
@@ -18,7 +18,7 @@ domains:
 - information technology
 homepage_url: http://biohackathon.org/resource/faldo
 id: faldo
-last_modified_date: '2025-10-31T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -285,6 +285,21 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
+- id: faldo.kg-bioportal
+  name: FALDO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Feature Annotation Location Description Ontology
+    (FALDO), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    FALDO_nodes.tsv and FALDO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FALDO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: faldo
+    relation_type: prov:hadPrimarySource
+  node_count: 40
+  edge_count: 46
+  latest_version: Created at the Biohackathon 2012 and 2013
 repository: https://github.com/OBioFoundry/FALDO
 synonyms:
 - Feature Annotation Location Description Ontology

--- a/resource/fao/fao.kg-bioportal.md
+++ b/resource/fao/fao.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Fungal Gross Anatomy Ontology (FAO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains FAO_nodes.tsv and
+  FAO_edges.tsv.
+edge_count: 156
+format: kgx
+id: fao.kg-bioportal
+name: FAO KGX graph (KG-Bioportal)
+node_count: 146
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAO.tar.gz
+layout: product_detail
+---

--- a/resource/fao/fao.md
+++ b/resource/fao/fao.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/fungal-anatomy-ontology/
 id: fao
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: fao
         relation_type: prov:hadPrimarySource
+  - id: fao.kg-bioportal
+    name: FAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Fungal Gross Anatomy Ontology (FAO), produced by KG-Bioportal from the BioPortal submission. The archive contains FAO_nodes.tsv and FAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: fao
+        relation_type: prov:hadPrimarySource
+    node_count: 146
+    edge_count: 156
 repository: https://github.com/obophenotype/fungal-anatomy-ontology
 taxon:
   - NCBITaxon:4751

--- a/resource/fbbi/fbbi.kg-bioportal.md
+++ b/resource/fbbi/fbbi.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Biological Imaging Methods Ontology (FBBI), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains FBBI_nodes.tsv
+  and FBBI_edges.tsv.
+edge_count: 1062
+format: kgx
+id: fbbi.kg-bioportal
+latest_version: '2026-06-25'
+name: FBBI KGX graph (KG-Bioportal)
+node_count: 896
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fbbi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FBbi.tar.gz
+layout: product_detail
+---

--- a/resource/fbbi/fbbi.md
+++ b/resource/fbbi/fbbi.md
@@ -28,7 +28,7 @@ domains:
 - general
 homepage_url: https://github.com/foundingGIDE/fbbi
 id: fbbi
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -76,6 +76,21 @@ products:
   original_source:
   - source: fbbi
     relation_type: prov:hadPrimarySource
+- id: fbbi.kg-bioportal
+  name: FBBI KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Biological Imaging Methods Ontology (FBBI), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains FBBI_nodes.tsv
+    and FBBI_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FBbi.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: fbbi
+    relation_type: prov:hadPrimarySource
+  node_count: 896
+  edge_count: 1062
+  latest_version: '2026-06-25'
 publications: []
 repository: https://github.com/foundingGIDE/fbbi
 ---

--- a/resource/fbcv/fbcv.kg-bioportal.md
+++ b/resource/fbcv/fbcv.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of FlyBase Controlled Vocabulary (FB-CV), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains FB-CV_nodes.tsv
+  and FB-CV_edges.tsv.
+edge_count: 5471
+format: kgx
+id: fbcv.kg-bioportal
+latest_version: '2026-07-10'
+name: FB-CV KGX graph (KG-Bioportal)
+node_count: 2467
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fbcv
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-CV.tar.gz
+layout: product_detail
+---

--- a/resource/fbcv/fbcv.md
+++ b/resource/fbcv/fbcv.md
@@ -21,7 +21,7 @@ domains:
 homepage_url: http://purl.obolibrary.org/obo/fbcv
 id: fbcv
 infores_id: fbcv
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -59,6 +59,21 @@ products:
   original_source:
   - source: fbcv
     relation_type: prov:hadPrimarySource
+- id: fbcv.kg-bioportal
+  name: FB-CV KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of FlyBase Controlled Vocabulary (FB-CV), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains FB-CV_nodes.tsv
+    and FB-CV_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-CV.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: fbcv
+    relation_type: prov:hadPrimarySource
+  node_count: 2467
+  edge_count: 5471
+  latest_version: '2026-07-10'
 repository: https://github.com/FlyBase/flybase-controlled-vocabulary
 publications: []
 ---

--- a/resource/fbsp/fbsp.kg-bioportal.md
+++ b/resource/fbsp/fbsp.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Fly Taxonomy (FB-SP), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains FB-SP_nodes.tsv and FB-SP_edges.tsv.
+edge_count: 6619
+format: kgx
+id: fbsp.kg-bioportal
+name: FB-SP KGX graph (KG-Bioportal)
+node_count: 6622
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fbsp
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-SP.tar.gz
+layout: product_detail
+---

--- a/resource/fbsp/fbsp.md
+++ b/resource/fbsp/fbsp.md
@@ -20,7 +20,7 @@ domains:
 - organisms
 homepage_url: http://www.flybase.org/
 id: fbsp
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -37,6 +37,19 @@ products:
     source: fbsp
   product_url: http://purl.obolibrary.org/obo/fbsp.owl
   warnings: []
+- id: fbsp.kg-bioportal
+  name: FB-SP KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Fly Taxonomy (FB-SP), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains FB-SP_nodes.tsv and FB-SP_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FB-SP.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: fbsp
+    relation_type: prov:hadPrimarySource
+  node_count: 6622
+  edge_count: 6619
 publications: []
 taxon:
 - NCBITaxon:7227

--- a/resource/fideo/fideo.kg-bioportal.md
+++ b/resource/fideo/fideo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Food Interactions with Drugs Evidence Ontology (FIDEO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains FIDEO_nodes.tsv
+  and FIDEO_edges.tsv.
+edge_count: 7649
+format: kgx
+id: fideo.kg-bioportal
+latest_version: '2023-12-18'
+name: FIDEO KGX graph (KG-Bioportal)
+node_count: 3565
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fideo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIDEO.tar.gz
+layout: product_detail
+---

--- a/resource/fideo/fideo.md
+++ b/resource/fideo/fideo.md
@@ -19,7 +19,7 @@ domains:
 - nutrition
 homepage_url: https://gitub.u-bordeaux.fr/erias/fideo
 id: fideo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -37,12 +37,10 @@ products:
     source: fideo
   product_url: http://purl.obolibrary.org/obo/fideo.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
+  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
   - 'File was not able to be retrieved when checked on 2026-07-02: Timeout connecting
     to URL'
-  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
-    header found'
 - category: GraphProduct
   compression: gzip
   description: PharMeBINet V2 JSON release published on February 6, 2024.
@@ -619,6 +617,21 @@ products:
     source: uniprot
   - relation_type: prov:wasDerivedFrom
     source: wikipathways
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Food Interactions with Drugs Evidence Ontology
+    (FIDEO), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    FIDEO_nodes.tsv and FIDEO_edges.tsv.
+  edge_count: 7649
+  format: kgx
+  id: fideo.kg-bioportal
+  latest_version: '2023-12-18'
+  name: FIDEO KGX graph (KG-Bioportal)
+  node_count: 3565
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: fideo
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIDEO.tar.gz
 publications: []
 repository: https://gitub.u-bordeaux.fr/erias/fideo
 ---

--- a/resource/fire/fire.kg-bioportal.md
+++ b/resource/fire/fire.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Fire Ontology (FIRE), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains FIRE_nodes.tsv and FIRE_edges.tsv.
+edge_count: 106
+format: kgx
+id: fire.kg-bioportal
+latest_version: '0.8'
+name: FIRE KGX graph (KG-Bioportal)
+node_count: 95
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fire
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIRE.tar.gz
+layout: product_detail
+---

--- a/resource/fire/fire.md
+++ b/resource/fire/fire.md
@@ -28,7 +28,7 @@ domains:
 - biomedical
 homepage_url: https://doi.org/10.1016/j.celrep.2016.10.061
 id: fire
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -102,6 +102,20 @@ products:
   - relation_type: prov:hadPrimarySource
     source: motifmap
   product_url: https://available-inventions.umich.edu/product/genomickb-a-knowledgebase-for-the-human-genome
+- id: fire.kg-bioportal
+  name: FIRE KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Fire Ontology (FIRE), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains FIRE_nodes.tsv and FIRE_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIRE.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: fire
+    relation_type: prov:hadPrimarySource
+  node_count: 95
+  edge_count: 106
+  latest_version: '0.8'
 publications:
 - authors:
   - Schmitt AD

--- a/resource/fix/fix.kg-bioportal.md
+++ b/resource/fix/fix.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Physico-Chemical Methods and Properties (FIX), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains FIX_nodes.tsv
+  and FIX_edges.tsv.
+edge_count: 1684
+format: kgx
+id: fix.kg-bioportal
+latest_version: '1.2'
+name: FIX KGX graph (KG-Bioportal)
+node_count: 1179
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fix
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIX.tar.gz
+layout: product_detail
+---

--- a/resource/fix/fix.md
+++ b/resource/fix/fix.md
@@ -12,7 +12,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.ebi.ac.uk/chebi
 id: fix
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -39,10 +39,23 @@ products:
     source: fix
   product_url: http://purl.obolibrary.org/obo/fix.obo
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: Error connecting
-    to URL: No connection adapters were found for ''ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/fix.obo'''
   - 'File was not able to be retrieved when checked on 2026-08-06: Error connecting
     to URL: No connection adapters were found for ''ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/fix.obo'''
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Physico-Chemical Methods and Properties (FIX),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains FIX_nodes.tsv
+    and FIX_edges.tsv.
+  edge_count: 1684
+  format: kgx
+  id: fix.kg-bioportal
+  latest_version: '1.2'
+  name: FIX KGX graph (KG-Bioportal)
+  node_count: 1179
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: fix
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FIX.tar.gz
 publications: []
 ---
 ## Description

--- a/resource/flopo/flopo.kg-bioportal.md
+++ b/resource/flopo/flopo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Flora Phenotype Ontology (FLOPO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains FLOPO_nodes.tsv and FLOPO_edges.tsv.
+edge_count: 69743
+format: kgx
+id: flopo.kg-bioportal
+latest_version: '2026-07-31'
+name: FLOPO KGX graph (KG-Bioportal)
+node_count: 58680
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: flopo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/FLOPO.tar.gz
+layout: product_detail
+---

--- a/resource/flopo/flopo.md
+++ b/resource/flopo/flopo.md
@@ -19,7 +19,7 @@ domains:
 - phenotype
 homepage_url: https://github.com/flora-phenotype-ontology/flopoontology
 id: flopo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -37,6 +37,21 @@ products:
   original_source:
   - source: flopo
     relation_type: prov:hadPrimarySource
+- id: flopo.kg-bioportal
+  name: FLOPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Flora Phenotype Ontology (FLOPO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains FLOPO_nodes.tsv
+    and FLOPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/FLOPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: flopo
+    relation_type: prov:hadPrimarySource
+  node_count: 58680
+  edge_count: 69743
+  latest_version: '2026-07-31'
 repository: https://github.com/flora-phenotype-ontology/flopoontology
 taxon:
 - NCBITaxon:33090

--- a/resource/flu/flu.kg-bioportal.md
+++ b/resource/flu/flu.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Influenza Ontology (FLU), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains FLU_nodes.tsv and FLU_edges.tsv.
+edge_count: 215
+format: kgx
+id: flu.kg-bioportal
+latest_version: 0.9.0
+name: FLU KGX graph (KG-Bioportal)
+node_count: 272
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: flu
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/FLU.tar.gz
+layout: product_detail
+---

--- a/resource/flu/flu.md
+++ b/resource/flu/flu.md
@@ -15,7 +15,7 @@ domains:
   - biomedical
 homepage_url: http://purl.obolibrary.org/obo/flu/
 id: flu
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -32,6 +32,19 @@ products:
     original_source:
       - source: flu
         relation_type: prov:hadPrimarySource
+  - id: flu.kg-bioportal
+    name: FLU KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Influenza Ontology (FLU), produced by KG-Bioportal from the BioPortal submission. The archive contains FLU_nodes.tsv and FLU_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/FLU.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: flu
+        relation_type: prov:hadPrimarySource
+    node_count: 272
+    edge_count: 215
+    latest_version: 0.9.0
 publications: []
 ---
 

--- a/resource/fobi/fobi.kg-bioportal.md
+++ b/resource/fobi/fobi.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of FOBI (Food-Biomarker Ontology) (FOBI), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains FOBI_nodes.tsv
+  and FOBI_edges.tsv.
+edge_count: 6815
+format: kgx
+id: fobi.kg-bioportal
+name: FOBI KGX graph (KG-Bioportal)
+node_count: 1359
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: fobi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FOBI.tar.gz
+layout: product_detail
+---

--- a/resource/fobi/fobi.md
+++ b/resource/fobi/fobi.md
@@ -20,7 +20,7 @@ domains:
 - nutrition
 homepage_url: https://github.com/pcastellanoescuder/FoodBiomarkerOntology
 id: fobi
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -40,6 +40,20 @@ products:
   original_source:
   - source: fobi
     relation_type: prov:hadPrimarySource
+- id: fobi.kg-bioportal
+  name: FOBI KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of FOBI (Food-Biomarker Ontology) (FOBI), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains FOBI_nodes.tsv
+    and FOBI_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/FOBI.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: fobi
+    relation_type: prov:hadPrimarySource
+  node_count: 1359
+  edge_count: 6815
 repository: https://github.com/pcastellanoescuder/FoodBiomarkerOntology
 publications:
 - authors:
@@ -51,7 +65,8 @@ publications:
   doi: 10.1093/databa/baaa033
   id: https://www.ncbi.nlm.nih.gov/pubmed/32556148
   journal: Database (Oxford)
-  title: 'FOBI: an ontology to represent food intake data and associate it with metabolomic data'
+  title: 'FOBI: an ontology to represent food intake data and associate it with metabolomic
+    data'
   year: '2020'
 - authors:
   - Castellano-Escuder P

--- a/resource/gallont/gallont.kg-bioportal.md
+++ b/resource/gallont/gallont.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Plant Gall Ontology (GALLONT), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains GALLONT_nodes.tsv and GALLONT_edges.tsv.
+edge_count: 1776
+format: kgx
+id: gallont.kg-bioportal
+latest_version: '2024-04-19'
+name: GALLONT KGX graph (KG-Bioportal)
+node_count: 861
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: gallont
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GALLONT.tar.gz
+layout: product_detail
+---

--- a/resource/gallont/gallont.md
+++ b/resource/gallont/gallont.md
@@ -19,7 +19,7 @@ domains:
   - phenotype
 homepage_url: https://adeans.github.io/gallont/
 id: gallont
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -47,6 +47,19 @@ products:
         source: gallont
     product_file_size: 60631
     product_url: http://purl.obolibrary.org/obo/gallont.obo
+  - id: gallont.kg-bioportal
+    name: GALLONT KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Plant Gall Ontology (GALLONT), produced by KG-Bioportal from the BioPortal submission. The archive contains GALLONT_nodes.tsv and GALLONT_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GALLONT.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: gallont
+        relation_type: prov:hadPrimarySource
+    node_count: 861
+    edge_count: 1776
+    latest_version: '2024-04-19'
 publications: []
 repository: https://github.com/adeans/gallont
 ---

--- a/resource/gecko/gecko.kg-bioportal.md
+++ b/resource/gecko/gecko.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Genomics Cohorts Knowledge Ontology (GECKO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains GECKO_nodes.tsv
+  and GECKO_edges.tsv.
+edge_count: 155
+format: kgx
+id: gecko.kg-bioportal
+name: GECKO KGX graph (KG-Bioportal)
+node_count: 176
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: gecko
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GECKO.tar.gz
+layout: product_detail
+---

--- a/resource/gecko/gecko.md
+++ b/resource/gecko/gecko.md
@@ -19,7 +19,7 @@ domains:
 - organisms
 homepage_url: https://github.com/IHCC-cohorts/GECKO
 id: gecko
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,20 @@ products:
   original_source:
   - source: gecko
     relation_type: prov:hadPrimarySource
+- id: gecko.kg-bioportal
+  name: GECKO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Genomics Cohorts Knowledge Ontology (GECKO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains GECKO_nodes.tsv
+    and GECKO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GECKO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: gecko
+    relation_type: prov:hadPrimarySource
+  node_count: 176
+  edge_count: 155
 repository: https://github.com/IHCC-cohorts/GECKO
 publications: []
 ---

--- a/resource/genepio/genepio.kg-bioportal.md
+++ b/resource/genepio/genepio.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Genomic Epidemiology Application Ontology (GENEPIO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains GENEPIO_nodes.tsv
+  and GENEPIO_edges.tsv.
+edge_count: 23079
+format: kgx
+id: genepio.kg-bioportal
+latest_version: '2026-04-13'
+name: GENEPIO KGX graph (KG-Bioportal)
+node_count: 10962
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: genepio
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENEPIO.tar.gz
+layout: product_detail
+---

--- a/resource/genepio/genepio.md
+++ b/resource/genepio/genepio.md
@@ -19,7 +19,7 @@ domains:
 homepage_url: http://genepio.org/
 id: genepio
 infores_id: genepio
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -37,6 +37,19 @@ products:
     original_source:
       - source: genepio
         relation_type: prov:hadPrimarySource
+  - id: genepio.kg-bioportal
+    name: GENEPIO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Genomic Epidemiology Application Ontology (GENEPIO), produced by KG-Bioportal from the BioPortal submission. The archive contains GENEPIO_nodes.tsv and GENEPIO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENEPIO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: genepio
+        relation_type: prov:hadPrimarySource
+    node_count: 10962
+    edge_count: 23079
+    latest_version: '2026-04-13'
 repository: https://github.com/GenEpiO/genepio
 publications: []
 ---

--- a/resource/geno/geno.kg-bioportal.md
+++ b/resource/geno/geno.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Genotype Ontology (GENO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains GENO_nodes.tsv and GENO_edges.tsv.
+edge_count: 1942
+format: kgx
+id: geno.kg-bioportal
+latest_version: '2026-02-02'
+name: GENO KGX graph (KG-Bioportal)
+node_count: 1352
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: geno
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENO.tar.gz
+layout: product_detail
+---

--- a/resource/geno/geno.md
+++ b/resource/geno/geno.md
@@ -19,7 +19,7 @@ domains:
 - biological systems
 homepage_url: https://github.com/monarch-initiative/GENO-ontology/
 id: geno
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -61,6 +61,20 @@ products:
     source: skos
   product_file_size: 102365
   product_url: https://raw.githubusercontent.com/monarch-initiative/monochrom/refs/heads/master/chr.owl
+- id: geno.kg-bioportal
+  name: GENO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Genotype Ontology (GENO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains GENO_nodes.tsv and GENO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GENO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: geno
+    relation_type: prov:hadPrimarySource
+  node_count: 1352
+  edge_count: 1942
+  latest_version: '2026-02-02'
 publications: []
 repository: https://github.com/monarch-initiative/GENO-ontology
 ---

--- a/resource/geo/geo.kg-bioportal.md
+++ b/resource/geo/geo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Geographical Entity Ontology (GEO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains GEO_nodes.tsv and
+  GEO_edges.tsv.
+edge_count: 0
+format: kgx
+id: geo.kg-bioportal
+latest_version: production version 2018-02-23
+name: GEO KGX graph (KG-Bioportal)
+node_count: 3
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: geo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/GEO.tar.gz
+layout: product_detail
+---

--- a/resource/geo/geo.md
+++ b/resource/geo/geo.md
@@ -18,7 +18,7 @@ domains:
 - environment
 homepage_url: https://github.com/ufbmi/geographical-entity-ontology/wiki
 id: geo
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -1130,6 +1130,21 @@ products:
     source: tissues
   - relation_type: prov:wasDerivedFrom
     source: wikipathways
+- id: geo.kg-bioportal
+  name: GEO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Geographical Entity Ontology (GEO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains GEO_nodes.tsv
+    and GEO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/GEO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: geo
+    relation_type: prov:hadPrimarySource
+  node_count: 3
+  edge_count: 0
+  latest_version: production version 2018-02-23
 publications: []
 repository: https://github.com/ufbmi/geographical-entity-ontology
 ---

--- a/resource/glycocoo/glycocoo.kg-bioportal.md
+++ b/resource/glycocoo/glycocoo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of GlycoConjugate Ontology (GLYCOCOO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains GLYCOCOO_nodes.tsv
+  and GLYCOCOO_edges.tsv.
+edge_count: 94
+format: kgx
+id: glycocoo.kg-bioportal
+latest_version: 1.1.3
+name: GLYCOCOO KGX graph (KG-Bioportal)
+node_count: 94
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: glycocoo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GLYCOCOO.tar.gz
+layout: product_detail
+---

--- a/resource/glycocoo/glycocoo.md
+++ b/resource/glycocoo/glycocoo.md
@@ -41,7 +41,7 @@ domains:
 - biomedical
 homepage_url: https://github.com/glycoinfo/GlycoCoO
 id: glycocoo
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 name: GlycoConjugate Ontology (GlycoCoO)
 products:
@@ -347,6 +347,21 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
+- id: glycocoo.kg-bioportal
+  name: GLYCOCOO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of GlycoConjugate Ontology (GLYCOCOO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains GLYCOCOO_nodes.tsv
+    and GLYCOCOO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GLYCOCOO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: glycocoo
+    relation_type: prov:hadPrimarySource
+  node_count: 94
+  edge_count: 94
+  latest_version: 1.1.3
 publications:
 - authors:
   - Issaku Yamada

--- a/resource/glycordf/glycordf.kg-bioportal.md
+++ b/resource/glycordf/glycordf.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of GlycoRDF (GLYCORDF), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains GLYCORDF_nodes.tsv and GLYCORDF_edges.tsv.
+edge_count: 514
+format: kgx
+id: glycordf.kg-bioportal
+latest_version: 1.2.1
+name: GLYCORDF KGX graph (KG-Bioportal)
+node_count: 605
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: glycordf
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GLYCORDF.tar.gz
+layout: product_detail
+---

--- a/resource/glycordf/glycordf.md
+++ b/resource/glycordf/glycordf.md
@@ -35,7 +35,7 @@ domains:
 - biomedical
 homepage_url: https://www.glycoinfo.org/GlycoRDF/
 id: glycordf
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 name: 'GlycoRDF: An Ontology to Standardize Glycomics Data in RDF'
 products:
@@ -402,13 +402,27 @@ products:
   secondary_source:
   - relation_type: prov:wasInformedBy
     source: glycordf
+- id: glycordf.kg-bioportal
+  name: GLYCORDF KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of GlycoRDF (GLYCORDF), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains GLYCORDF_nodes.tsv and GLYCORDF_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GLYCORDF.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: glycordf
+    relation_type: prov:hadPrimarySource
+  node_count: 605
+  edge_count: 514
+  latest_version: 1.2.1
 publications:
 - authors:
   - Rene Ranzinger
   - Kiyoko F. Aoki-Kinoshita
   - Matthew P. Campbell
   - Shin Kawano
-  - "Thomas L\xFCtteke"
+  - Thomas Lütteke
   - Shujiro Okuda
   - Daisuke Shinmachi
   - Toshihide Shikanai

--- a/resource/go/go.kg-bioportal.md
+++ b/resource/go/go.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Gene Ontology (GO), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains GO_nodes.tsv and GO_edges.tsv.
+edge_count: 114015
+format: kgx
+id: go.kg-bioportal
+latest_version: '2026-06-15'
+name: GO KGX graph (KG-Bioportal)
+node_count: 66332
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: go
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GO.tar.gz
+layout: product_detail
+---

--- a/resource/go/go.md
+++ b/resource/go/go.md
@@ -26,7 +26,7 @@ domains:
 homepage_url: http://geneontology.org/
 id: go
 infores_id: go
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -65,8 +65,6 @@ products:
     source: go
   product_url: http://purl.obolibrary.org/obo/go.json
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
   - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
 - category: OntologyProduct
@@ -90,8 +88,6 @@ products:
     source: go
   product_url: http://purl.obolibrary.org/obo/go/extensions/go-plus.json
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
   - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
 - category: OntologyProduct
@@ -128,8 +124,6 @@ products:
     source: go
   product_url: http://purl.obolibrary.org/obo/go/go-basic.json
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
   - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
 - category: OntologyProduct
@@ -3896,8 +3890,8 @@ products:
   compatibility:
   - standard: biolink
   compression: zip
-  description: Curated mechanistic drug–disease paths comprising the DrugMechDB dataset
-    packaged as a downloadable archive.
+  description: "Curated mechanistic drug\u2013disease paths comprising the DrugMechDB\
+    \ dataset packaged as a downloadable archive."
   dump_format: other
   format: mixed
   id: drugmechdb.graph
@@ -6577,14 +6571,12 @@ products:
     source: uniprot
   product_url: https://kghub.io/kg-covid-19/
   warnings:
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
+    when accessing file'
   - 'Download offline as of 2026-07-01: the KG-Hub reorganization has taken this file
     offline. The kghub.io and kg-hub.berkeleybop.io hosts return HTTP 404 for all
     kg-covid-19 artifacts (current and dated) and the kg-hub-public-data S3 objects
     return HTTP 403. No replacement public download URL is available.'
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
 - category: GraphProduct
   description: KGX Distribution of KG-IDG
   format: kgx
@@ -6623,13 +6615,11 @@ products:
     source: tcrd
   product_url: https://kg-hub.berkeleybop.io/kg-idg/current/kg-idg.tar.gz
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
   - 'File was not able to be retrieved when checked on 2026-07-01: HTTP 404 error.
     The kg-hub.berkeleybop.io host is being reorganized and KG-IDG downloads are pending
     relocation to a new home; no live download is currently available.'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
 - category: GraphProduct
   description: Merged KG with ontology-grounded KG and literature-based graph as TSV
     file
@@ -7048,6 +7038,20 @@ products:
     source: uniprot
   - relation_type: prov:wasInfluencedBy
     source: wikipathways
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Gene Ontology (GO), produced by KG-Bioportal from
+    the BioPortal submission. The archive contains GO_nodes.tsv and GO_edges.tsv.
+  edge_count: 114015
+  format: kgx
+  id: go.kg-bioportal
+  latest_version: '2026-06-15'
+  name: GO KGX graph (KG-Bioportal)
+  node_count: 66332
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: go
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GO.tar.gz
 publications:
 - authors:
   - Ashburner M

--- a/resource/goldterms/goldterms.kg-bioportal.md
+++ b/resource/goldterms/goldterms.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of GOLD Ecosystem Classification (GOLDTERMS), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains GOLDTERMS_nodes.tsv
+  and GOLDTERMS_edges.tsv.
+edge_count: 11199
+format: kgx
+id: goldterms.kg-bioportal
+name: GOLDTERMS KGX graph (KG-Bioportal)
+node_count: 2428
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: goldterms
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GOLDTERMS.tar.gz
+layout: product_detail
+---

--- a/resource/goldterms/goldterms.md
+++ b/resource/goldterms/goldterms.md
@@ -23,7 +23,7 @@ domains:
 - biological systems
 homepage_url: https://gold.jgi.doe.gov/
 id: goldterms
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://github.com/cmungall/gold-ontology/blob/main/LICENSE
@@ -200,6 +200,20 @@ products:
     source: progenomes
   product_file_size: 12570522
   product_url: https://www.bork.embl.de/~robbani/metatraits/gtdb_species_summary_no_predictions.tsv.gz
+- id: goldterms.kg-bioportal
+  name: GOLDTERMS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of GOLD Ecosystem Classification (GOLDTERMS), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains GOLDTERMS_nodes.tsv
+    and GOLDTERMS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GOLDTERMS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: goldterms
+    relation_type: prov:hadPrimarySource
+  node_count: 2428
+  edge_count: 11199
 repository: https://github.com/cmungall/gold-ontology
 tags:
 - biopragmatics

--- a/resource/gomapman/gomapman.kg-bioportal.md
+++ b/resource/gomapman/gomapman.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of GoMapMan (GMM), produced by KG-Bioportal from the
+  BioPortal submission. The archive contains GMM_nodes.tsv and GMM_edges.tsv.
+edge_count: 1895
+format: kgx
+id: gomapman.kg-bioportal
+latest_version: '1.2'
+name: GMM KGX graph (KG-Bioportal)
+node_count: 1902
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: gomapman
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GMM.tar.gz
+layout: product_detail
+---

--- a/resource/gomapman/gomapman.md
+++ b/resource/gomapman/gomapman.md
@@ -26,7 +26,7 @@ domains:
 - systems biology
 homepage_url: https://gomapman.nib.si/
 id: gomapman
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -412,6 +412,20 @@ products:
     source: gomapman
   product_file_size: 702407
   product_url: https://skm.nib.si/downloads/ckn/v1-2018.06/nodes
+- id: gomapman.kg-bioportal
+  name: GMM KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of GoMapMan (GMM), produced by KG-Bioportal from
+    the BioPortal submission. The archive contains GMM_nodes.tsv and GMM_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/GMM.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: gomapman
+    relation_type: prov:hadPrimarySource
+  node_count: 1902
+  edge_count: 1895
+  latest_version: '1.2'
 publications:
 - authors:
   - Ramsak Z

--- a/resource/hao/hao.kg-bioportal.md
+++ b/resource/hao/hao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Hymenoptera Anatomy Ontology (HAO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains HAO_nodes.tsv and
+  HAO_edges.tsv.
+edge_count: 4952
+format: kgx
+id: hao.kg-bioportal
+latest_version: '2023-06-01'
+name: HAO KGX graph (KG-Bioportal)
+node_count: 5384
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: hao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HAO.tar.gz
+layout: product_detail
+---

--- a/resource/hao/hao.md
+++ b/resource/hao/hao.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: http://hymao.org
 id: hao
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -56,6 +56,19 @@ products:
     original_source:
       - source: hao
         relation_type: prov:hadPrimarySource
+  - id: hao.kg-bioportal
+    name: HAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Hymenoptera Anatomy Ontology (HAO), produced by KG-Bioportal from the BioPortal submission. The archive contains HAO_nodes.tsv and HAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: hao
+        relation_type: prov:hadPrimarySource
+    node_count: 5384
+    edge_count: 4952
+    latest_version: '2023-06-01'
 repository: https://github.com/hymao/hao
 taxon:
   - NCBITaxon:7399

--- a/resource/hom/hom.kg-bioportal.md
+++ b/resource/hom/hom.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Homology and Related Concepts in Biology
+  (HOM), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  HOM_nodes.tsv and HOM_edges.tsv.
+edge_count: 84
+format: kgx
+id: hom.kg-bioportal
+latest_version: releases/2015-01-07
+name: HOM KGX graph (KG-Bioportal)
+node_count: 86
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: hom
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HOM.tar.gz
+layout: product_detail
+---

--- a/resource/hom/hom.md
+++ b/resource/hom/hom.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/BgeeDB/homology-ontology
 id: hom
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: hom
         relation_type: prov:hadPrimarySource
+  - id: hom.kg-bioportal
+    name: HOM KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology of Homology and Related Concepts in Biology (HOM), produced by KG-Bioportal from the BioPortal submission. The archive contains HOM_nodes.tsv and HOM_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HOM.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: hom
+        relation_type: prov:hadPrimarySource
+    node_count: 86
+    edge_count: 84
+    latest_version: releases/2015-01-07
 repository: https://github.com/BgeeDB/homology-ontology
 publications:
   - authors:

--- a/resource/hp/hp.kg-bioportal.md
+++ b/resource/hp/hp.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Human Phenotype Ontology (HP), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains HP_nodes.tsv and HP_edges.tsv.
+edge_count: 52509
+format: kgx
+id: hp.kg-bioportal
+latest_version: '2026-06-23'
+name: HP KGX graph (KG-Bioportal)
+node_count: 25358
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: hp
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HP.tar.gz
+layout: product_detail
+---

--- a/resource/hp/hp.md
+++ b/resource/hp/hp.md
@@ -27,7 +27,7 @@ domains:
 homepage_url: http://www.human-phenotype-ontology.org/
 id: hp
 infores_id: hpo
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://hpo.jax.org/app/license
@@ -3255,8 +3255,8 @@ products:
   compatibility:
   - standard: biolink
   compression: zip
-  description: Curated mechanistic drug–disease paths comprising the DrugMechDB dataset
-    packaged as a downloadable archive.
+  description: "Curated mechanistic drug\u2013disease paths comprising the DrugMechDB\
+    \ dataset packaged as a downloadable archive."
   dump_format: other
   format: mixed
   id: drugmechdb.graph
@@ -5162,14 +5162,12 @@ products:
     source: uniprot
   product_url: https://kghub.io/kg-covid-19/
   warnings:
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
+    when accessing file'
   - 'Download offline as of 2026-07-01: the KG-Hub reorganization has taken this file
     offline. The kghub.io and kg-hub.berkeleybop.io hosts return HTTP 404 for all
     kg-covid-19 artifacts (current and dated) and the kg-hub-public-data S3 objects
     return HTTP 403. No replacement public download URL is available.'
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
 - category: GraphProduct
   description: KGX Distribution of KG-IDG
   format: kgx
@@ -5208,13 +5206,11 @@ products:
     source: tcrd
   product_url: https://kg-hub.berkeleybop.io/kg-idg/current/kg-idg.tar.gz
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
   - 'File was not able to be retrieved when checked on 2026-07-01: HTTP 404 error.
     The kg-hub.berkeleybop.io host is being reorganized and KG-IDG downloads are pending
     relocation to a new home; no live download is currently available.'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
 - category: GraphProduct
   description: Merged KG with ontology-grounded KG and literature-based graph as TSV
     file
@@ -5593,10 +5589,24 @@ products:
     source: hp
   - relation_type: prov:wasInfluencedBy
     source: mondo
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Human Phenotype Ontology (HP), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains HP_nodes.tsv and HP_edges.tsv.
+  edge_count: 52509
+  format: kgx
+  id: hp.kg-bioportal
+  latest_version: '2026-06-23'
+  name: HP KGX graph (KG-Bioportal)
+  node_count: 25358
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: hp
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HP.tar.gz
 publications:
 - authors:
   - Robinson PN
-  - Köhler S
+  - "K\xF6hler S"
   - Bauer S
   - Seelow D
   - Horn D
@@ -5609,7 +5619,7 @@ publications:
   year: '2008'
 - authors:
   - Groza T
-  - Köhler S
+  - "K\xF6hler S"
   - Moldenhauer D
   - Vasilevsky N
   - Baynam G
@@ -5633,7 +5643,7 @@ publications:
   title: 'The Human Phenotype Ontology: Semantic Unification of Common and Rare Disease.'
   year: '2015'
 - authors:
-  - Köhler S
+  - "K\xF6hler S"
   - Doelken SC
   - Mungall CJ
   - Bauer S
@@ -5650,7 +5660,7 @@ publications:
   - Girdea M
   - Helbig I
   - Hurst JA
-  - Jähn J
+  - "J\xE4hn J"
   - Jackson LG
   - Kelly AM
   - Ledbetter DH
@@ -5687,7 +5697,7 @@ publications:
     through phenotype data.'
   year: '2014'
 - authors:
-  - Köhler S
+  - "K\xF6hler S"
   - Carmody L
   - Vasilevsky N
   - Jacobsen JOB
@@ -5712,7 +5722,7 @@ publications:
   - Chang WH
   - Bergerson J
   - Laulederkind SJF
-  - Yüksel Z
+  - "Y\xFCksel Z"
   - Beltran S
   - Freeman AF
   - Sergouniotis PI
@@ -5738,8 +5748,8 @@ publications:
   - Notarangelo L
   - Similuk M
   - Zhang XA
-  - Gómez-Andrés D
-  - Lochmüller H
+  - "G\xF3mez-Andr\xE9s D"
+  - "Lochm\xFCller H"
   - Dollfus H
   - Rosenzweig S
   - Marwaha S

--- a/resource/hravs/hravs.kg-bioportal.md
+++ b/resource/hravs/hravs.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of HuBMAP Research Attributes Value Set (HRAVS), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains HRAVS_nodes.tsv
+  and HRAVS_edges.tsv.
+edge_count: 2596
+format: kgx
+id: hravs.kg-bioportal
+name: HRAVS KGX graph (KG-Bioportal)
+node_count: 969
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: hravs
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HRAVS.tar.gz
+layout: product_detail
+---

--- a/resource/hravs/hravs.md
+++ b/resource/hravs/hravs.md
@@ -18,7 +18,7 @@ domains:
 - information technology
 homepage_url: https://humanatlas.io/
 id: hravs
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -202,6 +202,20 @@ products:
     source: vccf
   product_file_size: 376981902
   product_url: https://cdn.humanatlas.io/digital-objects/collection/hra/v2.2/graph.nq
+- id: hravs.kg-bioportal
+  name: HRAVS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of HuBMAP Research Attributes Value Set (HRAVS),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains HRAVS_nodes.tsv
+    and HRAVS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HRAVS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: hravs
+    relation_type: prov:hadPrimarySource
+  node_count: 969
+  edge_count: 2596
 publications:
 - authors:
   - Andreas Bueckle

--- a/resource/hsapdv/hsapdv.kg-bioportal.md
+++ b/resource/hsapdv/hsapdv.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Human Developmental Stages Ontology (HSAPDV), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains HSAPDV_nodes.tsv
+  and HSAPDV_edges.tsv.
+edge_count: 975
+format: kgx
+id: hsapdv.kg-bioportal
+latest_version: '2025-01-23'
+name: HSAPDV KGX graph (KG-Bioportal)
+node_count: 368
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: hsapdv
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HSAPDV.tar.gz
+layout: product_detail
+---

--- a/resource/hsapdv/hsapdv.md
+++ b/resource/hsapdv/hsapdv.md
@@ -19,7 +19,7 @@ domains:
 homepage_url: https://github.com/obophenotype/developmental-stage-ontologies/wiki/HsapDv
 id: hsapdv
 infores_id: hsapdv
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -456,6 +456,21 @@ products:
     source: mondo
   - relation_type: prov:wasInfluencedBy
     source: hsapdv
+- id: hsapdv.kg-bioportal
+  name: HSAPDV KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Human Developmental Stages Ontology (HSAPDV),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains HSAPDV_nodes.tsv
+    and HSAPDV_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HSAPDV.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: hsapdv
+    relation_type: prov:hadPrimarySource
+  node_count: 368
+  edge_count: 975
+  latest_version: '2025-01-23'
 publications: []
 repository: https://github.com/obophenotype/developmental-stage-ontologies
 ---

--- a/resource/hso/hso.kg-bioportal.md
+++ b/resource/hso/hso.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Health Surveillance Ontology (HSO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains HSO_nodes.tsv and
+  HSO_edges.tsv.
+edge_count: 2042
+format: kgx
+id: hso.kg-bioportal
+latest_version: 3.1.1
+name: HSO KGX graph (KG-Bioportal)
+node_count: 1283
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: hso
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HSO.tar.gz
+layout: product_detail
+---

--- a/resource/hso/hso.md
+++ b/resource/hso/hso.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://w3id.org/hso
 id: hso
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: hso
         relation_type: prov:hadPrimarySource
+  - id: hso.kg-bioportal
+    name: HSO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Health Surveillance Ontology (HSO), produced by KG-Bioportal from the BioPortal submission. The archive contains HSO_nodes.tsv and HSO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HSO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: hso
+        relation_type: prov:hadPrimarySource
+    node_count: 1283
+    edge_count: 2042
+    latest_version: 3.1.1
 repository: https://github.com/SVA-SE/HSO
 publications: []
 ---

--- a/resource/htn/htn.kg-bioportal.md
+++ b/resource/htn/htn.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Hypertension Ontology (HTN), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains HTN_nodes.tsv and HTN_edges.tsv.
+edge_count: 1963
+format: kgx
+id: htn.kg-bioportal
+name: HTN KGX graph (KG-Bioportal)
+node_count: 1130
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: htn
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HTN.tar.gz
+layout: product_detail
+---

--- a/resource/htn/htn.md
+++ b/resource/htn/htn.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/aellenhicks/htn_owl
 id: htn
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,18 @@ products:
     original_source:
       - source: htn
         relation_type: prov:hadPrimarySource
+  - id: htn.kg-bioportal
+    name: HTN KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Hypertension Ontology (HTN), produced by KG-Bioportal from the BioPortal submission. The archive contains HTN_nodes.tsv and HTN_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/HTN.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: htn
+        relation_type: prov:hadPrimarySource
+    node_count: 1130
+    edge_count: 1963
 repository: https://github.com/aellenhicks/htn_owl
 publications: []
 ---

--- a/resource/iao/iao.kg-bioportal.md
+++ b/resource/iao/iao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Information Artifact Ontology (IAO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains IAO_nodes.tsv and
+  IAO_edges.tsv.
+edge_count: 878
+format: kgx
+id: iao.kg-bioportal
+latest_version: '2026-03-30'
+name: IAO KGX graph (KG-Bioportal)
+node_count: 505
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: iao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IAO.tar.gz
+layout: product_detail
+---

--- a/resource/iao/iao.md
+++ b/resource/iao/iao.md
@@ -19,7 +19,7 @@ domains:
   - information technology
 homepage_url: https://github.com/information-artifact-ontology/IAO/
 id: "iao"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/4.0/"
@@ -303,6 +303,19 @@ products:
         source: obi
     product_file_size: 642902930
     product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
+  - id: iao.kg-bioportal
+    name: IAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Information Artifact Ontology (IAO), produced by KG-Bioportal from the BioPortal submission. The archive contains IAO_nodes.tsv and IAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: iao
+        relation_type: prov:hadPrimarySource
+    node_count: 505
+    edge_count: 878
+    latest_version: '2026-03-30'
 publications:
   - authors:
       - Ceusters W

--- a/resource/ico/ico.kg-bioportal.md
+++ b/resource/ico/ico.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Informed Consent Ontology (ICO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains ICO_nodes.tsv and ICO_edges.tsv.
+edge_count: 3300
+format: kgx
+id: ico.kg-bioportal
+latest_version: '2026-02-28'
+name: ICO KGX graph (KG-Bioportal)
+node_count: 1589
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ico
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICO.tar.gz
+layout: product_detail
+---

--- a/resource/ico/ico.md
+++ b/resource/ico/ico.md
@@ -19,7 +19,7 @@ domains:
 - general
 homepage_url: https://github.com/ICO-ontology/ICO
 id: ico
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,20 @@ products:
   original_source:
   - source: ico
     relation_type: prov:hadPrimarySource
+- id: ico.kg-bioportal
+  name: ICO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Informed Consent Ontology (ICO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains ICO_nodes.tsv and ICO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ICO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ico
+    relation_type: prov:hadPrimarySource
+  node_count: 1589
+  edge_count: 3300
+  latest_version: '2026-02-28'
 repository: https://github.com/ICO-ontology/ICO
 publications:
 - authors:

--- a/resource/ido/ido.kg-bioportal.md
+++ b/resource/ido/ido.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Infectious Disease Ontology (IDO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains IDO_nodes.tsv and IDO_edges.tsv.
+edge_count: 835
+format: kgx
+id: ido.kg-bioportal
+latest_version: 8-3-20
+name: IDO KGX graph (KG-Bioportal)
+node_count: 538
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ido
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDO.tar.gz
+layout: product_detail
+---

--- a/resource/ido/ido.md
+++ b/resource/ido/ido.md
@@ -21,7 +21,7 @@ domains:
 - biomedical
 homepage_url: http://www.bioontology.org/wiki/index.php/Infectious_Disease_Ontology
 id: ido
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -227,6 +227,21 @@ products:
     source: zfa
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
+- id: ido.kg-bioportal
+  name: IDO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Infectious Disease Ontology (IDO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains IDO_nodes.tsv
+    and IDO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ido
+    relation_type: prov:hadPrimarySource
+  node_count: 538
+  edge_count: 835
+  latest_version: 8-3-20
 publications:
 - authors:
   - Babcock S

--- a/resource/idomal/idomal.kg-bioportal.md
+++ b/resource/idomal/idomal.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Malaria Ontology (IDOMAL), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains IDOMAL_nodes.tsv and IDOMAL_edges.tsv.
+edge_count: 4505
+format: kgx
+id: idomal.kg-bioportal
+latest_version: 1.3.9
+name: IDOMAL KGX graph (KG-Bioportal)
+node_count: 3203
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: idomal
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDOMAL.tar.gz
+layout: product_detail
+---

--- a/resource/idomal/idomal.md
+++ b/resource/idomal/idomal.md
@@ -15,7 +15,7 @@ domains:
   - biomedical
 homepage_url: https://www.vectorbase.org/ontology-browser
 id: idomal
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -43,6 +43,19 @@ products:
     original_source:
       - source: idomal
         relation_type: prov:hadPrimarySource
+  - id: idomal.kg-bioportal
+    name: IDOMAL KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Malaria Ontology (IDOMAL), produced by KG-Bioportal from the BioPortal submission. The archive contains IDOMAL_nodes.tsv and IDOMAL_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/IDOMAL.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: idomal
+        relation_type: prov:hadPrimarySource
+    node_count: 3203
+    edge_count: 4505
+    latest_version: 1.3.9
 repository: https://github.com/VEuPathDB-ontology/IDOMAL
 publications: []
 ---

--- a/resource/ino/ino.kg-bioportal.md
+++ b/resource/ino/ino.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Interaction Network Ontology (INO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains INO_nodes.tsv and
+  INO_edges.tsv.
+edge_count: 965
+format: kgx
+id: ino.kg-bioportal
+latest_version: 1.1.13
+name: INO KGX graph (KG-Bioportal)
+node_count: 496
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ino
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INO.tar.gz
+layout: product_detail
+---

--- a/resource/ino/ino.md
+++ b/resource/ino/ino.md
@@ -19,7 +19,7 @@ domains:
 homepage_url: https://github.com/INO-ontology/ino
 id: ino
 infores_id: ino
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -37,6 +37,19 @@ products:
     original_source:
       - source: ino
         relation_type: prov:hadPrimarySource
+  - id: ino.kg-bioportal
+    name: INO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Interaction Network Ontology (INO), produced by KG-Bioportal from the BioPortal submission. The archive contains INO_nodes.tsv and INO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/INO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ino
+        relation_type: prov:hadPrimarySource
+    node_count: 496
+    edge_count: 965
+    latest_version: 1.1.13
 repository: https://github.com/INO-ontology/ino
 publications:
   - authors:

--- a/resource/kg-bioportal/kg-bioportal.browser.md
+++ b/resource/kg-bioportal/kg-bioportal.browser.md
@@ -1,0 +1,17 @@
+---
+category: GraphicalInterface
+description: Browsable listing of every KG-Bioportal graph, with node and edge counts,
+  transform status, and a download link for each. This is the canonical index of the
+  transforms; KG-Registry does not mirror the full inventory.
+format: http
+id: kg-bioportal.browser
+name: KG-Bioportal Graph Browser
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: kg-bioportal
+product_url: https://ncbo.github.io/kg-bioportal/graphs/
+secondary_source:
+- relation_type: prov:wasDerivedFrom
+  source: bioportal
+layout: product_detail
+---

--- a/resource/kg-bioportal/kg-bioportal.code.md
+++ b/resource/kg-bioportal/kg-bioportal.code.md
@@ -1,0 +1,13 @@
+---
+category: ProcessProduct
+description: Python package and GitHub Actions workflow that download BioPortal ontologies
+  and convert them to KGX with ROBOT and the KGX toolkit.
+format: python
+id: kg-bioportal.code
+name: KG-Bioportal Transform Pipeline
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: kg-bioportal
+product_url: https://github.com/ncbo/kg-bioportal
+layout: product_detail
+---

--- a/resource/kg-bioportal/kg-bioportal.graphs.md
+++ b/resource/kg-bioportal/kg-bioportal.graphs.md
@@ -1,0 +1,20 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV graphs for all successfully transformed BioPortal ontologies,
+  published as one gzipped tar archive per ontology on the latest release. Individual
+  archives are at https://github.com/ncbo/kg-bioportal/releases/latest/download/<ACRONYM>.tar.gz
+  and contain <ACRONYM>_nodes.tsv and <ACRONYM>_edges.tsv.
+format: kgx
+id: kg-bioportal.graphs
+latest_version: latest
+name: KG-Bioportal KGX Graphs
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: kg-bioportal
+product_url: https://github.com/ncbo/kg-bioportal/releases/latest
+secondary_source:
+- relation_type: prov:wasDerivedFrom
+  source: bioportal
+layout: product_detail
+---

--- a/resource/kg-bioportal/kg-bioportal.manifest.md
+++ b/resource/kg-bioportal/kg-bioportal.manifest.md
@@ -1,0 +1,17 @@
+---
+category: Product
+description: Manifest of every transform attempt, giving the BioPortal acronym, status,
+  node and edge counts, source submission, and release download URL for each ontology.
+  Refreshed with each monthly transform run.
+format: yaml
+id: kg-bioportal.manifest
+name: KG-Bioportal Transform Manifest
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: kg-bioportal
+product_url: https://github.com/ncbo/kg-bioportal/releases/latest/download/onto_stats.yaml
+secondary_source:
+- relation_type: prov:wasDerivedFrom
+  source: bioportal
+layout: product_detail
+---

--- a/resource/kg-bioportal/kg-bioportal.md
+++ b/resource/kg-bioportal/kg-bioportal.md
@@ -1,0 +1,124 @@
+---
+activity_status: active
+category: Aggregator
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: support@bioontology.org
+  - contact_type: url
+    value: https://www.bioontology.org/
+  label: National Center for Biomedical Ontology (NCBO), Stanford
+creation_date: '2026-08-06T00:00:00Z'
+description: KG-Bioportal transforms the ontologies hosted by BioPortal into KGX
+  node and edge files, so each can be used as a knowledge graph. Transforms run
+  monthly on GitHub Actions and every successful result is published as a release
+  asset, alongside a manifest of per-ontology status and node/edge counts. Over
+  a thousand ontologies are covered; the graph browser is the authoritative
+  listing.
+domains:
+- biomedical
+- clinical
+- information technology
+- general
+homepage_url: https://ncbo.github.io/kg-bioportal/
+id: kg-bioportal
+last_modified_date: '2026-08-06T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://www.bioontology.org/terms/
+  label: BioPortal Terms of Use (individual ontologies carry their own licenses)
+name: KG-Bioportal
+products:
+- category: GraphicalInterface
+  description: Browsable listing of every KG-Bioportal graph, with node and edge
+    counts, transform status, and a download link for each. This is the canonical
+    index of the transforms; KG-Registry does not mirror the full inventory.
+  format: http
+  id: kg-bioportal.browser
+  name: KG-Bioportal Graph Browser
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: kg-bioportal
+  product_url: https://ncbo.github.io/kg-bioportal/graphs/
+  secondary_source:
+  - relation_type: prov:wasDerivedFrom
+    source: bioportal
+- category: Product
+  description: Manifest of every transform attempt, giving the BioPortal acronym,
+    status, node and edge counts, source submission, and release download URL for
+    each ontology. Refreshed with each monthly transform run.
+  format: yaml
+  id: kg-bioportal.manifest
+  name: KG-Bioportal Transform Manifest
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: kg-bioportal
+  product_url: https://github.com/ncbo/kg-bioportal/releases/latest/download/onto_stats.yaml
+  secondary_source:
+  - relation_type: prov:wasDerivedFrom
+    source: bioportal
+- category: GraphProduct
+  description: KGX TSV graphs for all successfully transformed BioPortal
+    ontologies, published as one gzipped tar archive per ontology on the latest
+    release. Individual archives are at
+    https://github.com/ncbo/kg-bioportal/releases/latest/download/<ACRONYM>.tar.gz
+    and contain <ACRONYM>_nodes.tsv and <ACRONYM>_edges.tsv.
+  compression: targz
+  format: kgx
+  id: kg-bioportal.graphs
+  latest_version: latest
+  name: KG-Bioportal KGX Graphs
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: kg-bioportal
+  product_url: https://github.com/ncbo/kg-bioportal/releases/latest
+  secondary_source:
+  - relation_type: prov:wasDerivedFrom
+    source: bioportal
+- category: ProcessProduct
+  description: Python package and GitHub Actions workflow that download BioPortal
+    ontologies and convert them to KGX with ROBOT and the KGX toolkit.
+  format: python
+  id: kg-bioportal.code
+  name: KG-Bioportal Transform Pipeline
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: kg-bioportal
+  product_url: https://github.com/ncbo/kg-bioportal
+repository: https://github.com/ncbo/kg-bioportal
+---
+# KG-Bioportal
+
+KG-Bioportal is a transform pipeline and graph collection: it takes the ontologies
+in [BioPortal](https://bioportal.bioontology.org/) and converts each into
+[KGX](https://github.com/biolink/kgx) node and edge TSVs. The transforms run
+monthly on GitHub Actions, and each successful result is attached to a GitHub
+release as `<ACRONYM>.tar.gz`.
+
+## Finding a graph
+
+Because KG-Bioportal covers all of BioPortal, its inventory runs to well over a
+thousand entries -- far more than belongs on a single registry page. Use the
+[graph browser](https://ncbo.github.io/kg-bioportal/graphs/) to search the full
+set. Every archive is also reachable directly at a stable URL:
+
+```
+https://github.com/ncbo/kg-bioportal/releases/latest/download/<ACRONYM>.tar.gz
+```
+
+## Relationship to KG-Registry
+
+Where an ontology transformed by KG-Bioportal already has a KG-Registry resource
+page, that page carries the transform as its own `<resource>.kg-bioportal`
+product, added by `util/sync_kg_bioportal.py`. Transforms that failed or were
+skipped have no artifact and are not recorded here; the browser explains those
+cases. KG-Bioportal's graph browser in turn draws part of its listing from
+KG-Registry, so the sync deliberately never creates registry resources from the
+KG-Bioportal manifest.
+
+## Coverage limits
+
+The largest ontologies -- NCBITaxon, SNOMED CT, RxNorm, PR, NCIT, and others --
+exceed what GitHub-hosted runners can transform and are skipped rather than
+failing the build. Their status and the reason are recorded in the manifest.

--- a/resource/kgcl/kgcl.kg-bioportal.md
+++ b/resource/kgcl/kgcl.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Knowledge Graph Change Language (KGCL), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains KGCL_nodes.tsv
+  and KGCL_edges.tsv.
+edge_count: 526
+format: kgx
+id: kgcl.kg-bioportal
+latest_version: 0.1.0
+name: KGCL KGX graph (KG-Bioportal)
+node_count: 218
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: kgcl
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/KGCL.tar.gz
+layout: product_detail
+---

--- a/resource/kgcl/kgcl.md
+++ b/resource/kgcl/kgcl.md
@@ -69,29 +69,42 @@ products:
         relation_type: prov:hadPrimarySource
     product_file_size: 7492
     product_url: https://w3id.org/kgcl/kgcl.yaml
+  - id: kgcl.kg-bioportal
+    name: KGCL KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Knowledge Graph Change Language (KGCL), produced by KG-Bioportal from the BioPortal submission. The archive contains KGCL_nodes.tsv and KGCL_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/KGCL.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: kgcl
+        relation_type: prov:hadPrimarySource
+    node_count: 218
+    edge_count: 526
+    latest_version: 0.1.0
 publications:
-- authors:
-  - Hegde H
-  - Vendetti J
-  - Goutte-Gattat D
-  - Caufield JH
-  - Graybeal JB
-  - Harris NL
-  - Karam N
-  - Kindermann C
-  - Matentzoglu N
-  - Overton JA
-  - Mungall CJ
-  doi: 10.1093/database/baae133
-  id: doi:10.1093/database/baae133
-  journal: Database
-  preferred: true
-  title: A change language for ontologies and knowledge graphs
-  year: '2025'
+  - authors:
+      - Hegde H
+      - Vendetti J
+      - Goutte-Gattat D
+      - Caufield JH
+      - Graybeal JB
+      - Harris NL
+      - Karam N
+      - Kindermann C
+      - Matentzoglu N
+      - Overton JA
+      - Mungall CJ
+    doi: 10.1093/database/baae133
+    id: doi:10.1093/database/baae133
+    journal: Database
+    preferred: true
+    title: A change language for ontologies and knowledge graphs
+    year: '2025'
 repository: https://github.com/INCATools/kgcl/
 version: 0.7.0
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2025-08-06T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 ---
 
 ## Overview

--- a/resource/labo/labo.kg-bioportal.md
+++ b/resource/labo/labo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of clinical LABoratory Ontology (LABO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains LABO_nodes.tsv
+  and LABO_edges.tsv.
+edge_count: 547
+format: kgx
+id: labo.kg-bioportal
+name: LABO KGX graph (KG-Bioportal)
+node_count: 298
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: labo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LABO.tar.gz
+layout: product_detail
+---

--- a/resource/labo/labo.md
+++ b/resource/labo/labo.md
@@ -20,7 +20,7 @@ domains:
 - information technology
 homepage_url: https://github.com/OpenLHS/LABO
 id: labo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -38,15 +38,29 @@ products:
   original_source:
   - source: labo
     relation_type: prov:hadPrimarySource
+- id: labo.kg-bioportal
+  name: LABO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of clinical LABoratory Ontology (LABO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains LABO_nodes.tsv
+    and LABO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LABO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: labo
+    relation_type: prov:hadPrimarySource
+  node_count: 298
+  edge_count: 547
 repository: https://github.com/OpenLHS/LABO
 taxon:
 - NCBITaxon:9606
 publications:
 - authors:
-  - "Barton, Adrien"
-  - "Fabry, Paul"
-  - "Lavoie, Luc"
-  - "Ethier, Jean-François"
+  - Barton, Adrien
+  - Fabry, Paul
+  - Lavoie, Luc
+  - Ethier, Jean-François
   doi: 10.5281/zenodo.6522019
   id: https://doi.org/10.5281/zenodo.6522019
   journal: Zenodo

--- a/resource/lepao/lepao.kg-bioportal.md
+++ b/resource/lepao/lepao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Lepidoptera Anatomy Ontology (LEPAO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains LEPAO_nodes.tsv
+  and LEPAO_edges.tsv.
+edge_count: 2404
+format: kgx
+id: lepao.kg-bioportal
+latest_version: '2023-02-18'
+name: LEPAO KGX graph (KG-Bioportal)
+node_count: 1215
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: lepao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LEPAO.tar.gz
+layout: product_detail
+---

--- a/resource/lepao/lepao.md
+++ b/resource/lepao/lepao.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/insect-morphology/lepao
 id: lepao
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: lepao
         relation_type: prov:hadPrimarySource
+  - id: lepao.kg-bioportal
+    name: LEPAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Lepidoptera Anatomy Ontology (LEPAO), produced by KG-Bioportal from the BioPortal submission. The archive contains LEPAO_nodes.tsv and LEPAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/LEPAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: lepao
+        relation_type: prov:hadPrimarySource
+    node_count: 1215
+    edge_count: 2404
+    latest_version: '2023-02-18'
 repository: https://github.com/insect-morphology/lepao
 publications: []
 ---

--- a/resource/lipro/lipro.kg-bioportal.md
+++ b/resource/lipro/lipro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Lipid Ontology (LIPRO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains LIPRO_nodes.tsv and LIPRO_edges.tsv.
+edge_count: 17
+format: kgx
+id: lipro.kg-bioportal
+latest_version: See Remote Site
+name: LIPRO KGX graph (KG-Bioportal)
+node_count: 292
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: lipro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/LIPRO.tar.gz
+layout: product_detail
+---

--- a/resource/lipro/lipro.md
+++ b/resource/lipro/lipro.md
@@ -16,7 +16,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: https://obofoundry.org/ontology/lipro.html
 id: lipro
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -35,6 +35,20 @@ products:
     source: lipro
   product_file_size: 50539
   product_url: http://aber-owl.net/media/ontologies/LIPRO/4/lipro.owl
+- id: lipro.kg-bioportal
+  name: LIPRO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Lipid Ontology (LIPRO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains LIPRO_nodes.tsv and LIPRO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/LIPRO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: lipro
+    relation_type: prov:hadPrimarySource
+  node_count: 292
+  edge_count: 17
+  latest_version: See Remote Site
 publications:
 - authors:
   - Chepelev LL

--- a/resource/ma/ma.kg-bioportal.md
+++ b/resource/ma/ma.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mouse Adult Gross Anatomy Ontology (MA), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains MA_nodes.tsv
+  and MA_edges.tsv.
+edge_count: 4284
+format: kgx
+id: ma.kg-bioportal
+latest_version: '2026-02-24'
+name: MA KGX graph (KG-Bioportal)
+node_count: 3408
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ma
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MA.tar.gz
+layout: product_detail
+---

--- a/resource/ma/ma.md
+++ b/resource/ma/ma.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/adult-mouse-anatomy-ontology
 id: "ma"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "https://creativecommons.org/licenses/by/4.0/"
@@ -234,6 +234,19 @@ products:
         source: zfa
     product_file_size: 64058275
     product_url: https://www.ebi.ac.uk/efo/efo.obo
+  - id: ma.kg-bioportal
+    name: MA KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Mouse Adult Gross Anatomy Ontology (MA), produced by KG-Bioportal from the BioPortal submission. The archive contains MA_nodes.tsv and MA_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MA.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ma
+        relation_type: prov:hadPrimarySource
+    node_count: 3408
+    edge_count: 4284
+    latest_version: '2026-02-24'
 publications:
   - authors:
       - Hayamizu TF

--- a/resource/mamo/mamo.kg-bioportal.md
+++ b/resource/mamo/mamo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mathematical Modelling Ontology (MAMO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains MAMO_nodes.tsv
+  and MAMO_edges.tsv.
+edge_count: 168
+format: kgx
+id: mamo.kg-bioportal
+latest_version: '2023-02-03'
+name: MAMO KGX graph (KG-Bioportal)
+node_count: 117
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mamo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MAMO.tar.gz
+layout: product_detail
+---

--- a/resource/mamo/mamo.md
+++ b/resource/mamo/mamo.md
@@ -13,7 +13,7 @@ domains:
 - information technology
 homepage_url: http://sourceforge.net/p/mamo-ontology/wiki/Home/
 id: mamo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://opensource.org/licenses/Artistic-2.0
@@ -30,6 +30,21 @@ products:
   original_source:
   - source: mamo
     relation_type: prov:hadPrimarySource
+- id: mamo.kg-bioportal
+  name: MAMO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Mathematical Modelling Ontology (MAMO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains MAMO_nodes.tsv
+    and MAMO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MAMO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: mamo
+    relation_type: prov:hadPrimarySource
+  node_count: 117
+  edge_count: 168
+  latest_version: '2023-02-03'
 repository: http://sourceforge.net/p/mamo-ontology
 publications: []
 ---

--- a/resource/mat/mat.kg-bioportal.md
+++ b/resource/mat/mat.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Minimal Anatomical Terminology (MAT), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains MAT_nodes.tsv and
+  MAT_edges.tsv.
+edge_count: 3954
+format: kgx
+id: mat.kg-bioportal
+latest_version: '1.1'
+name: MAT KGX graph (KG-Bioportal)
+node_count: 2204
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mat
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MAT.tar.gz
+layout: product_detail
+---

--- a/resource/mat/mat.md
+++ b/resource/mat/mat.md
@@ -11,7 +11,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-07-03T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 domains:
 - anatomy and development
 contacts:
@@ -20,7 +20,22 @@ contacts:
   contact_details:
   - contact_type: email
     value: j.bard@ed.ac.uk
-products: []
+products:
+- id: mat.kg-bioportal
+  name: MAT KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Minimal Anatomical Terminology (MAT), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains MAT_nodes.tsv
+    and MAT_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MAT.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: mat
+    relation_type: prov:hadPrimarySource
+  node_count: 2204
+  edge_count: 3954
+  latest_version: '1.1'
 publications: []
 ---
 ## Description

--- a/resource/mco/mco.kg-bioportal.md
+++ b/resource/mco/mco.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Microbial Conditions Ontology (MCO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains MCO_nodes.tsv and
+  MCO_edges.tsv.
+edge_count: 9520
+format: kgx
+id: mco.kg-bioportal
+name: MCO KGX graph (KG-Bioportal)
+node_count: 3561
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mco
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCO.tar.gz
+layout: product_detail
+---

--- a/resource/mco/mco.md
+++ b/resource/mco/mco.md
@@ -27,7 +27,7 @@ domains:
 - general
 homepage_url: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology
 id: mco
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -55,6 +55,20 @@ products:
   original_source:
   - source: mco
     relation_type: prov:hadPrimarySource
+- id: mco.kg-bioportal
+  name: MCO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Microbial Conditions Ontology (MCO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains MCO_nodes.tsv
+    and MCO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: mco
+    relation_type: prov:hadPrimarySource
+  node_count: 3561
+  edge_count: 9520
 repository: https://github.com/microbial-conditions-ontology/microbial-conditions-ontology
 publications: []
 ---

--- a/resource/mcro/mcro.kg-bioportal.md
+++ b/resource/mcro/mcro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Model Card Report Ontology (MCRO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MCRO_nodes.tsv and MCRO_edges.tsv.
+edge_count: 124
+format: kgx
+id: mcro.kg-bioportal
+latest_version: '2023-03-07'
+name: MCRO KGX graph (KG-Bioportal)
+node_count: 92
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mcro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCRO.tar.gz
+layout: product_detail
+---

--- a/resource/mcro/mcro.md
+++ b/resource/mcro/mcro.md
@@ -21,7 +21,7 @@ domains:
 - information technology
 homepage_url: https://github.com/UTHealth-Ontology/MCRO
 id: mcro
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -39,6 +39,21 @@ products:
   original_source:
   - source: mcro
     relation_type: prov:hadPrimarySource
+- id: mcro.kg-bioportal
+  name: MCRO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Model Card Report Ontology (MCRO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains MCRO_nodes.tsv
+    and MCRO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MCRO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: mcro
+    relation_type: prov:hadPrimarySource
+  node_count: 92
+  edge_count: 124
+  latest_version: '2023-03-07'
 repository: https://github.com/UTHealth-Ontology/MCRO
 publications:
 - authors:

--- a/resource/medlineplus/medlineplus.kg-bioportal.md
+++ b/resource/medlineplus/medlineplus.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of MedlinePlus Health Topics (MEDLINEPLUS), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains MEDLINEPLUS_nodes.tsv
+  and MEDLINEPLUS_edges.tsv.
+edge_count: 2037
+format: kgx
+id: medlineplus.kg-bioportal
+latest_version: '20250624'
+name: MEDLINEPLUS KGX graph (KG-Bioportal)
+node_count: 6111
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: medlineplus
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEDLINEPLUS.tar.gz
+layout: product_detail
+---

--- a/resource/medlineplus/medlineplus.md
+++ b/resource/medlineplus/medlineplus.md
@@ -29,7 +29,7 @@ domains:
 homepage_url: https://medlineplus.gov/
 id: medlineplus
 infores_id: medlineplus
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 name: MedlinePlus
 products:
@@ -431,6 +431,21 @@ products:
     source: medlineplus
   product_file_size: 132
   product_url: https://github.com/biothings/pending.api/blob/translator-output/plugins/DISEASES/DISEASES_trapi_edges.jsonl
+- id: medlineplus.kg-bioportal
+  name: MEDLINEPLUS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of MedlinePlus Health Topics (MEDLINEPLUS), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains MEDLINEPLUS_nodes.tsv
+    and MEDLINEPLUS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MEDLINEPLUS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: medlineplus
+    relation_type: prov:hadPrimarySource
+  node_count: 6111
+  edge_count: 2037
+  latest_version: '20250624'
 taxon:
 - NCBITaxon:9606
 ---

--- a/resource/metpo/metpo.kg-bioportal.md
+++ b/resource/metpo/metpo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of METPO (METPO), produced by KG-Bioportal from the
+  BioPortal submission. The archive contains METPO_nodes.tsv and METPO_edges.tsv.
+edge_count: 3189
+format: kgx
+id: metpo.kg-bioportal
+latest_version: '2026-06-12'
+name: METPO KGX graph (KG-Bioportal)
+node_count: 1654
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: metpo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/METPO.tar.gz
+layout: product_detail
+---

--- a/resource/metpo/metpo.md
+++ b/resource/metpo/metpo.md
@@ -20,7 +20,7 @@ domains:
 - biological systems
 homepage_url: https://github.com/berkeleybop/metpo
 id: metpo
-last_modified_date: '2026-01-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -243,6 +243,20 @@ products:
     source: uniprot
   product_file_size: 4640682152
   product_url: https://portal.nersc.gov/project/m4689/KGMicrobe-biomedical-function-20250222.tar.gz
+- id: metpo.kg-bioportal
+  name: METPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of METPO (METPO), produced by KG-Bioportal from the
+    BioPortal submission. The archive contains METPO_nodes.tsv and METPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/METPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: metpo
+    relation_type: prov:hadPrimarySource
+  node_count: 1654
+  edge_count: 3189
+  latest_version: '2026-06-12'
 repository: https://github.com/berkeleybop/metpo
 synonyms:
 - METPO

--- a/resource/mf/mf.kg-bioportal.md
+++ b/resource/mf/mf.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mental Functioning Ontology (MF), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MF_nodes.tsv and MF_edges.tsv.
+edge_count: 806
+format: kgx
+id: mf.kg-bioportal
+latest_version: '2025-07-08'
+name: MF KGX graph (KG-Bioportal)
+node_count: 533
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mf
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MF.tar.gz
+layout: product_detail
+---

--- a/resource/mf/mf.md
+++ b/resource/mf/mf.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/jannahastings/mental-functioning-ontology
 id: "mf"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/3.0/"
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: mf
         relation_type: prov:hadPrimarySource
+  - id: mf.kg-bioportal
+    name: MF KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Mental Functioning Ontology (MF), produced by KG-Bioportal from the BioPortal submission. The archive contains MF_nodes.tsv and MF_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MF.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mf
+        relation_type: prov:hadPrimarySource
+    node_count: 533
+    edge_count: 806
+    latest_version: '2025-07-08'
 repository: https://github.com/jannahastings/mental-functioning-ontology
 publications:
   - authors:

--- a/resource/mfmo/mfmo.kg-bioportal.md
+++ b/resource/mfmo/mfmo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mammalian Feeding Muscle Ontology (MFMO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains MFMO_nodes.tsv
+  and MFMO_edges.tsv.
+edge_count: 425
+format: kgx
+id: mfmo.kg-bioportal
+name: MFMO KGX graph (KG-Bioportal)
+node_count: 282
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mfmo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFMO.tar.gz
+layout: product_detail
+---

--- a/resource/mfmo/mfmo.md
+++ b/resource/mfmo/mfmo.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/rdruzinsky/feedontology
 id: mfmo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,18 @@ products:
     original_source:
       - source: mfmo
         relation_type: prov:hadPrimarySource
+  - id: mfmo.kg-bioportal
+    name: MFMO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Mammalian Feeding Muscle Ontology (MFMO), produced by KG-Bioportal from the BioPortal submission. The archive contains MFMO_nodes.tsv and MFMO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFMO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mfmo
+        relation_type: prov:hadPrimarySource
+    node_count: 282
+    edge_count: 425
 repository: https://github.com/RDruzinsky/feedontology
 taxon:
   - NCBITaxon:40674

--- a/resource/mfo/mfo.kg-bioportal.md
+++ b/resource/mfo/mfo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Medaka Fish Anatomy and Development Ontology (MFO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains MFO_nodes.tsv
+  and MFO_edges.tsv.
+edge_count: 4402
+format: kgx
+id: mfo.kg-bioportal
+name: MFO KGX graph (KG-Bioportal)
+node_count: 4374
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mfo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFO.tar.gz
+layout: product_detail
+---

--- a/resource/mfo/mfo.md
+++ b/resource/mfo/mfo.md
@@ -11,7 +11,7 @@ collection:
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 domains:
   - anatomy and development
 taxon:
@@ -35,9 +35,21 @@ products:
     original_source:
       - source: mfo
         relation_type: prov:hadPrimarySource
+  - id: mfo.kg-bioportal
+    name: MFO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Medaka Fish Anatomy and Development Ontology (MFO), produced by KG-Bioportal from the BioPortal submission. The archive contains MFO_nodes.tsv and MFO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mfo
+        relation_type: prov:hadPrimarySource
+    node_count: 4374
+    edge_count: 4402
 publications: []
 use_instead:
-- olatdv
+  - olatdv
 ---
 
 ## Description

--- a/resource/mfoem/mfoem.kg-bioportal.md
+++ b/resource/mfoem/mfoem.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Emotion Ontology (MFOEM), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MFOEM_nodes.tsv and MFOEM_edges.tsv.
+edge_count: 1109
+format: kgx
+id: mfoem.kg-bioportal
+latest_version: '2025-07-31'
+name: MFOEM KGX graph (KG-Bioportal)
+node_count: 771
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mfoem
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFOEM.tar.gz
+layout: product_detail
+---

--- a/resource/mfoem/mfoem.md
+++ b/resource/mfoem/mfoem.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/jannahastings/emotion-ontology
 id: mfoem
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: mfoem
         relation_type: prov:hadPrimarySource
+  - id: mfoem.kg-bioportal
+    name: MFOEM KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Emotion Ontology (MFOEM), produced by KG-Bioportal from the BioPortal submission. The archive contains MFOEM_nodes.tsv and MFOEM_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFOEM.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mfoem
+        relation_type: prov:hadPrimarySource
+    node_count: 771
+    edge_count: 1109
+    latest_version: '2025-07-31'
 repository: https://github.com/jannahastings/emotion-ontology
 publications:
   - authors:

--- a/resource/mfomd/mfomd.kg-bioportal.md
+++ b/resource/mfomd/mfomd.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of MFO Mental Disease Ontology (MFOMD), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains MFOMD_nodes.tsv
+  and MFOMD_edges.tsv.
+edge_count: 11
+format: kgx
+id: mfomd.kg-bioportal
+latest_version: '2020-04-26'
+name: MFOMD KGX graph (KG-Bioportal)
+node_count: 34
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mfomd
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFOMD.tar.gz
+layout: product_detail
+---

--- a/resource/mfomd/mfomd.md
+++ b/resource/mfomd/mfomd.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/jannahastings/mental-functioning-ontology
 id: "mfomd"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/3.0/"
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: mfomd
         relation_type: prov:hadPrimarySource
+  - id: mfomd.kg-bioportal
+    name: MFOMD KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of MFO Mental Disease Ontology (MFOMD), produced by KG-Bioportal from the BioPortal submission. The archive contains MFOMD_nodes.tsv and MFOMD_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MFOMD.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mfomd
+        relation_type: prov:hadPrimarySource
+    node_count: 34
+    edge_count: 11
+    latest_version: '2020-04-26'
 repository: https://github.com/jannahastings/mental-functioning-ontology
 publications:
   - authors:

--- a/resource/mi/mi.kg-bioportal.md
+++ b/resource/mi/mi.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Molecular Interactions (MI), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MI_nodes.tsv and MI_edges.tsv.
+edge_count: 3178
+format: kgx
+id: mi.kg-bioportal
+name: MI KGX graph (KG-Bioportal)
+node_count: 1703
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MI.tar.gz
+layout: product_detail
+---

--- a/resource/mi/mi.md
+++ b/resource/mi/mi.md
@@ -21,7 +21,7 @@ domains:
 homepage_url: https://github.com/HUPO-PSI/psi-mi-CV
 id: mi
 infores_id: mi
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -545,18 +545,16 @@ products:
   - relation_type: prov:used
     source: mi
   warnings:
+  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
+    header found'
+  - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
+    to URL'
   - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
     header found
   - File was not able to be retrieved when checked on 2026-03-08_ HTTP 500 error when
     accessing file
   - File was not able to be retrieved when checked on 2026-02-18_ Timeout connecting
     to URL
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
-    header found'
 - category: Product
   description: Human protein interactions from MINT in PSI-MI MITAB format for Homo
     sapiens (NCBITaxon 9606).
@@ -575,18 +573,16 @@ products:
   - relation_type: prov:used
     source: mi
   warnings:
+  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
+    header found'
+  - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
+    to URL'
   - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
     header found
   - File was not able to be retrieved when checked on 2026-03-08_ HTTP 500 error when
     accessing file
   - File was not able to be retrieved when checked on 2025-12-04_ Timeout connecting
     to URL
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
-    header found'
 - category: Product
   description: Mouse protein interactions from MINT in PSI-MI MITAB format for Mus
     musculus (NCBITaxon 10090).
@@ -605,18 +601,16 @@ products:
   - relation_type: prov:used
     source: mi
   warnings:
+  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
+    header found'
+  - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
+    to URL'
   - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
     header found
   - File was not able to be retrieved when checked on 2026-03-08_ HTTP 500 error when
     accessing file
   - File was not able to be retrieved when checked on 2026-01-06_ Timeout connecting
     to URL
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
-  - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
-    to URL'
-  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
-    header found'
 - category: Product
   description: Drosophila melanogaster protein interactions from MINT in PSI-MI MITAB
     format.
@@ -635,13 +629,11 @@ products:
   - relation_type: prov:used
     source: mi
   warnings:
-  - PSICQUIC query endpoints may stream results without a stable Content-Length header.
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
+  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
   - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
     to URL'
-  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
-    header found'
+  - PSICQUIC query endpoints may stream results without a stable Content-Length header.
 - category: Product
   description: Saccharomyces cerevisiae protein interactions from MINT in PSI-MI MITAB
     format.
@@ -660,13 +652,11 @@ products:
   - relation_type: prov:used
     source: mi
   warnings:
-  - PSICQUIC query endpoints may stream results without a stable Content-Length header.
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
+  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
   - 'File was not able to be retrieved when checked on 2026-07-10: Timeout connecting
     to URL'
-  - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
-    header found'
+  - PSICQUIC query endpoints may stream results without a stable Content-Length header.
 - category: ProgrammingInterface
   description: PSICQUIC SOAP and REST web services for programmatic access to MINT
     data using Molecular Interactions Query Language (MIQL).
@@ -684,12 +674,25 @@ products:
     source: intact
   - relation_type: prov:used
     source: mi
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Molecular Interactions (MI), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains MI_nodes.tsv and MI_edges.tsv.
+  edge_count: 3178
+  format: kgx
+  id: mi.kg-bioportal
+  name: MI KGX graph (KG-Bioportal)
+  node_count: 1703
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: mi
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MI.tar.gz
 publications:
 - authors:
   - Henning Hermjakob
   - Luisa Montecchi-Palazzi
   - Gary Bader
-  - Jérôme Wojcik
+  - "J\xE9r\xF4me Wojcik"
   - Lukasz Salwinski
   - Arnaud Ceol
   - Susan Moore

--- a/resource/miapa/miapa.kg-bioportal.md
+++ b/resource/miapa/miapa.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of MIAPA Ontology (MIAPA), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MIAPA_nodes.tsv and MIAPA_edges.tsv.
+edge_count: 58
+format: kgx
+id: miapa.kg-bioportal
+name: MIAPA KGX graph (KG-Bioportal)
+node_count: 88
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: miapa
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIAPA.tar.gz
+layout: product_detail
+---

--- a/resource/miapa/miapa.md
+++ b/resource/miapa/miapa.md
@@ -19,7 +19,7 @@ domains:
 - information technology
 homepage_url: http://www.evoio.org/wiki/MIAPA
 id: miapa
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -37,6 +37,19 @@ products:
   original_source:
   - source: miapa
     relation_type: prov:hadPrimarySource
+- id: miapa.kg-bioportal
+  name: MIAPA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of MIAPA Ontology (MIAPA), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains MIAPA_nodes.tsv and MIAPA_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIAPA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: miapa
+    relation_type: prov:hadPrimarySource
+  node_count: 88
+  edge_count: 58
 repository: https://github.com/evoinfo/miapa
 publications:
 - authors:

--- a/resource/mirnao/mirnao.kg-bioportal.md
+++ b/resource/mirnao/mirnao.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of MicroRNA Ontology (MIRNAO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MIRNAO_nodes.tsv and MIRNAO_edges.tsv.
+edge_count: 764
+format: kgx
+id: mirnao.kg-bioportal
+latest_version: '1.7'
+name: MIRNAO KGX graph (KG-Bioportal)
+node_count: 695
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mirnao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIRNAO.tar.gz
+layout: product_detail
+---

--- a/resource/mirnao/mirnao.md
+++ b/resource/mirnao/mirnao.md
@@ -15,7 +15,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://code.google.com/p/mirna-ontology/
 id: mirnao
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -33,10 +33,22 @@ products:
     source: mirnao
   product_url: http://purl.obolibrary.org/obo/mirnao.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
   - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of MicroRNA Ontology (MIRNAO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains MIRNAO_nodes.tsv and MIRNAO_edges.tsv.
+  edge_count: 764
+  format: kgx
+  id: mirnao.kg-bioportal
+  latest_version: '1.7'
+  name: MIRNAO KGX graph (KG-Bioportal)
+  node_count: 695
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: mirnao
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIRNAO.tar.gz
 publications: []
 ---
 ## Description

--- a/resource/miro/miro.kg-bioportal.md
+++ b/resource/miro/miro.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mosquito Insecticide Resistance (MIRO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains MIRO_nodes.tsv
+  and MIRO_edges.tsv.
+edge_count: 4456
+format: kgx
+id: miro.kg-bioportal
+latest_version: releases/2014-05-14
+name: MIRO KGX graph (KG-Bioportal)
+node_count: 4450
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: miro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIRO.tar.gz
+layout: product_detail
+---

--- a/resource/miro/miro.md
+++ b/resource/miro/miro.md
@@ -15,7 +15,7 @@ domains:
   - environment
 homepage_url: http://purl.obolibrary.org/obo/miro.owl
 id: miro
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -42,6 +42,19 @@ products:
     original_source:
       - source: miro
         relation_type: prov:hadPrimarySource
+  - id: miro.kg-bioportal
+    name: MIRO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Mosquito Insecticide Resistance (MIRO), produced by KG-Bioportal from the BioPortal submission. The archive contains MIRO_nodes.tsv and MIRO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MIRO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: miro
+        relation_type: prov:hadPrimarySource
+    node_count: 4450
+    edge_count: 4456
+    latest_version: releases/2014-05-14
 repository: https://github.com/VEuPathDB-ontology/MIRO
 taxon:
   - NCBITaxon:44484

--- a/resource/mixs/mixs.kg-bioportal.md
+++ b/resource/mixs/mixs.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Minimal Information about any Sequence Ontology
+  (MIXS), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  MIXS_nodes.tsv and MIXS_edges.tsv.
+edge_count: 7242
+format: kgx
+id: mixs.kg-bioportal
+latest_version: 7.0.1
+name: MIXS KGX graph (KG-Bioportal)
+node_count: 2391
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mixs
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/MIXS.tar.gz
+layout: product_detail
+---

--- a/resource/mixs/mixs.md
+++ b/resource/mixs/mixs.md
@@ -32,9 +32,22 @@ products:
         relation_type: prov:hadPrimarySource
     product_file_size: 154279
     product_url: https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/refs/heads/main/project/owl/mixs.owl.ttl
+  - id: mixs.kg-bioportal
+    name: MIXS KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Minimal Information about any Sequence Ontology (MIXS), produced by KG-Bioportal from the BioPortal submission. The archive contains MIXS_nodes.tsv and MIXS_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/MIXS.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mixs
+        relation_type: prov:hadPrimarySource
+    node_count: 2391
+    edge_count: 7242
+    latest_version: 7.0.1
 repository: https://github.com/GenomicsStandardsConsortium/mixs
 creation_date: '2025-03-09T00:00:00Z'
-last_modified_date: '2025-09-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 ---
 
 mixs

--- a/resource/mmo/mmo.kg-bioportal.md
+++ b/resource/mmo/mmo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Measurement Method Ontology (MMO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MMO_nodes.tsv and MMO_edges.tsv.
+edge_count: 987
+format: kgx
+id: mmo.kg-bioportal
+latest_version: '2.109'
+name: MMO KGX graph (KG-Bioportal)
+node_count: 880
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mmo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MMO.tar.gz
+layout: product_detail
+---

--- a/resource/mmo/mmo.md
+++ b/resource/mmo/mmo.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=MMO:0000000
 id: mmo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -46,41 +46,54 @@ products:
     original_source:
       - source: mmo
         relation_type: prov:hadPrimarySource
+  - id: mmo.kg-bioportal
+    name: MMO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Measurement Method Ontology (MMO), produced by KG-Bioportal from the BioPortal submission. The archive contains MMO_nodes.tsv and MMO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MMO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mmo
+        relation_type: prov:hadPrimarySource
+    node_count: 880
+    edge_count: 987
+    latest_version: '2.109'
 repository: https://github.com/rat-genome-database/MMO-Measurement-Method-Ontology
 publications:
-- authors:
-  - Shimoyama M
-  - Nigam R
-  - McIntosh LS
-  - Nagarajan R
-  - Rice T
-  - Rao DC
-  - Dwinell MR
-  doi: 10.3389/fgene.2012.00087
-  id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
-  journal: Front Genet
-  title: Three ontologies to define phenotype measurement data.
-  year: '2012'
-- authors:
-  - Smith JR
-  - Park CA
-  - Nigam R
-  - Laulederkind SJ
-  - Hayman GT
-  - Wang SJ
-  - Lowry TF
-  - Petri V
-  - Pons JD
-  - Tutaj M
-  - Liu W
-  - Worthey EA
-  - Shimoyama M
-  - Dwinell MR
-  doi: 10.1186/2041-1480-4-26
-  id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
-  journal: J Biomed Semantics
-  title: 'The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications.'
-  year: '2013'
+  - authors:
+      - Shimoyama M
+      - Nigam R
+      - McIntosh LS
+      - Nagarajan R
+      - Rice T
+      - Rao DC
+      - Dwinell MR
+    doi: 10.3389/fgene.2012.00087
+    id: https://www.ncbi.nlm.nih.gov/pubmed/22654893
+    journal: Front Genet
+    title: Three ontologies to define phenotype measurement data.
+    year: '2012'
+  - authors:
+      - Smith JR
+      - Park CA
+      - Nigam R
+      - Laulederkind SJ
+      - Hayman GT
+      - Wang SJ
+      - Lowry TF
+      - Petri V
+      - Pons JD
+      - Tutaj M
+      - Liu W
+      - Worthey EA
+      - Shimoyama M
+      - Dwinell MR
+    doi: 10.1186/2041-1480-4-26
+    id: https://www.ncbi.nlm.nih.gov/pubmed/24103152
+    journal: J Biomed Semantics
+    title: 'The clinical measurement, measurement method and experimental condition ontologies: expansion, improvements and new applications.'
+    year: '2013'
 ---
 
 ## Description

--- a/resource/mmusdv/mmusdv.kg-bioportal.md
+++ b/resource/mmusdv/mmusdv.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mouse Developmental Stages (MMUSDV), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains MMUSDV_nodes.tsv
+  and MMUSDV_edges.tsv.
+edge_count: 367
+format: kgx
+id: mmusdv.kg-bioportal
+name: MMUSDV KGX graph (KG-Bioportal)
+node_count: 174
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mmusdv
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MMUSDV.tar.gz
+layout: product_detail
+---

--- a/resource/mmusdv/mmusdv.md
+++ b/resource/mmusdv/mmusdv.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/developmental-stage-ontologies/wiki/MmusDv
 id: mmusdv
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: mmusdv
         relation_type: prov:hadPrimarySource
+  - id: mmusdv.kg-bioportal
+    name: MMUSDV KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Mouse Developmental Stages (MMUSDV), produced by KG-Bioportal from the BioPortal submission. The archive contains MMUSDV_nodes.tsv and MMUSDV_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MMUSDV.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mmusdv
+        relation_type: prov:hadPrimarySource
+    node_count: 174
+    edge_count: 367
 repository: https://github.com/obophenotype/developmental-stage-ontologies
 publications: []
 ---

--- a/resource/mo/mo.kg-bioportal.md
+++ b/resource/mo/mo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Microarray and Gene Expression Data Ontology (MO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains MO_nodes.tsv
+  and MO_edges.tsv.
+edge_count: 464
+format: kgx
+id: mo.kg-bioportal
+latest_version: 1.3.1.1
+name: MO KGX graph (KG-Bioportal)
+node_count: 1045
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MO.tar.gz
+layout: product_detail
+---

--- a/resource/mo/mo.md
+++ b/resource/mo/mo.md
@@ -18,7 +18,7 @@ domains:
 - general
 homepage_url: http://mged.sourceforge.net/ontologies/MGEDontology.php
 id: mo
-last_modified_date: '2026-07-10T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -35,13 +35,26 @@ products:
     source: mo
   product_url: http://purl.obolibrary.org/obo/mo.owl
   warnings:
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
+    when accessing file'
   - The original OBO PURL (http://purl.obolibrary.org/obo/mo.owl) no longer resolves
     (HTTP 404); product_url now points to a Wayback Machine archived snapshot of the
     MGED Ontology OWL.
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Microarray and Gene Expression Data Ontology (MO),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains MO_nodes.tsv
+    and MO_edges.tsv.
+  edge_count: 464
+  format: kgx
+  id: mo.kg-bioportal
+  latest_version: 1.3.1.1
+  name: MO KGX graph (KG-Bioportal)
+  node_count: 1045
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: mo
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/MO.tar.gz
 publications:
 - authors:
   - Whetzel PL

--- a/resource/mop/mop.kg-bioportal.md
+++ b/resource/mop/mop.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Molecular Process Ontology (MOP), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MOP_nodes.tsv and MOP_edges.tsv.
+edge_count: 3893
+format: kgx
+id: mop.kg-bioportal
+name: MOP KGX graph (KG-Bioportal)
+node_count: 3731
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mop
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOP.tar.gz
+layout: product_detail
+---

--- a/resource/mop/mop.md
+++ b/resource/mop/mop.md
@@ -19,7 +19,7 @@ domains:
 homepage_url: https://github.com/rsc-ontologies/rxno
 id: mop
 infores_id: mop
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,18 @@ products:
     original_source:
       - source: mop
         relation_type: prov:hadPrimarySource
+  - id: mop.kg-bioportal
+    name: MOP KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Molecular Process Ontology (MOP), produced by KG-Bioportal from the BioPortal submission. The archive contains MOP_nodes.tsv and MOP_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MOP.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mop
+        relation_type: prov:hadPrimarySource
+    node_count: 3731
+    edge_count: 3893
 repository: https://github.com/rsc-ontologies/rxno
 publications: []
 ---

--- a/resource/mp/mp.kg-bioportal.md
+++ b/resource/mp/mp.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mammalian Phenotype Ontology (MP), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MP_nodes.tsv and MP_edges.tsv.
+edge_count: 30356
+format: kgx
+id: mp.kg-bioportal
+latest_version: '2026-06-17'
+name: MP KGX graph (KG-Bioportal)
+node_count: 16057
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mp
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MP.tar.gz
+layout: product_detail
+---

--- a/resource/mp/mp.md
+++ b/resource/mp/mp.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://www.informatics.jax.org/vocab/mp_ontology/
 id: mp
 infores_id: mp
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -49,8 +49,6 @@ products:
     source: mp
   product_url: http://purl.obolibrary.org/obo/mp.obo
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
   - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
 - category: OntologyProduct
@@ -967,6 +965,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Mammalian Phenotype Ontology (MP), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains MP_nodes.tsv
+    and MP_edges.tsv.
+  edge_count: 30356
+  format: kgx
+  id: mp.kg-bioportal
+  latest_version: '2026-06-17'
+  name: MP KGX graph (KG-Bioportal)
+  node_count: 16057
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: mp
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MP.tar.gz
 publications:
 - authors:
   - Bello SM

--- a/resource/mpath/mpath.kg-bioportal.md
+++ b/resource/mpath/mpath.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mouse Pathology Ontology (MPATH), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MPATH_nodes.tsv and MPATH_edges.tsv.
+edge_count: 952
+format: kgx
+id: mpath.kg-bioportal
+latest_version: '2020-05-19'
+name: MPATH KGX graph (KG-Bioportal)
+node_count: 916
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mpath
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MPATH.tar.gz
+layout: product_detail
+---

--- a/resource/mpath/mpath.md
+++ b/resource/mpath/mpath.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://www.pathbase.net
 id: mpath
 infores_id: mpath
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -376,6 +376,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: mpath.kg-bioportal
+  name: MPATH KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Mouse Pathology Ontology (MPATH), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains MPATH_nodes.tsv
+    and MPATH_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MPATH.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: mpath
+    relation_type: prov:hadPrimarySource
+  node_count: 916
+  edge_count: 952
+  latest_version: '2020-05-19'
 publications: []
 repository: https://github.com/PaulNSchofield/mpath
 taxon:

--- a/resource/mpio/mpio.kg-bioportal.md
+++ b/resource/mpio/mpio.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Minimum PDDI Information Ontology (MPIO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains MPIO_nodes.tsv
+  and MPIO_edges.tsv.
+edge_count: 78
+format: kgx
+id: mpio.kg-bioportal
+latest_version: '2023-10-17'
+name: MPIO KGX graph (KG-Bioportal)
+node_count: 111
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mpio
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MPIO.tar.gz
+layout: product_detail
+---

--- a/resource/mpio/mpio.md
+++ b/resource/mpio/mpio.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/MPIO-Developers/MPIO
 id: "mpio"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/4.0/"
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: mpio
         relation_type: prov:hadPrimarySource
+  - id: mpio.kg-bioportal
+    name: MPIO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Minimum PDDI Information Ontology (MPIO), produced by KG-Bioportal from the BioPortal submission. The archive contains MPIO_nodes.tsv and MPIO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MPIO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mpio
+        relation_type: prov:hadPrimarySource
+    node_count: 111
+    edge_count: 78
+    latest_version: '2023-10-17'
 repository: https://github.com/MPIO-Developers/MPIO
 publications:
   - authors:

--- a/resource/mro/mro.kg-bioportal.md
+++ b/resource/mro/mro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of MHC Restriction Ontology (MHCRO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MHCRO_nodes.tsv and MHCRO_edges.tsv.
+edge_count: 168477
+format: kgx
+id: mro.kg-bioportal
+latest_version: '2026-02-10'
+name: MHCRO KGX graph (KG-Bioportal)
+node_count: 51499
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: mro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MHCRO.tar.gz
+layout: product_detail
+---

--- a/resource/mro/mro.md
+++ b/resource/mro/mro.md
@@ -18,7 +18,7 @@ domains:
   - chemistry and biochemistry
 homepage_url: https://github.com/IEDB/MRO
 id: mro
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: mro
         relation_type: prov:hadPrimarySource
+  - id: mro.kg-bioportal
+    name: MHCRO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of MHC Restriction Ontology (MHCRO), produced by KG-Bioportal from the BioPortal submission. The archive contains MHCRO_nodes.tsv and MHCRO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/MHCRO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: mro
+        relation_type: prov:hadPrimarySource
+    node_count: 51499
+    edge_count: 168477
+    latest_version: '2026-02-10'
 repository: https://github.com/IEDB/MRO
 publications:
   - authors:

--- a/resource/ms/ms.kg-bioportal.md
+++ b/resource/ms/ms.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mass Spectrometry Ontology (MS), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains MS_nodes.tsv and MS_edges.tsv.
+edge_count: 7529
+format: kgx
+id: ms.kg-bioportal
+latest_version: 4.1.195
+name: MS KGX graph (KG-Bioportal)
+node_count: 4182
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ms
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/MS.tar.gz
+layout: product_detail
+---

--- a/resource/ms/ms.md
+++ b/resource/ms/ms.md
@@ -20,7 +20,7 @@ domains:
 - general
 homepage_url: http://www.psidev.info/groups/controlled-vocabularies
 id: ms
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -383,6 +383,20 @@ products:
     source: dcat
   - relation_type: prov:wasInformedBy
     source: afo
+- id: ms.kg-bioportal
+  name: MS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Mass Spectrometry Ontology (MS), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains MS_nodes.tsv and MS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/MS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ms
+    relation_type: prov:hadPrimarySource
+  node_count: 4182
+  edge_count: 7529
+  latest_version: 4.1.195
 publications:
 - authors:
   - Mayer G
@@ -396,7 +410,7 @@ publications:
   - Levander F
   - Shofstahl J
   - Orchard S
-  - "Vizca\xEDno JA"
+  - Vizcaíno JA
   - Hermjakob H
   - Stephan C
   - Meyer HE

--- a/resource/nbo/nbo.kg-bioportal.md
+++ b/resource/nbo/nbo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Neuro Behavior Ontology (NBO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains NBO_nodes.tsv and NBO_edges.tsv.
+edge_count: 13594
+format: kgx
+id: nbo.kg-bioportal
+latest_version: '2023-07-04'
+name: NBO KGX graph (KG-Bioportal)
+node_count: 5142
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: nbo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NBO.tar.gz
+layout: product_detail
+---

--- a/resource/nbo/nbo.md
+++ b/resource/nbo/nbo.md
@@ -19,7 +19,7 @@ domains:
 homepage_url: https://github.com/obo-behavior/behavior-ontology/
 id: nbo
 infores_id: nbo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -187,6 +187,20 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: nbo.kg-bioportal
+  name: NBO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Neuro Behavior Ontology (NBO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains NBO_nodes.tsv and NBO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NBO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: nbo
+    relation_type: prov:hadPrimarySource
+  node_count: 5142
+  edge_count: 13594
+  latest_version: '2023-07-04'
 publications:
 - authors:
   - Hoehndorf R

--- a/resource/ncro/ncro.kg-bioportal.md
+++ b/resource/ncro/ncro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Non-coding RNA Ontology (NCRO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains NCRO_nodes.tsv and NCRO_edges.tsv.
+edge_count: 96
+format: kgx
+id: ncro.kg-bioportal
+latest_version: Working version 06102015
+name: NCRO KGX graph (KG-Bioportal)
+node_count: 100
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ncro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NCRO.tar.gz
+layout: product_detail
+---

--- a/resource/ncro/ncro.md
+++ b/resource/ncro/ncro.md
@@ -19,7 +19,7 @@ domains:
 - general
 homepage_url: http://omnisearch.soc.southalabama.edu/w/index.php/Ontology
 id: ncro
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,20 @@ products:
   original_source:
   - source: ncro
     relation_type: prov:hadPrimarySource
+- id: ncro.kg-bioportal
+  name: NCRO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Non-coding RNA Ontology (NCRO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains NCRO_nodes.tsv and NCRO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NCRO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ncro
+    relation_type: prov:hadPrimarySource
+  node_count: 100
+  edge_count: 96
+  latest_version: Working version 06102015
 repository: https://github.com/OmniSearch/ncro
 publications:
 - authors:

--- a/resource/ndfrt/ndfrt.kg-bioportal.md
+++ b/resource/ndfrt/ndfrt.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Veterans Health Administration National Drug File
+  (VANDF), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  VANDF_nodes.tsv and VANDF_edges.tsv.
+edge_count: 126
+format: kgx
+id: ndfrt.kg-bioportal
+latest_version: '2025_07_31'
+name: VANDF KGX graph (KG-Bioportal)
+node_count: 31362
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ndfrt
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VANDF.tar.gz
+layout: product_detail
+---

--- a/resource/ndfrt/ndfrt.md
+++ b/resource/ndfrt/ndfrt.md
@@ -11,7 +11,7 @@ domains:
 homepage_url: https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/vandf.html
 id: ndfrt
 infores_id: ndfrt
-last_modified_date: '2025-11-26T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 name: Veterans Health Administration National Drug File
 products:
@@ -660,6 +660,21 @@ products:
     source: snomedct
   - relation_type: prov:wasInformedBy
     source: umls
+- id: ndfrt.kg-bioportal
+  name: VANDF KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Veterans Health Administration National Drug File
+    (VANDF), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    VANDF_nodes.tsv and VANDF_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VANDF.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ndfrt
+    relation_type: prov:hadPrimarySource
+  node_count: 31362
+  edge_count: 126
+  latest_version: '2025_07_31'
 synonyms:
 - VANDF
 - NDF-RT

--- a/resource/ngbo/ngbo.kg-bioportal.md
+++ b/resource/ngbo/ngbo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Next Generation Biobanking Ontology (NGBO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains NGBO_nodes.tsv
+  and NGBO_edges.tsv.
+edge_count: 2428
+format: kgx
+id: ngbo.kg-bioportal
+latest_version: '2024-08-27'
+name: NGBO KGX graph (KG-Bioportal)
+node_count: 1824
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ngbo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NGBO.tar.gz
+layout: product_detail
+---

--- a/resource/ngbo/ngbo.md
+++ b/resource/ngbo/ngbo.md
@@ -23,7 +23,7 @@ domains:
 - general
 homepage_url: https://github.com/Dalalghamdi/NGBO
 id: ngbo
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -41,6 +41,21 @@ products:
   original_source:
   - source: ngbo
     relation_type: prov:hadPrimarySource
+- id: ngbo.kg-bioportal
+  name: NGBO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Next Generation Biobanking Ontology (NGBO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains NGBO_nodes.tsv
+    and NGBO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NGBO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ngbo
+    relation_type: prov:hadPrimarySource
+  node_count: 1824
+  edge_count: 2428
+  latest_version: '2024-08-27'
 repository: https://github.com/Dalalghamdi/NGBO
 publications:
 - authors:

--- a/resource/nmr/nmr.kg-bioportal.md
+++ b/resource/nmr/nmr.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of NMR-Controlled Vocabulary (NMR), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains NMR_nodes.tsv and NMR_edges.tsv.
+edge_count: 767
+format: kgx
+id: nmr.kg-bioportal
+latest_version: 1.1.0
+name: NMR KGX graph (KG-Bioportal)
+node_count: 794
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: nmr
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NMR.tar.gz
+layout: product_detail
+---

--- a/resource/nmr/nmr.md
+++ b/resource/nmr/nmr.md
@@ -17,7 +17,7 @@ domains:
 - general
 homepage_url: http://msi-ontology.sourceforge.net/
 id: nmr
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -35,12 +35,24 @@ products:
     source: nmr
   product_url: http://purl.obolibrary.org/obo/nmr.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
   - 'File was not able to be retrieved when checked on 2026-05-26: Timeout connecting
     to URL'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of NMR-Controlled Vocabulary (NMR), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains NMR_nodes.tsv and NMR_edges.tsv.
+  edge_count: 767
+  format: kgx
+  id: nmr.kg-bioportal
+  latest_version: 1.1.0
+  name: NMR KGX graph (KG-Bioportal)
+  node_count: 794
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: nmr
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NMR.tar.gz
 publications: []
 ---
 ## Description

--- a/resource/nomen/nomen.kg-bioportal.md
+++ b/resource/nomen/nomen.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of NOMEN - A nomenclatural ontology for biological
+  names (NOMEN), produced by KG-Bioportal from the BioPortal submission. The archive
+  contains NOMEN_nodes.tsv and NOMEN_edges.tsv.
+edge_count: 474
+format: kgx
+id: nomen.kg-bioportal
+name: NOMEN KGX graph (KG-Bioportal)
+node_count: 390
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: nomen
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NOMEN.tar.gz
+layout: product_detail
+---

--- a/resource/nomen/nomen.md
+++ b/resource/nomen/nomen.md
@@ -20,7 +20,7 @@ domains:
 - information technology
 homepage_url: https://github.com/SpeciesFileGroup/nomen
 id: nomen
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -38,6 +38,20 @@ products:
   original_source:
   - source: nomen
     relation_type: prov:hadPrimarySource
+- id: nomen.kg-bioportal
+  name: NOMEN KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of NOMEN - A nomenclatural ontology for biological
+    names (NOMEN), produced by KG-Bioportal from the BioPortal submission. The archive
+    contains NOMEN_nodes.tsv and NOMEN_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NOMEN.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: nomen
+    relation_type: prov:hadPrimarySource
+  node_count: 390
+  edge_count: 474
 repository: https://github.com/SpeciesFileGroup/nomen
 publications: []
 ---

--- a/resource/npo/npo.kg-bioportal.md
+++ b/resource/npo/npo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Neuron Phenotype Ontology (NPOKB), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains NPOKB_nodes.tsv and NPOKB_edges.tsv.
+edge_count: 5225
+format: kgx
+id: npo.kg-bioportal
+latest_version: '2026-03-19'
+name: NPOKB KGX graph (KG-Bioportal)
+node_count: 2916
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: npo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NPOKB.tar.gz
+layout: product_detail
+---

--- a/resource/npo/npo.md
+++ b/resource/npo/npo.md
@@ -25,7 +25,7 @@ domains:
 - neuroscience
 homepage_url: https://bioportal.bioontology.org/ontologies/NPOKB
 id: npo
-last_modified_date: '2025-11-26T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 name: Neuron Phenotype Ontology
 products:
@@ -259,6 +259,21 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
+- id: npo.kg-bioportal
+  name: NPOKB KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Neuron Phenotype Ontology (NPOKB), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains NPOKB_nodes.tsv
+    and NPOKB_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/NPOKB.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: npo
+    relation_type: prov:hadPrimarySource
+  node_count: 2916
+  edge_count: 5225
+  latest_version: '2026-03-19'
 publications:
 - authors:
   - Gillespie TH

--- a/resource/oarcs/oarcs.kg-bioportal.md
+++ b/resource/oarcs/oarcs.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Arthropod Circulatory Systems (OARCS),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains OARCS_nodes.tsv
+  and OARCS_edges.tsv.
+edge_count: 565
+format: kgx
+id: oarcs.kg-bioportal
+latest_version: '2019-04-18'
+name: OARCS KGX graph (KG-Bioportal)
+node_count: 652
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: oarcs
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OARCS.tar.gz
+layout: product_detail
+---

--- a/resource/oarcs/oarcs.md
+++ b/resource/oarcs/oarcs.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/aszool/oarcs
 id: oarcs
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: oarcs
         relation_type: prov:hadPrimarySource
+  - id: oarcs.kg-bioportal
+    name: OARCS KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology of Arthropod Circulatory Systems (OARCS), produced by KG-Bioportal from the BioPortal submission. The archive contains OARCS_nodes.tsv and OARCS_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OARCS.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: oarcs
+        relation_type: prov:hadPrimarySource
+    node_count: 652
+    edge_count: 565
+    latest_version: '2019-04-18'
 repository: https://github.com/aszool/oarcs
 publications: []
 ---

--- a/resource/obcs/obcs.kg-bioportal.md
+++ b/resource/obcs/obcs.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Biological and Clinical Statistics (OBCS),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains OBCS_nodes.tsv
+  and OBCS_edges.tsv.
+edge_count: 3773
+format: kgx
+id: obcs.kg-bioportal
+latest_version: '2023-12-08'
+name: OBCS KGX graph (KG-Bioportal)
+node_count: 1592
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: obcs
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBCS.tar.gz
+layout: product_detail
+---

--- a/resource/obcs/obcs.md
+++ b/resource/obcs/obcs.md
@@ -19,7 +19,7 @@ domains:
   - information technology
 homepage_url: https://github.com/obcs/obcs
 id: "obcs"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/4.0/"
@@ -52,6 +52,19 @@ products:
     original_source:
       - source: obcs
         relation_type: prov:hadPrimarySource
+  - id: obcs.kg-bioportal
+    name: OBCS KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology of Biological and Clinical Statistics (OBCS), produced by KG-Bioportal from the BioPortal submission. The archive contains OBCS_nodes.tsv and OBCS_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBCS.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: obcs
+        relation_type: prov:hadPrimarySource
+    node_count: 1592
+    edge_count: 3773
+    latest_version: '2023-12-08'
 repository: https://github.com/obcs/obcs
 ---
 

--- a/resource/obi/obi.kg-bioportal.md
+++ b/resource/obi/obi.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Biomedical Investigations (OBI), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OBI_nodes.tsv
+  and OBI_edges.tsv.
+edge_count: 16102
+format: kgx
+id: obi.kg-bioportal
+latest_version: '2026-05-08'
+name: OBI KGX graph (KG-Bioportal)
+node_count: 7552
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: obi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBI.tar.gz
+layout: product_detail
+---

--- a/resource/obi/obi.md
+++ b/resource/obi/obi.md
@@ -20,7 +20,7 @@ domains:
 - general
 homepage_url: http://obi-ontology.org
 id: obi
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -522,6 +522,21 @@ products:
     source: obi
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
+- id: obi.kg-bioportal
+  name: OBI KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology for Biomedical Investigations (OBI),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains OBI_nodes.tsv
+    and OBI_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBI.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: obi
+    relation_type: prov:hadPrimarySource
+  node_count: 7552
+  edge_count: 16102
+  latest_version: '2026-05-08'
 publications:
 - authors:
   - Bandrowski A

--- a/resource/obib/obib.kg-bioportal.md
+++ b/resource/obib/obib.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Biobanking (OBIB), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains OBIB_nodes.tsv and OBIB_edges.tsv.
+edge_count: 4499
+format: kgx
+id: obib.kg-bioportal
+latest_version: '2023-04-05'
+name: OBIB KGX graph (KG-Bioportal)
+node_count: 2419
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: obib
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBIB.tar.gz
+layout: product_detail
+---

--- a/resource/obib/obib.md
+++ b/resource/obib/obib.md
@@ -20,7 +20,7 @@ domains:
 - general
 homepage_url: https://github.com/biobanking/biobanking
 id: obib
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -268,6 +268,20 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
+- id: obib.kg-bioportal
+  name: OBIB KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology for Biobanking (OBIB), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains OBIB_nodes.tsv and OBIB_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBIB.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: obib
+    relation_type: prov:hadPrimarySource
+  node_count: 2419
+  edge_count: 4499
+  latest_version: '2023-04-05'
 publications: []
 repository: https://github.com/biobanking/biobanking
 ---

--- a/resource/occo/occo.kg-bioportal.md
+++ b/resource/occo/occo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Occupation Ontology (OCCO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains OCCO_nodes.tsv and OCCO_edges.tsv.
+edge_count: 10972
+format: kgx
+id: occo.kg-bioportal
+latest_version: '2023-08-20'
+name: OCCO KGX graph (KG-Bioportal)
+node_count: 1905
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: occo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCCO.tar.gz
+layout: product_detail
+---

--- a/resource/occo/occo.md
+++ b/resource/occo/occo.md
@@ -24,7 +24,7 @@ domains:
 - information technology
 homepage_url: https://github.com/Occupation-Ontology/OccO
 id: occo
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -42,6 +42,20 @@ products:
   original_source:
   - source: occo
     relation_type: prov:hadPrimarySource
+- id: occo.kg-bioportal
+  name: OCCO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Occupation Ontology (OCCO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains OCCO_nodes.tsv and OCCO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OCCO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: occo
+    relation_type: prov:hadPrimarySource
+  node_count: 1905
+  edge_count: 10972
+  latest_version: '2023-08-20'
 repository: https://github.com/Occupation-Ontology/OccO
 publications:
 - authors:

--- a/resource/ogi/ogi.kg-bioportal.md
+++ b/resource/ogi/ogi.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Genetic Interval (OGI), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains OGI_nodes.tsv and
+  OGI_edges.tsv.
+edge_count: 305
+format: kgx
+id: ogi.kg-bioportal
+latest_version: '2.0'
+name: OGI KGX graph (KG-Bioportal)
+node_count: 262
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ogi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OGI.tar.gz
+layout: product_detail
+---

--- a/resource/ogi/ogi.md
+++ b/resource/ogi/ogi.md
@@ -19,7 +19,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: https://code.google.com/p/ontology-for-genetic-interval/
 id: ogi
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -36,10 +36,23 @@ products:
     source: ogi
   product_url: http://purl.obolibrary.org/obo/ogi.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
   - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Ontology for Genetic Interval (OGI), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains OGI_nodes.tsv
+    and OGI_edges.tsv.
+  edge_count: 305
+  format: kgx
+  id: ogi.kg-bioportal
+  latest_version: '2.0'
+  name: OGI KGX graph (KG-Bioportal)
+  node_count: 262
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ogi
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/OGI.tar.gz
 publications: []
 use_instead:
 - ogsf

--- a/resource/ogms/ogms.kg-bioportal.md
+++ b/resource/ogms/ogms.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for General Medical Science (OGMS), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OGMS_nodes.tsv
+  and OGMS_edges.tsv.
+edge_count: 292
+format: kgx
+id: ogms.kg-bioportal
+latest_version: '2021-08-19'
+name: OGMS KGX graph (KG-Bioportal)
+node_count: 283
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ogms
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGMS.tar.gz
+layout: product_detail
+---

--- a/resource/ogms/ogms.md
+++ b/resource/ogms/ogms.md
@@ -19,7 +19,7 @@ domains:
 - biomedical
 homepage_url: https://github.com/OGMS/ogms
 id: ogms
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -263,13 +263,26 @@ products:
     source: tcrd
   product_url: https://kg-hub.berkeleybop.io/kg-idg/current/kg-idg.tar.gz
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
   - 'File was not able to be retrieved when checked on 2026-07-01: HTTP 404 error.
     The kg-hub.berkeleybop.io host is being reorganized and KG-IDG downloads are pending
     relocation to a new home; no live download is currently available.'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Ontology for General Medical Science (OGMS), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains OGMS_nodes.tsv
+    and OGMS_edges.tsv.
+  edge_count: 292
+  format: kgx
+  id: ogms.kg-bioportal
+  latest_version: '2021-08-19'
+  name: OGMS KGX graph (KG-Bioportal)
+  node_count: 283
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: ogms
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGMS.tar.gz
 publications:
 - authors:
   - Scheuermann RH

--- a/resource/ogsf/ogsf.kg-bioportal.md
+++ b/resource/ogsf/ogsf.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Genetic Susceptibility Factor (OGSF),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains OGSF_nodes.tsv
+  and OGSF_edges.tsv.
+edge_count: 1369
+format: kgx
+id: ogsf.kg-bioportal
+latest_version: '2.0'
+name: OGSF KGX graph (KG-Bioportal)
+node_count: 693
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ogsf
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGSF.tar.gz
+layout: product_detail
+---

--- a/resource/ogsf/ogsf.md
+++ b/resource/ogsf/ogsf.md
@@ -20,7 +20,7 @@ domains:
 - general
 homepage_url: https://github.com/linikujp/OGSF
 id: ogsf
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -38,6 +38,21 @@ products:
   original_source:
   - source: ogsf
     relation_type: prov:hadPrimarySource
+- id: ogsf.kg-bioportal
+  name: OGSF KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology for Genetic Susceptibility Factor (OGSF),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains OGSF_nodes.tsv
+    and OGSF_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OGSF.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ogsf
+    relation_type: prov:hadPrimarySource
+  node_count: 693
+  edge_count: 1369
+  latest_version: '2.0'
 repository: https://github.com/linikujp/OGSF
 publications: []
 ---

--- a/resource/ohd/ohd.kg-bioportal.md
+++ b/resource/ohd/ohd.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of The Oral Health and Disease Ontology (OHD), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OHD_nodes.tsv
+  and OHD_edges.tsv.
+edge_count: 7280
+format: kgx
+id: ohd.kg-bioportal
+latest_version: '2026-03-16'
+name: OHD KGX graph (KG-Bioportal)
+node_count: 2325
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ohd
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHD.tar.gz
+layout: product_detail
+---

--- a/resource/ohd/ohd.md
+++ b/resource/ohd/ohd.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://purl.obolibrary.org/obo/ohd
 id: ohd
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
         source: ohd
     product_file_size: 307089
     product_url: http://purl.obolibrary.org/obo/ohd.owl
+  - id: ohd.kg-bioportal
+    name: OHD KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of The Oral Health and Disease Ontology (OHD), produced by KG-Bioportal from the BioPortal submission. The archive contains OHD_nodes.tsv and OHD_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHD.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ohd
+        relation_type: prov:hadPrimarySource
+    node_count: 2325
+    edge_count: 7280
+    latest_version: '2026-03-16'
 publications:
   - authors:
       - Duncan WD

--- a/resource/ohmi/ohmi.kg-bioportal.md
+++ b/resource/ohmi/ohmi.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Host-Microbe Interactions (OHMI), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OHMI_nodes.tsv
+  and OHMI_edges.tsv.
+edge_count: 5277
+format: kgx
+id: ohmi.kg-bioportal
+latest_version: '2026-05-14'
+name: OHMI KGX graph (KG-Bioportal)
+node_count: 2652
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ohmi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHMI.tar.gz
+layout: product_detail
+---

--- a/resource/ohmi/ohmi.md
+++ b/resource/ohmi/ohmi.md
@@ -23,7 +23,7 @@ domains:
 - organisms
 homepage_url: https://github.com/ohmi-ontology/ohmi
 id: ohmi
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -41,6 +41,21 @@ products:
   original_source:
   - source: ohmi
     relation_type: prov:hadPrimarySource
+- id: ohmi.kg-bioportal
+  name: OHMI KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology of Host-Microbe Interactions (OHMI),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains OHMI_nodes.tsv
+    and OHMI_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHMI.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ohmi
+    relation_type: prov:hadPrimarySource
+  node_count: 2652
+  edge_count: 5277
+  latest_version: '2026-05-14'
 publications:
 - authors:
   - He Y

--- a/resource/ohpi/ohpi.kg-bioportal.md
+++ b/resource/ohpi/ohpi.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Host-Pathogen Interactions (OHPI), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OHPI_nodes.tsv
+  and OHPI_edges.tsv.
+edge_count: 41474
+format: kgx
+id: ohpi.kg-bioportal
+latest_version: 1.0.26
+name: OHPI KGX graph (KG-Bioportal)
+node_count: 14180
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ohpi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHPI.tar.gz
+layout: product_detail
+---

--- a/resource/ohpi/ohpi.md
+++ b/resource/ohpi/ohpi.md
@@ -18,7 +18,7 @@ domains:
   - biological systems
 homepage_url: https://github.com/OHPI/ohpi
 id: ohpi
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: ohpi
         relation_type: prov:hadPrimarySource
+  - id: ohpi.kg-bioportal
+    name: OHPI KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology of Host-Pathogen Interactions (OHPI), produced by KG-Bioportal from the BioPortal submission. The archive contains OHPI_nodes.tsv and OHPI_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OHPI.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ohpi
+        relation_type: prov:hadPrimarySource
+    node_count: 14180
+    edge_count: 41474
+    latest_version: 1.0.26
 repository: https://github.com/OHPI/ohpi
 publications:
   - authors:

--- a/resource/olatdv/olatdv.kg-bioportal.md
+++ b/resource/olatdv/olatdv.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Medaka Developmental Stages (OLATDV), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains OLATDV_nodes.tsv
+  and OLATDV_edges.tsv.
+edge_count: 91
+format: kgx
+id: olatdv.kg-bioportal
+name: OLATDV KGX graph (KG-Bioportal)
+node_count: 64
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: olatdv
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OLATDV.tar.gz
+layout: product_detail
+---

--- a/resource/olatdv/olatdv.md
+++ b/resource/olatdv/olatdv.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/developmental-stage-ontologies/wiki/OlatDv
 id: olatdv
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: olatdv
         relation_type: prov:hadPrimarySource
+  - id: olatdv.kg-bioportal
+    name: OLATDV KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Medaka Developmental Stages (OLATDV), produced by KG-Bioportal from the BioPortal submission. The archive contains OLATDV_nodes.tsv and OLATDV_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OLATDV.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: olatdv
+        relation_type: prov:hadPrimarySource
+    node_count: 64
+    edge_count: 91
 repository: https://github.com/obophenotype/developmental-stage-ontologies
 publications: []
 ---

--- a/resource/omit/omit.kg-bioportal.md
+++ b/resource/omit/omit.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for MicroRNA Target (OMIT), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains OMIT_nodes.tsv
+  and OMIT_edges.tsv.
+edge_count: 97760
+format: kgx
+id: omit.kg-bioportal
+latest_version: OBO 4.0-12122013-2338
+name: OMIT KGX graph (KG-Bioportal)
+node_count: 87856
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: omit
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMIT.tar.gz
+layout: product_detail
+---

--- a/resource/omit/omit.md
+++ b/resource/omit/omit.md
@@ -19,7 +19,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://omit.cis.usouthal.edu/
 id: omit
-last_modified_date: '2026-07-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -260,6 +260,21 @@ products:
     source: obi
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
+- id: omit.kg-bioportal
+  name: OMIT KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology for MicroRNA Target (OMIT), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains OMIT_nodes.tsv
+    and OMIT_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMIT.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: omit
+    relation_type: prov:hadPrimarySource
+  node_count: 87856
+  edge_count: 97760
+  latest_version: OBO 4.0-12122013-2338
 publications: []
 repository: https://github.com/OmniSearch/omit
 ---

--- a/resource/omo/omo.kg-bioportal.md
+++ b/resource/omo/omo.kg-bioportal.md
@@ -1,0 +1,16 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of OBO Metadata Ontology (OMO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains OMO_nodes.tsv and OMO_edges.tsv.
+edge_count: 67
+format: kgx
+id: omo.kg-bioportal
+name: OMO KGX graph (KG-Bioportal)
+node_count: 118
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: omo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMO.tar.gz
+layout: product_detail
+---

--- a/resource/omo/omo.md
+++ b/resource/omo/omo.md
@@ -21,7 +21,7 @@ domains:
 - information technology
 homepage_url: https://github.com/information-artifact-ontology/ontology-metadata
 id: omo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -227,6 +227,19 @@ products:
     source: zfa
   product_file_size: 64058275
   product_url: https://www.ebi.ac.uk/efo/efo.obo
+- id: omo.kg-bioportal
+  name: OMO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of OBO Metadata Ontology (OMO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains OMO_nodes.tsv and OMO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: omo
+    relation_type: prov:hadPrimarySource
+  node_count: 118
+  edge_count: 67
 publications: []
 repository: https://github.com/information-artifact-ontology/ontology-metadata
 ---

--- a/resource/omp/omp.kg-bioportal.md
+++ b/resource/omp/omp.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Microbial Phenotypes (OMP), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OMP_nodes.tsv
+  and OMP_edges.tsv.
+edge_count: 3815
+format: kgx
+id: omp.kg-bioportal
+latest_version: releases/2019-06-07
+name: OMP KGX graph (KG-Bioportal)
+node_count: 2445
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: omp
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMP.tar.gz
+layout: product_detail
+---

--- a/resource/omp/omp.md
+++ b/resource/omp/omp.md
@@ -19,7 +19,7 @@ domains:
 - phenotype
 homepage_url: http://microbialphenotypes.org
 id: omp
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -47,6 +47,21 @@ products:
   original_source:
   - source: omp
     relation_type: prov:hadPrimarySource
+- id: omp.kg-bioportal
+  name: OMP KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology of Microbial Phenotypes (OMP), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains OMP_nodes.tsv
+    and OMP_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMP.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: omp
+    relation_type: prov:hadPrimarySource
+  node_count: 2445
+  edge_count: 3815
+  latest_version: releases/2019-06-07
 repository: https://github.com/microbialphenotypes/OMP-ontology
 publications:
 - authors:

--- a/resource/omrse/omrse.kg-bioportal.md
+++ b/resource/omrse/omrse.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Modeling and Representation of Social
+  Entities (OMRSE), produced by KG-Bioportal from the BioPortal submission. The archive
+  contains OMRSE_nodes.tsv and OMRSE_edges.tsv.
+edge_count: 1341
+format: kgx
+id: omrse.kg-bioportal
+latest_version: '2026-07-08'
+name: OMRSE KGX graph (KG-Bioportal)
+node_count: 1399
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: omrse
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMRSE.tar.gz
+layout: product_detail
+---

--- a/resource/omrse/omrse.md
+++ b/resource/omrse/omrse.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/mcwdsi/OMRSE/wiki/OMRSE-Overview
 id: omrse
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: omrse
         relation_type: prov:hadPrimarySource
+  - id: omrse.kg-bioportal
+    name: OMRSE KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology for Modeling and Representation of Social Entities (OMRSE), produced by KG-Bioportal from the BioPortal submission. The archive contains OMRSE_nodes.tsv and OMRSE_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OMRSE.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: omrse
+        relation_type: prov:hadPrimarySource
+    node_count: 1399
+    edge_count: 1341
+    latest_version: '2026-07-08'
 repository: https://github.com/mcwdsi/OMRSE
 taxon:
   - NCBITaxon:9606

--- a/resource/one/one.kg-bioportal.md
+++ b/resource/one/one.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Nutritional Epidemiology (ONE), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains ONE_nodes.tsv
+  and ONE_edges.tsv.
+edge_count: 102
+format: kgx
+id: one.kg-bioportal
+latest_version: V2.2
+name: ONE KGX graph (KG-Bioportal)
+node_count: 125
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: one
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONE.tar.gz
+layout: product_detail
+---

--- a/resource/one/one.md
+++ b/resource/one/one.md
@@ -20,7 +20,7 @@ domains:
 - nutrition
 homepage_url: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 id: one
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -38,6 +38,21 @@ products:
   original_source:
   - source: one
     relation_type: prov:hadPrimarySource
+- id: one.kg-bioportal
+  name: ONE KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology for Nutritional Epidemiology (ONE), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains ONE_nodes.tsv
+    and ONE_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONE.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: one
+    relation_type: prov:hadPrimarySource
+  node_count: 125
+  edge_count: 102
+  latest_version: V2.2
 repository: https://github.com/cyang0128/Nutritional-epidemiologic-ontologies
 publications: []
 ---

--- a/resource/ons/ons.kg-bioportal.md
+++ b/resource/ons/ons.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Nutritional Studies (ONS), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains ONS_nodes.tsv
+  and ONS_edges.tsv.
+edge_count: 13920
+format: kgx
+id: ons.kg-bioportal
+latest_version: '2026-02-06'
+name: ONS KGX graph (KG-Bioportal)
+node_count: 5129
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ons
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONS.tar.gz
+layout: product_detail
+---

--- a/resource/ons/ons.md
+++ b/resource/ons/ons.md
@@ -19,7 +19,7 @@ domains:
 - nutrition
 homepage_url: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 id: ons
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,21 @@ products:
   original_source:
   - source: ons
     relation_type: prov:hadPrimarySource
+- id: ons.kg-bioportal
+  name: ONS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology for Nutritional Studies (ONS), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains ONS_nodes.tsv
+    and ONS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ons
+    relation_type: prov:hadPrimarySource
+  node_count: 5129
+  edge_count: 13920
+  latest_version: '2026-02-06'
 repository: https://github.com/enpadasi/Ontology-for-Nutritional-Studies
 publications:
 - authors:

--- a/resource/ontoavida/ontoavida.kg-bioportal.md
+++ b/resource/ontoavida/ontoavida.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: 'KGX TSV transform of OntoAvida: ontology for Avida digital evolution
+  platform (ONTOAVIDA), produced by KG-Bioportal from the BioPortal submission. The
+  archive contains ONTOAVIDA_nodes.tsv and ONTOAVIDA_edges.tsv.'
+edge_count: 807
+format: kgx
+id: ontoavida.kg-bioportal
+name: ONTOAVIDA KGX graph (KG-Bioportal)
+node_count: 741
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ontoavida
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOAVIDA.tar.gz
+layout: product_detail
+---

--- a/resource/ontoavida/ontoavida.md
+++ b/resource/ontoavida/ontoavida.md
@@ -22,7 +22,7 @@ domains:
 - information technology
 homepage_url: https://gitlab.com/fortunalab/ontoavida
 id: ontoavida
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -50,6 +50,20 @@ products:
   original_source:
   - source: ontoavida
     relation_type: prov:hadPrimarySource
+- id: ontoavida.kg-bioportal
+  name: ONTOAVIDA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: 'KGX TSV transform of OntoAvida: ontology for Avida digital evolution
+    platform (ONTOAVIDA), produced by KG-Bioportal from the BioPortal submission.
+    The archive contains ONTOAVIDA_nodes.tsv and ONTOAVIDA_edges.tsv.'
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTOAVIDA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ontoavida
+    relation_type: prov:hadPrimarySource
+  node_count: 741
+  edge_count: 807
 repository: https://gitlab.com/fortunalab/ontoavida
 publications:
 - authors:

--- a/resource/ontoneo/ontoneo.kg-bioportal.md
+++ b/resource/ontoneo/ontoneo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Obstetric and Neonatal Ontology (ONTONEO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains ONTONEO_nodes.tsv
+  and ONTONEO_edges.tsv.
+edge_count: 3316
+format: kgx
+id: ontoneo.kg-bioportal
+latest_version: '2025-03-14'
+name: ONTONEO KGX graph (KG-Bioportal)
+node_count: 2348
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ontoneo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTONEO.tar.gz
+layout: product_detail
+---

--- a/resource/ontoneo/ontoneo.md
+++ b/resource/ontoneo/ontoneo.md
@@ -20,7 +20,7 @@ domains:
 - biomedical
 homepage_url: https://ontoneo.com/
 id: ontoneo
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -38,6 +38,21 @@ products:
   original_source:
   - source: ontoneo
     relation_type: prov:hadPrimarySource
+- id: ontoneo.kg-bioportal
+  name: ONTONEO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Obstetric and Neonatal Ontology (ONTONEO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains ONTONEO_nodes.tsv
+    and ONTONEO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ONTONEO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ontoneo
+    relation_type: prov:hadPrimarySource
+  node_count: 2348
+  edge_count: 3316
+  latest_version: '2025-03-14'
 repository: https://github.com/ontoneo-project/Ontoneo
 publications:
 - authors:

--- a/resource/oostt/oostt.kg-bioportal.md
+++ b/resource/oostt/oostt.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Organizational Structures of Trauma
+  centers and Trauma systems (OOSTT), produced by KG-Bioportal from the BioPortal
+  submission. The archive contains OOSTT_nodes.tsv and OOSTT_edges.tsv.
+edge_count: 1178
+format: kgx
+id: oostt.kg-bioportal
+latest_version: release version - 2025-01-24
+name: OOSTT KGX graph (KG-Bioportal)
+node_count: 1117
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: oostt
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OOSTT.tar.gz
+layout: product_detail
+---

--- a/resource/oostt/oostt.md
+++ b/resource/oostt/oostt.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/OOSTT/OOSTT
 id: "oostt"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "http://creativecommons.org/licenses/by/4.0/"
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: oostt
         relation_type: prov:hadPrimarySource
+  - id: oostt.kg-bioportal
+    name: OOSTT KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology of Organizational Structures of Trauma centers and Trauma systems (OOSTT), produced by KG-Bioportal from the BioPortal submission. The archive contains OOSTT_nodes.tsv and OOSTT_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OOSTT.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: oostt
+        relation_type: prov:hadPrimarySource
+    node_count: 1117
+    edge_count: 1178
+    latest_version: release version - 2025-01-24
 publications:
   - authors:
       - Joseph Utecht

--- a/resource/opl/opl.kg-bioportal.md
+++ b/resource/opl/opl.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology for Parasite LifeCycle (OPL), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OPL_nodes.tsv
+  and OPL_edges.tsv.
+edge_count: 1839
+format: kgx
+id: opl.kg-bioportal
+latest_version: '2023-08-28'
+name: OPL KGX graph (KG-Bioportal)
+node_count: 745
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: opl
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPL.tar.gz
+layout: product_detail
+---

--- a/resource/opl/opl.md
+++ b/resource/opl/opl.md
@@ -19,7 +19,7 @@ domains:
   - organisms
 homepage_url: https://github.com/OPL-ontology/OPL
 id: "opl"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "https://creativecommons.org/licenses/by/4.0/"
@@ -37,6 +37,19 @@ products:
     original_source:
       - source: opl
         relation_type: prov:hadPrimarySource
+  - id: opl.kg-bioportal
+    name: OPL KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology for Parasite LifeCycle (OPL), produced by KG-Bioportal from the BioPortal submission. The archive contains OPL_nodes.tsv and OPL_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPL.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: opl
+        relation_type: prov:hadPrimarySource
+    node_count: 745
+    edge_count: 1839
+    latest_version: '2023-08-28'
 repository: https://github.com/OPL-ontology/OPL
 publications:
   - authors:

--- a/resource/opmi/opmi.kg-bioportal.md
+++ b/resource/opmi/opmi.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Precision Medicine and Investigation
+  (OPMI), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  OPMI_nodes.tsv and OPMI_edges.tsv.
+edge_count: 10056
+format: kgx
+id: opmi.kg-bioportal
+latest_version: 'Vision Release: 1.0.166'
+name: OPMI KGX graph (KG-Bioportal)
+node_count: 4201
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: opmi
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPMI.tar.gz
+layout: product_detail
+---

--- a/resource/opmi/opmi.md
+++ b/resource/opmi/opmi.md
@@ -21,7 +21,7 @@ domains:
 - general
 homepage_url: https://github.com/OPMI/opmi
 id: opmi
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -39,6 +39,21 @@ products:
   original_source:
   - source: opmi
     relation_type: prov:hadPrimarySource
+- id: opmi.kg-bioportal
+  name: OPMI KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology of Precision Medicine and Investigation
+    (OPMI), produced by KG-Bioportal from the BioPortal submission. The archive contains
+    OPMI_nodes.tsv and OPMI_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OPMI.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: opmi
+    relation_type: prov:hadPrimarySource
+  node_count: 4201
+  edge_count: 10056
+  latest_version: 'Vision Release: 1.0.166'
 publications:
 - authors:
   - He Y

--- a/resource/ordo/ordo.kg-bioportal.md
+++ b/resource/ordo/ordo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Orphanet Rare Disease Ontology (ORDO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains ORDO_nodes.tsv
+  and ORDO_edges.tsv.
+edge_count: 52455
+format: kgx
+id: ordo.kg-bioportal
+latest_version: '4.9'
+name: ORDO KGX graph (KG-Bioportal)
+node_count: 16393
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ordo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORDO.tar.gz
+layout: product_detail
+---

--- a/resource/ordo/ordo.md
+++ b/resource/ordo/ordo.md
@@ -24,7 +24,7 @@ domains:
 homepage_url: https://www.orphadata.com/ordo/
 id: "ordo"
 infores_id: "ordo"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "https://creativecommons.org/licenses/by/4.0/"
@@ -659,6 +659,19 @@ products:
         source: phenopacket-store
     product_file_size: 230046094
     product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+  - id: ordo.kg-bioportal
+    name: ORDO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Orphanet Rare Disease Ontology (ORDO), produced by KG-Bioportal from the BioPortal submission. The archive contains ORDO_nodes.tsv and ORDO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORDO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ordo
+        relation_type: prov:hadPrimarySource
+    node_count: 16393
+    edge_count: 52455
+    latest_version: '4.9'
 taxon:
   - NCBITaxon:9606
 ---

--- a/resource/ornaseq/ornaseq.kg-bioportal.md
+++ b/resource/ornaseq/ornaseq.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of RNA Sequencing (ORNASEQ), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains ORNASEQ_nodes.tsv
+  and ORNASEQ_edges.tsv.
+edge_count: 332
+format: kgx
+id: ornaseq.kg-bioportal
+name: ORNASEQ KGX graph (KG-Bioportal)
+node_count: 203
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ornaseq
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORNASEQ.tar.gz
+layout: product_detail
+---

--- a/resource/ornaseq/ornaseq.md
+++ b/resource/ornaseq/ornaseq.md
@@ -20,7 +20,7 @@ domains:
 - general
 homepage_url: http://kim.bio.upenn.edu/software/ornaseq.shtml
 id: ornaseq
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -38,6 +38,20 @@ products:
   original_source:
   - source: ornaseq
     relation_type: prov:hadPrimarySource
+- id: ornaseq.kg-bioportal
+  name: ORNASEQ KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Ontology of RNA Sequencing (ORNASEQ), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains ORNASEQ_nodes.tsv
+    and ORNASEQ_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ORNASEQ.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ornaseq
+    relation_type: prov:hadPrimarySource
+  node_count: 203
+  edge_count: 332
 repository: https://github.com/safisher/ornaseq
 publications: []
 ---

--- a/resource/ovae/ovae.kg-bioportal.md
+++ b/resource/ovae/ovae.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Ontology of Vaccine Adverse Events (OVAE), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains OVAE_nodes.tsv
+  and OVAE_edges.tsv.
+edge_count: 8403
+format: kgx
+id: ovae.kg-bioportal
+latest_version: 'Vision Release: 1.0.34'
+name: OVAE KGX graph (KG-Bioportal)
+node_count: 3350
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ovae
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OVAE.tar.gz
+layout: product_detail
+---

--- a/resource/ovae/ovae.md
+++ b/resource/ovae/ovae.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: http://www.violinet.org/ovae/
 id: ovae
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: ovae
         relation_type: prov:hadPrimarySource
+  - id: ovae.kg-bioportal
+    name: OVAE KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Ontology of Vaccine Adverse Events (OVAE), produced by KG-Bioportal from the BioPortal submission. The archive contains OVAE_nodes.tsv and OVAE_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OVAE.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: ovae
+        relation_type: prov:hadPrimarySource
+    node_count: 3350
+    edge_count: 8403
+    latest_version: 'Vision Release: 1.0.34'
 repository: https://github.com/OVAE-Ontology/ovae
 publications: []
 ---

--- a/resource/pato/pato.kg-bioportal.md
+++ b/resource/pato/pato.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Phenotypic Quality Ontology (PATO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains PATO_nodes.tsv
+  and PATO_edges.tsv.
+edge_count: 31234
+format: kgx
+id: pato.kg-bioportal
+latest_version: '2025-05-14'
+name: PATO KGX graph (KG-Bioportal)
+node_count: 9032
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: pato
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATO.tar.gz
+layout: product_detail
+---

--- a/resource/pato/pato.md
+++ b/resource/pato/pato.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://github.com/pato-ontology/pato/
 id: pato
 infores_id: pato
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -773,6 +773,21 @@ products:
     source: mondo
   - relation_type: prov:wasInfluencedBy
     source: hsapdv
+- id: pato.kg-bioportal
+  name: PATO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Phenotypic Quality Ontology (PATO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains PATO_nodes.tsv
+    and PATO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PATO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: pato
+    relation_type: prov:hadPrimarySource
+  node_count: 9032
+  edge_count: 31234
+  latest_version: '2025-05-14'
 publications:
 - authors:
   - Gkoutos GV

--- a/resource/pbpko/pbpko.kg-bioportal.md
+++ b/resource/pbpko/pbpko.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Physiologically-Based Pharmacokinetic ontology (PBPKO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains PBPKO_nodes.tsv
+  and PBPKO_edges.tsv.
+edge_count: 5226
+format: kgx
+id: pbpko.kg-bioportal
+latest_version: '2026-07-15'
+name: PBPKO KGX graph (KG-Bioportal)
+node_count: 1541
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: pbpko
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PBPKO.tar.gz
+layout: product_detail
+---

--- a/resource/pbpko/pbpko.md
+++ b/resource/pbpko/pbpko.md
@@ -18,7 +18,7 @@ domains:
   - chemistry and biochemistry
 homepage_url: https://github.com/InSilicoVida-Research-Lab/pbpko
 id: pbpko
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -36,19 +36,31 @@ products:
         source: pbpko
     product_file_size: 53137
     product_url: http://purl.obolibrary.org/obo/pbpko.owl
+  - id: pbpko.kg-bioportal
+    name: PBPKO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Physiologically-Based Pharmacokinetic ontology (PBPKO), produced by KG-Bioportal from the BioPortal submission. The archive contains PBPKO_nodes.tsv and PBPKO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PBPKO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: pbpko
+        relation_type: prov:hadPrimarySource
+    node_count: 1541
+    edge_count: 5226
+    latest_version: '2026-07-15'
 publications:
-- authors:
-  - Kumar V
-  - Deepika D
-  - Kumar S
-  - Sharma S
-  doi: 10.1016/j.toxlet.2024.07.382
-  id: https://doi.org/10.1016/j.toxlet.2024.07.382
-  journal: Toxicology Letters
-  preferred: true
-  title: P05-47 An ontology of Physiologically Based Pharmacokinetic Model (PBPK) for
-    harmonization and automation of modeling framework (PBPKO)
-  year: '2024'
+  - authors:
+      - Kumar V
+      - Deepika D
+      - Kumar S
+      - Sharma S
+    doi: 10.1016/j.toxlet.2024.07.382
+    id: https://doi.org/10.1016/j.toxlet.2024.07.382
+    journal: Toxicology Letters
+    preferred: true
+    title: P05-47 An ontology of Physiologically Based Pharmacokinetic Model (PBPK) for harmonization and automation of modeling framework (PBPKO)
+    year: '2024'
 repository: https://github.com/InSilicoVida-Research-Lab/pbpko
 ---
 

--- a/resource/pco/pco.kg-bioportal.md
+++ b/resource/pco/pco.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Population and Community Ontology (PCO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains PCO_nodes.tsv
+  and PCO_edges.tsv.
+edge_count: 1052
+format: kgx
+id: pco.kg-bioportal
+latest_version: '2013-10-03'
+name: PCO KGX graph (KG-Bioportal)
+node_count: 558
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: pco
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PCO.tar.gz
+layout: product_detail
+---

--- a/resource/pco/pco.md
+++ b/resource/pco/pco.md
@@ -19,7 +19,7 @@ domains:
   - environment
 homepage_url: https://github.com/PopulationAndCommunityOntology/pco
 id: pco
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -37,6 +37,19 @@ products:
     original_source:
       - source: pco
         relation_type: prov:hadPrimarySource
+  - id: pco.kg-bioportal
+    name: PCO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Population and Community Ontology (PCO), produced by KG-Bioportal from the BioPortal submission. The archive contains PCO_nodes.tsv and PCO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PCO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: pco
+        relation_type: prov:hadPrimarySource
+    node_count: 558
+    edge_count: 1052
+    latest_version: '2013-10-03'
 repository: https://github.com/PopulationAndCommunityOntology/pco
 publications:
   - authors:
@@ -69,8 +82,7 @@ publications:
     id: https://www.ncbi.nlm.nih.gov/pubmed/24595056
     journal: PLoS One
     preferred: true
-    title: 'Semantics in Support of Biodiversity Knowledge Discovery: An Introduction
-      to the Biological Collections Ontology and Related Ontologies'
+    title: 'Semantics in Support of Biodiversity Knowledge Discovery: An Introduction to the Biological Collections Ontology and Related Ontologies'
     year: '2014'
 ---
 

--- a/resource/pdro/pdro.kg-bioportal.md
+++ b/resource/pdro/pdro.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of The Prescription of Drugs Ontology (PDRO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains PDRO_nodes.tsv
+  and PDRO_edges.tsv.
+edge_count: 1456
+format: kgx
+id: pdro.kg-bioportal
+latest_version: '2026-06-09'
+name: PDRO KGX graph (KG-Bioportal)
+node_count: 649
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: pdro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDRO.tar.gz
+layout: product_detail
+---

--- a/resource/pdro/pdro.md
+++ b/resource/pdro/pdro.md
@@ -19,7 +19,7 @@ domains:
 - information technology
 homepage_url: https://github.com/OpenLHS/PDRO
 id: pdro
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,21 @@ products:
   original_source:
   - source: pdro
     relation_type: prov:hadPrimarySource
+- id: pdro.kg-bioportal
+  name: PDRO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of The Prescription of Drugs Ontology (PDRO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains PDRO_nodes.tsv
+    and PDRO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDRO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: pdro
+    relation_type: prov:hadPrimarySource
+  node_count: 649
+  edge_count: 1456
+  latest_version: '2026-06-09'
 repository: https://github.com/OpenLHS/PDRO
 publications:
 - authors:

--- a/resource/pdumdv/pdumdv.kg-bioportal.md
+++ b/resource/pdumdv/pdumdv.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Platynereis Developmental Stages (PDUMDV), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains PDUMDV_nodes.tsv
+  and PDUMDV_edges.tsv.
+edge_count: 42
+format: kgx
+id: pdumdv.kg-bioportal
+name: PDUMDV KGX graph (KG-Bioportal)
+node_count: 40
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: pdumdv
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDUMDV.tar.gz
+layout: product_detail
+---

--- a/resource/pdumdv/pdumdv.md
+++ b/resource/pdumdv/pdumdv.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/developmental-stage-ontologies/wiki/PdumDv
 id: pdumdv
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,18 @@ products:
     original_source:
       - source: pdumdv
         relation_type: prov:hadPrimarySource
+  - id: pdumdv.kg-bioportal
+    name: PDUMDV KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Platynereis Developmental Stages (PDUMDV), produced by KG-Bioportal from the BioPortal submission. The archive contains PDUMDV_nodes.tsv and PDUMDV_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PDUMDV.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: pdumdv
+        relation_type: prov:hadPrimarySource
+    node_count: 40
+    edge_count: 42
 repository: https://github.com/obophenotype/developmental-stage-ontologies
 publications: []
 ---

--- a/resource/phipo/phipo.kg-bioportal.md
+++ b/resource/phipo/phipo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Pathogen Host Interaction Phenotype Ontology (PHIPO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains PHIPO_nodes.tsv
+  and PHIPO_edges.tsv.
+edge_count: 40085
+format: kgx
+id: phipo.kg-bioportal
+latest_version: '2026-03-12'
+name: PHIPO KGX graph (KG-Bioportal)
+node_count: 12086
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: phipo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHIPO.tar.gz
+layout: product_detail
+---

--- a/resource/phipo/phipo.md
+++ b/resource/phipo/phipo.md
@@ -20,7 +20,7 @@ domains:
 - phenotype
 homepage_url: https://github.com/PHI-base/phipo
 id: phipo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -48,6 +48,21 @@ products:
   original_source:
   - source: phipo
     relation_type: prov:hadPrimarySource
+- id: phipo.kg-bioportal
+  name: PHIPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Pathogen Host Interaction Phenotype Ontology (PHIPO),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains PHIPO_nodes.tsv
+    and PHIPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PHIPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: phipo
+    relation_type: prov:hadPrimarySource
+  node_count: 12086
+  edge_count: 40085
+  latest_version: '2026-03-12'
 repository: https://github.com/PHI-base/phipo
 publications:
 - authors:

--- a/resource/plana/plana.kg-bioportal.md
+++ b/resource/plana/plana.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Planarian Anatomy and Developmental Stage Ontolgoy
+  (PLANA), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  PLANA_nodes.tsv and PLANA_edges.tsv.
+edge_count: 4198
+format: kgx
+id: plana.kg-bioportal
+latest_version: '2023-03-13'
+name: PLANA KGX graph (KG-Bioportal)
+node_count: 1488
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: plana
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANA.tar.gz
+layout: product_detail
+---

--- a/resource/plana/plana.md
+++ b/resource/plana/plana.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/planaria-ontology
 id: plana
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: plana
         relation_type: prov:hadPrimarySource
+  - id: plana.kg-bioportal
+    name: PLANA KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Planarian Anatomy and Developmental Stage Ontolgoy (PLANA), produced by KG-Bioportal from the BioPortal submission. The archive contains PLANA_nodes.tsv and PLANA_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANA.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: plana
+        relation_type: prov:hadPrimarySource
+    node_count: 1488
+    edge_count: 4198
+    latest_version: '2023-03-13'
 repository: https://github.com/obophenotype/planaria-ontology
 publications:
   - authors:

--- a/resource/planp/planp.kg-bioportal.md
+++ b/resource/planp/planp.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Planarian Phenotype Ontology (PLANP), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains PLANP_nodes.tsv
+  and PLANP_edges.tsv.
+edge_count: 12777
+format: kgx
+id: planp.kg-bioportal
+name: PLANP KGX graph (KG-Bioportal)
+node_count: 4790
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: planp
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANP.tar.gz
+layout: product_detail
+---

--- a/resource/planp/planp.md
+++ b/resource/planp/planp.md
@@ -20,7 +20,7 @@ domains:
 - phenotype
 homepage_url: https://github.com/obophenotype/planarian-phenotype-ontology
 id: planp
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -48,6 +48,20 @@ products:
   original_source:
   - source: planp
     relation_type: prov:hadPrimarySource
+- id: planp.kg-bioportal
+  name: PLANP KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Planarian Phenotype Ontology (PLANP), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains PLANP_nodes.tsv
+    and PLANP_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANP.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: planp
+    relation_type: prov:hadPrimarySource
+  node_count: 4790
+  edge_count: 12777
 repository: https://github.com/obophenotype/planarian-phenotype-ontology
 publications: []
 ---

--- a/resource/po/po.kg-bioportal.md
+++ b/resource/po/po.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Plant Ontology (PO), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains PO_nodes.tsv and PO_edges.tsv.
+edge_count: 4425
+format: kgx
+id: po.kg-bioportal
+latest_version: releases/2024-04-17
+name: PO KGX graph (KG-Bioportal)
+node_count: 2073
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: po
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PO.tar.gz
+layout: product_detail
+---

--- a/resource/po/po.md
+++ b/resource/po/po.md
@@ -19,7 +19,7 @@ domains:
 - anatomy and development
 homepage_url: http://browser.planteome.org/amigo
 id: po
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -657,6 +657,20 @@ products:
     source: gomapman
   product_file_size: 702407
   product_url: https://skm.nib.si/downloads/ckn/v1-2018.06/nodes
+- id: po.kg-bioportal
+  name: PO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Plant Ontology (PO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains PO_nodes.tsv and PO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: po
+    relation_type: prov:hadPrimarySource
+  node_count: 2073
+  edge_count: 4425
+  latest_version: releases/2024-04-17
 publications:
 - authors:
   - Cooper L

--- a/resource/poro/poro.kg-bioportal.md
+++ b/resource/poro/poro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Porifera Ontology (PORO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains PORO_nodes.tsv and PORO_edges.tsv.
+edge_count: 1163
+format: kgx
+id: poro.kg-bioportal
+latest_version: unknown
+name: PORO KGX graph (KG-Bioportal)
+node_count: 944
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: poro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PORO.tar.gz
+layout: product_detail
+---

--- a/resource/poro/poro.md
+++ b/resource/poro/poro.md
@@ -18,7 +18,7 @@ domains:
   - anatomy and development
 homepage_url: https://github.com/obophenotype/porifera-ontology
 id: poro
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: poro
         relation_type: prov:hadPrimarySource
+  - id: poro.kg-bioportal
+    name: PORO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Porifera Ontology (PORO), produced by KG-Bioportal from the BioPortal submission. The archive contains PORO_nodes.tsv and PORO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PORO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: poro
+        relation_type: prov:hadPrimarySource
+    node_count: 944
+    edge_count: 1163
+    latest_version: unknown
 repository: https://github.com/obophenotype/porifera-ontology
 taxon:
   - NCBITaxon:6040

--- a/resource/ppo/ppo.kg-bioportal.md
+++ b/resource/ppo/ppo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Plant Phenology Ontology (PPO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains PPO_nodes.tsv and PPO_edges.tsv.
+edge_count: 1480
+format: kgx
+id: ppo.kg-bioportal
+latest_version: '2026-05-06'
+name: PPO KGX graph (KG-Bioportal)
+node_count: 921
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ppo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PPO.tar.gz
+layout: product_detail
+---

--- a/resource/ppo/ppo.md
+++ b/resource/ppo/ppo.md
@@ -20,7 +20,7 @@ domains:
 - phenotype
 homepage_url: https://github.com/PlantPhenoOntology/PPO
 id: ppo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -38,6 +38,20 @@ products:
   original_source:
   - source: ppo
     relation_type: prov:hadPrimarySource
+- id: ppo.kg-bioportal
+  name: PPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Plant Phenology Ontology (PPO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains PPO_nodes.tsv and PPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ppo
+    relation_type: prov:hadPrimarySource
+  node_count: 921
+  edge_count: 1480
+  latest_version: '2026-05-06'
 repository: https://github.com/PlantPhenoOntology/PPO
 taxon:
 - NCBITaxon:33090

--- a/resource/prefer/prefer.kg-bioportal.md
+++ b/resource/prefer/prefer.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Precision Fermentation Ontology (PREFER), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains PREFER_nodes.tsv
+  and PREFER_edges.tsv.
+edge_count: 22849
+format: kgx
+id: prefer.kg-bioportal
+latest_version: '2026-07-14'
+name: PREFER KGX graph (KG-Bioportal)
+node_count: 7597
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: prefer
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PREFER.tar.gz
+layout: product_detail
+---

--- a/resource/prefer/prefer.md
+++ b/resource/prefer/prefer.md
@@ -21,7 +21,7 @@ domains:
 - general
 homepage_url: https://github.com/Multiomics-Analytics-Group/prefer_ontology
 id: prefer
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -91,6 +91,21 @@ products:
     source: prefer
   product_file_size: 233928
   product_url: http://purl.obolibrary.org/obo/prefer/prefer-base.json
+- id: prefer.kg-bioportal
+  name: PREFER KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Precision Fermentation Ontology (PREFER), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains PREFER_nodes.tsv
+    and PREFER_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PREFER.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: prefer
+    relation_type: prov:hadPrimarySource
+  node_count: 7597
+  edge_count: 22849
+  latest_version: '2026-07-14'
 publications:
 - id: https://arxiv.org/abs/2602.16755
   title: 'PREFER: An Ontology for the PREcision FERmentation Community'

--- a/resource/proco/proco.kg-bioportal.md
+++ b/resource/proco/proco.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Process Chemistry Ontology (PROCO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains PROCO_nodes.tsv
+  and PROCO_edges.tsv.
+edge_count: 2728
+format: kgx
+id: proco.kg-bioportal
+latest_version: PROCO release 20220414
+name: PROCO KGX graph (KG-Bioportal)
+node_count: 1166
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: proco
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PROCO.tar.gz
+layout: product_detail
+---

--- a/resource/proco/proco.md
+++ b/resource/proco/proco.md
@@ -18,7 +18,7 @@ domains:
   - chemistry and biochemistry
 homepage_url: https://github.com/proco-ontology/PROCO
 id: proco
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: proco
         relation_type: prov:hadPrimarySource
+  - id: proco.kg-bioportal
+    name: PROCO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Process Chemistry Ontology (PROCO), produced by KG-Bioportal from the BioPortal submission. The archive contains PROCO_nodes.tsv and PROCO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PROCO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: proco
+        relation_type: prov:hadPrimarySource
+    node_count: 1166
+    edge_count: 2728
+    latest_version: PROCO release 20220414
 repository: https://github.com/proco-ontology/PROCO
 publications:
   - authors:

--- a/resource/propreo/propreo.kg-bioportal.md
+++ b/resource/propreo/propreo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Proteomics Data and Process Provenance Ontology
+  (PROPREO), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  PROPREO_nodes.tsv and PROPREO_edges.tsv.
+edge_count: 593
+format: kgx
+id: propreo.kg-bioportal
+latest_version: '1.1'
+name: PROPREO KGX graph (KG-Bioportal)
+node_count: 512
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: propreo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PROPREO.tar.gz
+layout: product_detail
+---

--- a/resource/propreo/propreo.md
+++ b/resource/propreo/propreo.md
@@ -15,7 +15,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://lsdis.cs.uga.edu/projects/glycomics/propreo/
 id: propreo
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -32,10 +32,23 @@ products:
     source: propreo
   product_url: http://purl.obolibrary.org/obo/propreo.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
   - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Proteomics Data and Process Provenance Ontology
+    (PROPREO), produced by KG-Bioportal from the BioPortal submission. The archive
+    contains PROPREO_nodes.tsv and PROPREO_edges.tsv.
+  edge_count: 593
+  format: kgx
+  id: propreo.kg-bioportal
+  latest_version: '1.1'
+  name: PROPREO KGX graph (KG-Bioportal)
+  node_count: 512
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: propreo
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08/PROPREO.tar.gz
 publications: []
 ---
 ## Description

--- a/resource/psdo/psdo.kg-bioportal.md
+++ b/resource/psdo/psdo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Performance Summary Display Ontology (PSDO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains PSDO_nodes.tsv
+  and PSDO_edges.tsv.
+edge_count: 136
+format: kgx
+id: psdo.kg-bioportal
+latest_version: 1.0.1
+name: PSDO KGX graph (KG-Bioportal)
+node_count: 128
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: psdo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PSDO.tar.gz
+layout: product_detail
+---

--- a/resource/psdo/psdo.md
+++ b/resource/psdo/psdo.md
@@ -19,7 +19,7 @@ domains:
 - information technology
 homepage_url: https://github.com/Display-Lab/psdo
 id: psdo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -37,6 +37,21 @@ products:
   original_source:
   - source: psdo
     relation_type: prov:hadPrimarySource
+- id: psdo.kg-bioportal
+  name: PSDO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Performance Summary Display Ontology (PSDO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains PSDO_nodes.tsv
+    and PSDO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PSDO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: psdo
+    relation_type: prov:hadPrimarySource
+  node_count: 128
+  edge_count: 136
+  latest_version: 1.0.1
 repository: https://github.com/Display-Lab/psdo
 publications: []
 ---

--- a/resource/pso/pso.kg-bioportal.md
+++ b/resource/pso/pso.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Plant Stress Ontology (PLANTSO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains PLANTSO_nodes.tsv and PLANTSO_edges.tsv.
+edge_count: 16147
+format: kgx
+id: pso.kg-bioportal
+latest_version: '2026-01-08'
+name: PLANTSO KGX graph (KG-Bioportal)
+node_count: 5355
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: pso
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANTSO.tar.gz
+layout: product_detail
+---

--- a/resource/pso/pso.md
+++ b/resource/pso/pso.md
@@ -19,7 +19,7 @@ domains:
   - agriculture
 homepage_url: https://github.com/Planteome/plant-stress-ontology
 id: pso
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -47,6 +47,19 @@ products:
     original_source:
       - source: pso
         relation_type: prov:hadPrimarySource
+  - id: pso.kg-bioportal
+    name: PLANTSO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Plant Stress Ontology (PLANTSO), produced by KG-Bioportal from the BioPortal submission. The archive contains PLANTSO_nodes.tsv and PLANTSO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PLANTSO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: pso
+        relation_type: prov:hadPrimarySource
+    node_count: 5355
+    edge_count: 16147
+    latest_version: '2026-01-08'
 repository: https://github.com/Planteome/plant-stress-ontology
 publications:
   - authors:

--- a/resource/pw/pw.kg-bioportal.md
+++ b/resource/pw/pw.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Pathway Ontology (PW), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains PW_nodes.tsv and PW_edges.tsv.
+edge_count: 3455
+format: kgx
+id: pw.kg-bioportal
+latest_version: '2026-05-16'
+name: PW KGX graph (KG-Bioportal)
+node_count: 2787
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: pw
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PW.tar.gz
+layout: product_detail
+---

--- a/resource/pw/pw.md
+++ b/resource/pw/pw.md
@@ -18,7 +18,7 @@ domains:
 - biological systems
 homepage_url: http://rgd.mcw.edu/rgdweb/ontology/search.html
 id: pw
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -353,6 +353,20 @@ products:
     source: uberon
   product_file_size: 936065236
   product_url: https://zenodo.org/records/12536780/files/NP-KG_v3.0.0.gpickle?download=1
+- id: pw.kg-bioportal
+  name: PW KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Pathway Ontology (PW), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains PW_nodes.tsv and PW_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PW.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: pw
+    relation_type: prov:hadPrimarySource
+  node_count: 2787
+  edge_count: 3455
+  latest_version: '2026-05-16'
 publications:
 - authors:
   - Petri V

--- a/resource/rex/rex.kg-bioportal.md
+++ b/resource/rex/rex.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Physico-Chemical Process (REX), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains REX_nodes.tsv and REX_edges.tsv.
+edge_count: 734
+format: kgx
+id: rex.kg-bioportal
+latest_version: '1.13'
+name: REX KGX graph (KG-Bioportal)
+node_count: 570
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: rex
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REX.tar.gz
+layout: product_detail
+---

--- a/resource/rex/rex.md
+++ b/resource/rex/rex.md
@@ -11,7 +11,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://purl.obolibrary.org/obo/rex.owl
 id: rex
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -28,6 +28,20 @@ products:
     source: rex
   product_url: http://purl.obolibrary.org/obo/rex.owl
   warnings: []
+- id: rex.kg-bioportal
+  name: REX KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Physico-Chemical Process (REX), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains REX_nodes.tsv and REX_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/REX.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: rex
+    relation_type: prov:hadPrimarySource
+  node_count: 570
+  edge_count: 734
+  latest_version: '1.13'
 publications: []
 ---
 ## Description

--- a/resource/rnao/rnao.kg-bioportal.md
+++ b/resource/rnao/rnao.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of RNA Ontology (RNAO), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains RNAO_nodes.tsv and RNAO_edges.tsv.
+edge_count: 1362
+format: kgx
+id: rnao.kg-bioportal
+latest_version: r113
+name: RNAO KGX graph (KG-Bioportal)
+node_count: 811
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: rnao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RNAO.tar.gz
+layout: product_detail
+---

--- a/resource/rnao/rnao.md
+++ b/resource/rnao/rnao.md
@@ -16,7 +16,7 @@ domains:
   - chemistry and biochemistry
 homepage_url: https://github.com/bgsu-rna/rnao
 id: rnao
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -44,6 +44,19 @@ products:
     original_source:
       - source: rnao
         relation_type: prov:hadPrimarySource
+  - id: rnao.kg-bioportal
+    name: RNAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of RNA Ontology (RNAO), produced by KG-Bioportal from the BioPortal submission. The archive contains RNAO_nodes.tsv and RNAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RNAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: rnao
+        relation_type: prov:hadPrimarySource
+    node_count: 811
+    edge_count: 1362
+    latest_version: r113
 repository: https://github.com/BGSU-RNA/rnao
 publications: []
 ---

--- a/resource/ro/ro.kg-bioportal.md
+++ b/resource/ro/ro.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Relations Ontology (OBOREL), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains OBOREL_nodes.tsv and OBOREL_edges.tsv.
+edge_count: 2787
+format: kgx
+id: ro.kg-bioportal
+latest_version: '2025-12-17'
+name: OBOREL KGX graph (KG-Bioportal)
+node_count: 1234
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: ro
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBOREL.tar.gz
+layout: product_detail
+---

--- a/resource/ro/ro.md
+++ b/resource/ro/ro.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://oborel.github.io/
 id: ro
 infores_id: ro
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -791,12 +791,26 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: ro.kg-bioportal
+  name: OBOREL KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Relations Ontology (OBOREL), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains OBOREL_nodes.tsv and OBOREL_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/OBOREL.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: ro
+    relation_type: prov:hadPrimarySource
+  node_count: 1234
+  edge_count: 2787
+  latest_version: '2025-12-17'
 publications:
 - authors:
   - Barry Smith
   - Werner Ceusters
   - Bert Klagges
-  - "Jacob K\xF6hler"
+  - Jacob Köhler
   - Anand Kumar
   - Jane Lomax
   - Chris Mungall

--- a/resource/rs/rs.kg-bioportal.md
+++ b/resource/rs/rs.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Rat Strain Ontology (RS), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains RS_nodes.tsv and RS_edges.tsv.
+edge_count: 7580
+format: kgx
+id: rs.kg-bioportal
+latest_version: '2026-07-29'
+name: RS KGX graph (KG-Bioportal)
+node_count: 5714
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: rs
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RS.tar.gz
+layout: product_detail
+---

--- a/resource/rs/rs.md
+++ b/resource/rs/rs.md
@@ -19,7 +19,7 @@ domains:
 - organisms
 homepage_url: http://rgd.mcw.edu/rgdweb/search/strains.html
 id: rs
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -46,6 +46,20 @@ products:
   original_source:
   - source: rs
     relation_type: prov:hadPrimarySource
+- id: rs.kg-bioportal
+  name: RS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Rat Strain Ontology (RS), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains RS_nodes.tsv and RS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: rs
+    relation_type: prov:hadPrimarySource
+  node_count: 5714
+  edge_count: 7580
+  latest_version: '2026-07-29'
 repository: https://github.com/rat-genome-database/RS-Rat-Strain-Ontology
 taxon:
 - NCBITaxon:10114

--- a/resource/rxno/rxno.kg-bioportal.md
+++ b/resource/rxno/rxno.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Name Reaction Ontology (RXNO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains RXNO_nodes.tsv and RXNO_edges.tsv.
+edge_count: 1939
+format: kgx
+id: rxno.kg-bioportal
+latest_version: releases/2021-12-16
+name: RXNO KGX graph (KG-Bioportal)
+node_count: 1128
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: rxno
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RXNO.tar.gz
+layout: product_detail
+---

--- a/resource/rxno/rxno.md
+++ b/resource/rxno/rxno.md
@@ -18,7 +18,7 @@ domains:
   - chemistry and biochemistry
 homepage_url: https://github.com/rsc-ontologies/rxno
 id: rxno
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -36,6 +36,19 @@ products:
     original_source:
       - source: rxno
         relation_type: prov:hadPrimarySource
+  - id: rxno.kg-bioportal
+    name: RXNO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Name Reaction Ontology (RXNO), produced by KG-Bioportal from the BioPortal submission. The archive contains RXNO_nodes.tsv and RXNO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/RXNO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: rxno
+        relation_type: prov:hadPrimarySource
+    node_count: 1128
+    edge_count: 1939
+    latest_version: releases/2021-12-16
 repository: https://github.com/rsc-ontologies/rxno
 publications: []
 ---

--- a/resource/sao/sao.kg-bioportal.md
+++ b/resource/sao/sao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Subcellular Anatomy Ontology (SAO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains SAO_nodes.tsv and
+  SAO_edges.tsv.
+edge_count: 2541
+format: kgx
+id: sao.kg-bioportal
+latest_version: Version 1.2
+name: SAO KGX graph (KG-Bioportal)
+node_count: 863
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: sao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SAO.tar.gz
+layout: product_detail
+---

--- a/resource/sao/sao.md
+++ b/resource/sao/sao.md
@@ -15,7 +15,7 @@ domains:
 - anatomy and development
 homepage_url: http://ccdb.ucsd.edu/CCDBWebSite/sao.html
 id: sao
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -33,10 +33,23 @@ products:
     source: sao
   product_url: http://purl.obolibrary.org/obo/sao.owl
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
   - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
     when accessing file'
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Subcellular Anatomy Ontology (SAO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains SAO_nodes.tsv
+    and SAO_edges.tsv.
+  edge_count: 2541
+  format: kgx
+  id: sao.kg-bioportal
+  latest_version: Version 1.2
+  name: SAO KGX graph (KG-Bioportal)
+  node_count: 863
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: sao
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SAO.tar.gz
 publications: []
 taxon:
 - NCBITaxon:9606

--- a/resource/sbo/sbo.kg-bioportal.md
+++ b/resource/sbo/sbo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Systems Biology Ontology (SBO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains SBO_nodes.tsv and SBO_edges.tsv.
+edge_count: 745
+format: kgx
+id: sbo.kg-bioportal
+latest_version: 28:08:2021 03:13
+name: SBO KGX graph (KG-Bioportal)
+node_count: 697
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: sbo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SBO.tar.gz
+layout: product_detail
+---

--- a/resource/sbo/sbo.md
+++ b/resource/sbo/sbo.md
@@ -19,7 +19,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.ebi.ac.uk/sbo/
 id: sbo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://opensource.org/licenses/Artistic-2.0
@@ -266,6 +266,20 @@ products:
   - relation_type: prov:hadPrimarySource
     source: wikipathways
   product_url: https://ubkg-downloads.xconsortia.org/
+- id: sbo.kg-bioportal
+  name: SBO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Systems Biology Ontology (SBO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains SBO_nodes.tsv and SBO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SBO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: sbo
+    relation_type: prov:hadPrimarySource
+  node_count: 697
+  edge_count: 745
+  latest_version: 28:08:2021 03:13
 publications:
 - authors:
   - Mélanie Courtot

--- a/resource/scdo/scdo.kg-bioportal.md
+++ b/resource/scdo/scdo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Sickle Cell Disease Ontology (SCDO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains SCDO_nodes.tsv
+  and SCDO_edges.tsv.
+edge_count: 7286
+format: kgx
+id: scdo.kg-bioportal
+latest_version: '2021-04-15'
+name: SCDO KGX graph (KG-Bioportal)
+node_count: 2870
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: scdo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SCDO.tar.gz
+layout: product_detail
+---

--- a/resource/scdo/scdo.md
+++ b/resource/scdo/scdo.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://scdontology.h3abionet.org/
 id: scdo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.gnu.org/licenses/gpl-3.0.en.html
@@ -45,69 +45,82 @@ products:
     original_source:
       - source: scdo
         relation_type: prov:hadPrimarySource
+  - id: scdo.kg-bioportal
+    name: SCDO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Sickle Cell Disease Ontology (SCDO), produced by KG-Bioportal from the BioPortal submission. The archive contains SCDO_nodes.tsv and SCDO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SCDO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: scdo
+        relation_type: prov:hadPrimarySource
+    node_count: 2870
+    edge_count: 7286
+    latest_version: '2021-04-15'
 repository: https://github.com/scdodev/scdo-ontology
 publications:
-- authors:
-  - Mazandu GK
-  - Hotchkiss J
-  - Nembaware V
-  - Wonkam A
-  - Mulder N
-  doi: 10.1093/database/baac014
-  id: https://www.ncbi.nlm.nih.gov/pubmed/35363306
-  journal: Database (Oxford)
-  title: 'The Sickle Cell Disease Ontology: recent development and expansion of the universal sickle cell knowledge representation.'
-  year: '2022'
-- authors:
-  - Nembaware V
-  - Mazandu GK
-  - Hotchkiss J
-  - Safari Serufuri JM
-  - Kent J
-  - Kengne AP
-  - Anie K
-  - Munung NS
-  - Bukini D
-  - Bitoungui VJN
-  - Munube D
-  - Chirwa U
-  - Chunda-Liyoka C
-  - Jonathan A
-  - Flor-Park MV
-  - Esoh KK
-  - Jonas M
-  - Mnika K
-  - Oosterwyk C
-  - Masamu U
-  - Morrice J
-  - Uwineza A
-  - Nguweneza A
-  - Banda K
-  - Nyanor I
-  - Adjei DN
-  - Siebu NE
-  - Nkanyemka M
-  - Kuona P
-  - Tayo BO
-  - Campbell A
-  - Oron AP
-  - Nnodu OE
-  - Painstil V
-  - Makani J
-  - Mulder N
-  - Wonkam A
-  doi: 10.1089/omi.2020.0153
-  id: https://www.ncbi.nlm.nih.gov/pubmed/33021900
-  journal: OMICS
-  title: 'The Sickle Cell Disease Ontology: Enabling Collaborative Research and Co-Designing of New Planetary Health Applications.'
-  year: '2020'
-- authors:
-  - Sickle Cell Disease Ontology Working Group
-  doi: 10.1093/database/baz118
-  id: https://www.ncbi.nlm.nih.gov/pubmed/31769834
-  journal: Database (Oxford)
-  title: 'The Sickle Cell Disease Ontology: enabling universal sickle cell-based knowledge representation.'
-  year: '2019'
+  - authors:
+      - Mazandu GK
+      - Hotchkiss J
+      - Nembaware V
+      - Wonkam A
+      - Mulder N
+    doi: 10.1093/database/baac014
+    id: https://www.ncbi.nlm.nih.gov/pubmed/35363306
+    journal: Database (Oxford)
+    title: 'The Sickle Cell Disease Ontology: recent development and expansion of the universal sickle cell knowledge representation.'
+    year: '2022'
+  - authors:
+      - Nembaware V
+      - Mazandu GK
+      - Hotchkiss J
+      - Safari Serufuri JM
+      - Kent J
+      - Kengne AP
+      - Anie K
+      - Munung NS
+      - Bukini D
+      - Bitoungui VJN
+      - Munube D
+      - Chirwa U
+      - Chunda-Liyoka C
+      - Jonathan A
+      - Flor-Park MV
+      - Esoh KK
+      - Jonas M
+      - Mnika K
+      - Oosterwyk C
+      - Masamu U
+      - Morrice J
+      - Uwineza A
+      - Nguweneza A
+      - Banda K
+      - Nyanor I
+      - Adjei DN
+      - Siebu NE
+      - Nkanyemka M
+      - Kuona P
+      - Tayo BO
+      - Campbell A
+      - Oron AP
+      - Nnodu OE
+      - Painstil V
+      - Makani J
+      - Mulder N
+      - Wonkam A
+    doi: 10.1089/omi.2020.0153
+    id: https://www.ncbi.nlm.nih.gov/pubmed/33021900
+    journal: OMICS
+    title: 'The Sickle Cell Disease Ontology: Enabling Collaborative Research and Co-Designing of New Planetary Health Applications.'
+    year: '2020'
+  - authors:
+      - Sickle Cell Disease Ontology Working Group
+    doi: 10.1093/database/baz118
+    id: https://www.ncbi.nlm.nih.gov/pubmed/31769834
+    journal: Database (Oxford)
+    title: 'The Sickle Cell Disease Ontology: enabling universal sickle cell-based knowledge representation.'
+    year: '2019'
 ---
 
 ## Description

--- a/resource/sepio/sepio.kg-bioportal.md
+++ b/resource/sepio/sepio.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Scientific Evidence and Provenance Information Ontology
+  (SEPIO), produced by KG-Bioportal from the BioPortal submission. The archive contains
+  SEPIO_nodes.tsv and SEPIO_edges.tsv.
+edge_count: 878
+format: kgx
+id: sepio.kg-bioportal
+latest_version: '2023-06-13'
+name: SEPIO KGX graph (KG-Bioportal)
+node_count: 529
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: sepio
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/SEPIO.tar.gz
+layout: product_detail
+---

--- a/resource/sepio/sepio.md
+++ b/resource/sepio/sepio.md
@@ -19,7 +19,7 @@ domains:
   - general
 homepage_url: https://github.com/monarch-initiative/SEPIO-ontology
 id: "sepio"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "https://creativecommons.org/licenses/by/3.0/"
@@ -37,6 +37,19 @@ products:
     original_source:
       - source: sepio
         relation_type: prov:hadPrimarySource
+  - id: sepio.kg-bioportal
+    name: SEPIO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Scientific Evidence and Provenance Information Ontology (SEPIO), produced by KG-Bioportal from the BioPortal submission. The archive contains SEPIO_nodes.tsv and SEPIO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/SEPIO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: sepio
+        relation_type: prov:hadPrimarySource
+    node_count: 529
+    edge_count: 878
+    latest_version: '2023-06-13'
 repository: https://github.com/monarch-initiative/SEPIO-ontology
 publications:
   - authors:

--- a/resource/sibo/sibo.kg-bioportal.md
+++ b/resource/sibo/sibo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Social Insect Behavior Ontology (SIBO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains SIBO_nodes.tsv
+  and SIBO_edges.tsv.
+edge_count: 1103
+format: kgx
+id: sibo.kg-bioportal
+name: SIBO KGX graph (KG-Bioportal)
+node_count: 547
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: sibo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SIBO.tar.gz
+layout: product_detail
+---

--- a/resource/sibo/sibo.md
+++ b/resource/sibo/sibo.md
@@ -16,7 +16,7 @@ domains:
   - biological systems
 homepage_url: https://github.com/obophenotype/sibo
 id: sibo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -44,6 +44,18 @@ products:
     original_source:
       - source: sibo
         relation_type: prov:hadPrimarySource
+  - id: sibo.kg-bioportal
+    name: SIBO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Social Insect Behavior Ontology (SIBO), produced by KG-Bioportal from the BioPortal submission. The archive contains SIBO_nodes.tsv and SIBO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SIBO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: sibo
+        relation_type: prov:hadPrimarySource
+    node_count: 547
+    edge_count: 1103
 repository: https://github.com/obophenotype/sibo
 publications: []
 ---

--- a/resource/sio/sio.kg-bioportal.md
+++ b/resource/sio/sio.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Semanticscience Integrated Ontology (SIO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains SIO_nodes.tsv
+  and SIO_edges.tsv.
+edge_count: 4185
+format: kgx
+id: sio.kg-bioportal
+latest_version: '1.61'
+name: SIO KGX graph (KG-Bioportal)
+node_count: 1897
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: sio
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SIO.tar.gz
+layout: product_detail
+---

--- a/resource/sio/sio.md
+++ b/resource/sio/sio.md
@@ -19,7 +19,7 @@ domains:
 - information technology
 homepage_url: https://semanticscience.org/
 id: sio
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -132,6 +132,21 @@ products:
     source: dcat
   - relation_type: prov:wasInformedBy
     source: afo
+- id: sio.kg-bioportal
+  name: SIO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Semanticscience Integrated Ontology (SIO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains SIO_nodes.tsv
+    and SIO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SIO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: sio
+    relation_type: prov:hadPrimarySource
+  node_count: 1897
+  edge_count: 4185
+  latest_version: '1.61'
 publications:
 - authors:
   - Michel Dumontier

--- a/resource/slso/slso.kg-bioportal.md
+++ b/resource/slso/slso.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Space Life Sciences Ontology (SLSO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains SLSO_nodes.tsv
+  and SLSO_edges.tsv.
+edge_count: 8853
+format: kgx
+id: slso.kg-bioportal
+latest_version: '2025-12-11'
+name: SLSO KGX graph (KG-Bioportal)
+node_count: 6111
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: slso
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SLSO.tar.gz
+layout: product_detail
+---

--- a/resource/slso/slso.md
+++ b/resource/slso/slso.md
@@ -21,7 +21,7 @@ domains:
 - general
 homepage_url: https://github.com/nasa/LSDAO
 id: slso
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -49,6 +49,21 @@ products:
     source: slso
   product_file_size: 413238
   product_url: http://purl.obolibrary.org/obo/slso.obo
+- id: slso.kg-bioportal
+  name: SLSO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Space Life Sciences Ontology (SLSO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains SLSO_nodes.tsv
+    and SLSO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SLSO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: slso
+    relation_type: prov:hadPrimarySource
+  node_count: 6111
+  edge_count: 8853
+  latest_version: '2025-12-11'
 publications: []
 repository: https://github.com/nasa/LSDAO
 ---

--- a/resource/so/so.kg-bioportal.md
+++ b/resource/so/so.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Sequence Types and Features Ontology (SO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains SO_nodes.tsv
+  and SO_edges.tsv.
+edge_count: 3924
+format: kgx
+id: so.kg-bioportal
+latest_version: unknown
+name: SO KGX graph (KG-Bioportal)
+node_count: 2842
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: so
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SO.tar.gz
+layout: product_detail
+---

--- a/resource/so/so.md
+++ b/resource/so/so.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://www.sequenceontology.org/
 id: so
 infores_id: so
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -583,6 +583,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: so.kg-bioportal
+  name: SO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Sequence Types and Features Ontology (SO), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains SO_nodes.tsv
+    and SO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: so
+    relation_type: prov:hadPrimarySource
+  node_count: 2842
+  edge_count: 3924
+  latest_version: unknown
 publications:
 - authors:
   - Eilbeck K

--- a/resource/sopharm/sopharm.kg-bioportal.md
+++ b/resource/sopharm/sopharm.kg-bioportal.md
@@ -1,0 +1,20 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Suggested Ontology for Pharmacogenomics (SOPHARM),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains SOPHARM_nodes.tsv
+  and SOPHARM_edges.tsv.
+edge_count: 294
+format: kgx
+id: sopharm.kg-bioportal
+latest_version: 'Version: SO-Pharm 2.2
+
+  Release: 02 Mar 2017'
+name: SOPHARM KGX graph (KG-Bioportal)
+node_count: 232
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: sopharm
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOPHARM.tar.gz
+layout: product_detail
+---

--- a/resource/sopharm/sopharm.md
+++ b/resource/sopharm/sopharm.md
@@ -15,7 +15,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.loria.fr/~coulet/sopharm2.0_description.php
 id: sopharm
-last_modified_date: '2026-06-24T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -40,6 +40,23 @@ products:
   - relation_type: prov:hadPrimarySource
     source: sopharm
   product_url: https://bioportal.bioontology.org/ontologies/SOPHARM
+- id: sopharm.kg-bioportal
+  name: SOPHARM KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Suggested Ontology for Pharmacogenomics (SOPHARM),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains SOPHARM_nodes.tsv
+    and SOPHARM_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SOPHARM.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: sopharm
+    relation_type: prov:hadPrimarySource
+  node_count: 232
+  edge_count: 294
+  latest_version: 'Version: SO-Pharm 2.2
+
+    Release: 02 Mar 2017'
 publications: []
 taxon:
 - NCBITaxon:9606

--- a/resource/spd/spd.kg-bioportal.md
+++ b/resource/spd/spd.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Spider Anatomy Ontology (SPD), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains SPD_nodes.tsv and SPD_edges.tsv.
+edge_count: 1214
+format: kgx
+id: spd.kg-bioportal
+latest_version: '1.1'
+name: SPD KGX graph (KG-Bioportal)
+node_count: 853
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: spd
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SPD.tar.gz
+layout: product_detail
+---

--- a/resource/spd/spd.md
+++ b/resource/spd/spd.md
@@ -20,7 +20,7 @@ domains:
 - anatomy and development
 homepage_url: http://research.amnh.org/atol/files/
 id: spd
-last_modified_date: '2026-07-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -38,6 +38,20 @@ products:
   original_source:
   - source: spd
     relation_type: prov:hadPrimarySource
+- id: spd.kg-bioportal
+  name: SPD KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Spider Anatomy Ontology (SPD), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains SPD_nodes.tsv and SPD_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SPD.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: spd
+    relation_type: prov:hadPrimarySource
+  node_count: 853
+  edge_count: 1214
+  latest_version: '1.1'
 repository: https://github.com/obophenotype/spider-ontology
 taxon:
 - NCBITaxon:6893

--- a/resource/stato/stato.kg-bioportal.md
+++ b/resource/stato/stato.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Statistics Ontology (STATO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains STATO_nodes.tsv and STATO_edges.tsv.
+edge_count: 3999
+format: kgx
+id: stato.kg-bioportal
+latest_version: '2026-04-20'
+name: STATO KGX graph (KG-Bioportal)
+node_count: 1446
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: stato
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STATO.tar.gz
+layout: product_detail
+---

--- a/resource/stato/stato.md
+++ b/resource/stato/stato.md
@@ -25,7 +25,7 @@ domains:
 - information technology
 homepage_url: http://stato-ontology.org/
 id: stato
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -78,6 +78,20 @@ products:
     source: obi
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
+- id: stato.kg-bioportal
+  name: STATO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Statistics Ontology (STATO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains STATO_nodes.tsv and STATO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STATO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: stato
+    relation_type: prov:hadPrimarySource
+  node_count: 1446
+  edge_count: 3999
+  latest_version: '2026-04-20'
 publications:
 - authors:
   - Rocca-Serra P

--- a/resource/sty/sty.kg-bioportal.md
+++ b/resource/sty/sty.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Semantic Types Ontology (STY), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains STY_nodes.tsv and STY_edges.tsv.
+edge_count: 127
+format: kgx
+id: sty.kg-bioportal
+latest_version: 2025AB
+name: STY KGX graph (KG-Bioportal)
+node_count: 130
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: sty
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STY.tar.gz
+layout: product_detail
+---

--- a/resource/sty/sty.md
+++ b/resource/sty/sty.md
@@ -14,7 +14,7 @@ domains:
 - biomedical
 homepage_url: https://www.nlm.nih.gov/research/umls/knowledge_sources/semantic_network/index.html
 id: sty
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://lhncbc.nlm.nih.gov/semanticnetwork/
@@ -54,8 +54,6 @@ products:
     source: sty
   product_url: https://www.nlm.nih.gov/research/umls/knowledge_sources/semantic_network/SemGroups.txt
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
   - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
 - category: Product
@@ -70,6 +68,20 @@ products:
     source: sty
   product_file_size: 1583
   product_url: https://w3id.org/biopragmatics/resources/sty/sty.tsv
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Semantic Types Ontology (STY), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains STY_nodes.tsv and STY_edges.tsv.
+  edge_count: 127
+  format: kgx
+  id: sty.kg-bioportal
+  latest_version: 2025AB
+  name: STY KGX graph (KG-Bioportal)
+  node_count: 130
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: sty
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/STY.tar.gz
 publications:
 - authors:
   - McCray AT

--- a/resource/swo/swo.kg-bioportal.md
+++ b/resource/swo/swo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Software Ontology (SWO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains SWO_nodes.tsv and SWO_edges.tsv.
+edge_count: 5783
+format: kgx
+id: swo.kg-bioportal
+latest_version: '2023-03-05'
+name: SWO KGX graph (KG-Bioportal)
+node_count: 3542
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: swo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SWO.tar.gz
+layout: product_detail
+---

--- a/resource/swo/swo.md
+++ b/resource/swo/swo.md
@@ -22,7 +22,7 @@ domains:
 - information technology
 homepage_url: https://github.com/allysonlister/swo
 id: swo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -50,6 +50,20 @@ products:
   original_source:
   - source: swo
     relation_type: prov:hadPrimarySource
+- id: swo.kg-bioportal
+  name: SWO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Software Ontology (SWO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains SWO_nodes.tsv and SWO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SWO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: swo
+    relation_type: prov:hadPrimarySource
+  node_count: 3542
+  edge_count: 5783
+  latest_version: '2023-03-05'
 repository: https://github.com/allysonlister/swo
 publications:
 - authors:

--- a/resource/symp/symp.kg-bioportal.md
+++ b/resource/symp/symp.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Symptom Ontology (SYMP), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains SYMP_nodes.tsv and SYMP_edges.tsv.
+edge_count: 916
+format: kgx
+id: symp.kg-bioportal
+latest_version: '2024-05-17'
+name: SYMP KGX graph (KG-Bioportal)
+node_count: 1044
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: symp
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SYMP.tar.gz
+layout: product_detail
+---

--- a/resource/symp/symp.md
+++ b/resource/symp/symp.md
@@ -19,7 +19,7 @@ domains:
 homepage_url: https://github.com/DiseaseOntology/SymptomOntology
 id: symp
 infores_id: symp
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -47,6 +47,19 @@ products:
     original_source:
       - source: symp
         relation_type: prov:hadPrimarySource
+  - id: symp.kg-bioportal
+    name: SYMP KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Symptom Ontology (SYMP), produced by KG-Bioportal from the BioPortal submission. The archive contains SYMP_nodes.tsv and SYMP_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/SYMP.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: symp
+        relation_type: prov:hadPrimarySource
+    node_count: 1044
+    edge_count: 916
+    latest_version: '2024-05-17'
 repository: https://github.com/DiseaseOntology/SymptomOntology
 taxon:
   - NCBITaxon:9606

--- a/resource/t4fs/t4fs.kg-bioportal.md
+++ b/resource/t4fs/t4fs.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of terms4FAIRskills (T4FS), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains T4FS_nodes.tsv and T4FS_edges.tsv.
+edge_count: 768
+format: kgx
+id: t4fs.kg-bioportal
+latest_version: '2025-02-09'
+name: T4FS KGX graph (KG-Bioportal)
+node_count: 675
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: t4fs
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/T4FS.tar.gz
+layout: product_detail
+---

--- a/resource/t4fs/t4fs.md
+++ b/resource/t4fs/t4fs.md
@@ -20,7 +20,7 @@ domains:
 - information technology
 homepage_url: https://github.com/terms4fairskills/FAIRterminology
 id: t4fs
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -58,6 +58,20 @@ products:
     source: t4fs
   product_file_size: 74586
   product_url: http://purl.obolibrary.org/obo/t4fs.json
+- id: t4fs.kg-bioportal
+  name: T4FS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of terms4FAIRskills (T4FS), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains T4FS_nodes.tsv and T4FS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/T4FS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: t4fs
+    relation_type: prov:hadPrimarySource
+  node_count: 675
+  edge_count: 768
+  latest_version: '2025-02-09'
 publications:
 - authors:
   - Molloy, Laura

--- a/resource/tads/tads.kg-bioportal.md
+++ b/resource/tads/tads.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Tick Gross Anatomy Ontology (TADS), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains TADS_nodes.tsv
+  and TADS_edges.tsv.
+edge_count: 948
+format: kgx
+id: tads.kg-bioportal
+latest_version: '1.21'
+name: TADS KGX graph (KG-Bioportal)
+node_count: 644
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: tads
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TADS.tar.gz
+layout: product_detail
+---

--- a/resource/tads/tads.md
+++ b/resource/tads/tads.md
@@ -15,7 +15,7 @@ domains:
   - anatomy and development
 homepage_url: https://www.vectorbase.org/ontology-browser
 id: tads
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -43,6 +43,19 @@ products:
     original_source:
       - source: tads
         relation_type: prov:hadPrimarySource
+  - id: tads.kg-bioportal
+    name: TADS KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Tick Gross Anatomy Ontology (TADS), produced by KG-Bioportal from the BioPortal submission. The archive contains TADS_nodes.tsv and TADS_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TADS.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: tads
+        relation_type: prov:hadPrimarySource
+    node_count: 644
+    edge_count: 948
+    latest_version: '1.21'
 repository: https://github.com/VEuPathDB-ontology/TADS
 taxon:
   - NCBITaxon:6939

--- a/resource/tao/tao.kg-bioportal.md
+++ b/resource/tao/tao.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Teleost Anatomy Ontology (TAO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains TAO_nodes.tsv and TAO_edges.tsv.
+edge_count: 5423
+format: kgx
+id: tao.kg-bioportal
+latest_version: '2012-08-10'
+name: TAO KGX graph (KG-Bioportal)
+node_count: 3487
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: tao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TAO.tar.gz
+layout: product_detail
+---

--- a/resource/tao/tao.md
+++ b/resource/tao/tao.md
@@ -16,7 +16,7 @@ domains:
   - anatomy and development
 homepage_url: http://wiki.phenoscape.org/wiki/Teleost_Anatomy_Ontology
 id: tao
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -34,6 +34,19 @@ products:
     original_source:
       - source: tao
         relation_type: prov:hadPrimarySource
+  - id: tao.kg-bioportal
+    name: TAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Teleost Anatomy Ontology (TAO), produced by KG-Bioportal from the BioPortal submission. The archive contains TAO_nodes.tsv and TAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: tao
+        relation_type: prov:hadPrimarySource
+    node_count: 3487
+    edge_count: 5423
+    latest_version: '2012-08-10'
 taxon:
   - NCBITaxon:32443
 publications:
@@ -53,7 +66,7 @@ publications:
     title: 'The teleost anatomy ontology: anatomical representation for the genomics age'
     year: '2010'
 use_instead:
-- uberon
+  - uberon
 ---
 
 ## Description

--- a/resource/taxrank/taxrank.kg-bioportal.md
+++ b/resource/taxrank/taxrank.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Taxonomic Rank Vocabulary (TAXRANK), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains TAXRANK_nodes.tsv
+  and TAXRANK_edges.tsv.
+edge_count: 80
+format: kgx
+id: taxrank.kg-bioportal
+latest_version: unknown
+name: TAXRANK KGX graph (KG-Bioportal)
+node_count: 96
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: taxrank
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TAXRANK.tar.gz
+layout: product_detail
+---

--- a/resource/taxrank/taxrank.md
+++ b/resource/taxrank/taxrank.md
@@ -20,7 +20,7 @@ domains:
 - organisms
 homepage_url: https://github.com/phenoscape/taxrank
 id: taxrank
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -48,6 +48,21 @@ products:
   original_source:
   - source: taxrank
     relation_type: prov:hadPrimarySource
+- id: taxrank.kg-bioportal
+  name: TAXRANK KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Taxonomic Rank Vocabulary (TAXRANK), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains TAXRANK_nodes.tsv
+    and TAXRANK_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TAXRANK.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: taxrank
+    relation_type: prov:hadPrimarySource
+  node_count: 96
+  edge_count: 80
+  latest_version: unknown
 repository: https://github.com/phenoscape/taxrank
 publications:
 - authors:

--- a/resource/tgma/tgma.kg-bioportal.md
+++ b/resource/tgma/tgma.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Mosquito Gross Anatomy Ontology (TGMA), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains TGMA_nodes.tsv
+  and TGMA_edges.tsv.
+edge_count: 2733
+format: kgx
+id: tgma.kg-bioportal
+latest_version: releases/2013-06-03
+name: TGMA KGX graph (KG-Bioportal)
+node_count: 1887
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: tgma
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TGMA.tar.gz
+layout: product_detail
+---

--- a/resource/tgma/tgma.md
+++ b/resource/tgma/tgma.md
@@ -15,7 +15,7 @@ domains:
   - anatomy and development
 homepage_url: https://www.vectorbase.org/ontology-browser
 id: tgma
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -43,6 +43,19 @@ products:
     original_source:
       - source: tgma
         relation_type: prov:hadPrimarySource
+  - id: tgma.kg-bioportal
+    name: TGMA KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Mosquito Gross Anatomy Ontology (TGMA), produced by KG-Bioportal from the BioPortal submission. The archive contains TGMA_nodes.tsv and TGMA_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TGMA.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: tgma
+        relation_type: prov:hadPrimarySource
+    node_count: 1887
+    edge_count: 2733
+    latest_version: releases/2013-06-03
 repository: https://github.com/VEuPathDB-ontology/TGMA
 taxon:
   - NCBITaxon:44484

--- a/resource/to/to.kg-bioportal.md
+++ b/resource/to/to.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Plant Trait Ontology (PTO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains PTO_nodes.tsv and PTO_edges.tsv.
+edge_count: 1989
+format: kgx
+id: to.kg-bioportal
+latest_version: May 2025
+name: PTO KGX graph (KG-Bioportal)
+node_count: 1761
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: to
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PTO.tar.gz
+layout: product_detail
+---

--- a/resource/to/to.md
+++ b/resource/to/to.md
@@ -19,7 +19,7 @@ domains:
 - phenotype
 homepage_url: http://browser.planteome.org/amigo
 id: to
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -289,6 +289,20 @@ products:
   - relation_type: prov:hadPrimarySource
     source: rapdb
   product_url: https://github.com/Knowledge-Graph-Hub/eco-kg
+- id: to.kg-bioportal
+  name: PTO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Plant Trait Ontology (PTO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains PTO_nodes.tsv and PTO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PTO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: to
+    relation_type: prov:hadPrimarySource
+  node_count: 1761
+  edge_count: 1989
+  latest_version: May 2025
 publications:
 - authors:
   - Cooper L

--- a/resource/trans/trans.kg-bioportal.md
+++ b/resource/trans/trans.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Pathogen Transmission Ontology (PTRANS), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains PTRANS_nodes.tsv
+  and PTRANS_edges.tsv.
+edge_count: 33
+format: kgx
+id: trans.kg-bioportal
+latest_version: '2026-03-13'
+name: PTRANS KGX graph (KG-Bioportal)
+node_count: 53
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: trans
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PTRANS.tar.gz
+layout: product_detail
+---

--- a/resource/trans/trans.md
+++ b/resource/trans/trans.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://github.com/DiseaseOntology/PathogenTransmissionOntology
 id: trans
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: trans
         relation_type: prov:hadPrimarySource
+  - id: trans.kg-bioportal
+    name: PTRANS KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Pathogen Transmission Ontology (PTRANS), produced by KG-Bioportal from the BioPortal submission. The archive contains PTRANS_nodes.tsv and PTRANS_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/PTRANS.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: trans
+        relation_type: prov:hadPrimarySource
+    node_count: 53
+    edge_count: 33
+    latest_version: '2026-03-13'
 repository: https://github.com/DiseaseOntology/PathogenTransmissionOntology
 publications:
   - authors:

--- a/resource/tto/tto.kg-bioportal.md
+++ b/resource/tto/tto.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Teleost Taxonomy Ontology (TTO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains TTO_nodes.tsv and TTO_edges.tsv.
+edge_count: 77538
+format: kgx
+id: tto.kg-bioportal
+latest_version: unknown
+name: TTO KGX graph (KG-Bioportal)
+node_count: 38743
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: tto
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TTO.tar.gz
+layout: product_detail
+---

--- a/resource/tto/tto.md
+++ b/resource/tto/tto.md
@@ -19,7 +19,7 @@ domains:
 - organisms
 homepage_url: https://github.com/phenoscape/teleost-taxonomy-ontology
 id: tto
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/publicdomain/zero/1.0/
@@ -47,6 +47,20 @@ products:
   original_source:
   - source: tto
     relation_type: prov:hadPrimarySource
+- id: tto.kg-bioportal
+  name: TTO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Teleost Taxonomy Ontology (TTO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains TTO_nodes.tsv and TTO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TTO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: tto
+    relation_type: prov:hadPrimarySource
+  node_count: 38743
+  edge_count: 77538
+  latest_version: unknown
 repository: https://github.com/phenoscape/teleost-taxonomy-ontology
 taxon:
 - NCBITaxon:32443

--- a/resource/txpo/txpo.kg-bioportal.md
+++ b/resource/txpo/txpo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Toxic Process Ontology (TXPO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains TXPO_nodes.tsv and TXPO_edges.tsv.
+edge_count: 23316
+format: kgx
+id: txpo.kg-bioportal
+latest_version: 2022/12/07
+name: TXPO KGX graph (KG-Bioportal)
+node_count: 10304
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: txpo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TXPO.tar.gz
+layout: product_detail
+---

--- a/resource/txpo/txpo.md
+++ b/resource/txpo/txpo.md
@@ -19,7 +19,7 @@ domains:
 - chemistry and biochemistry
 homepage_url: https://toxpilot.nibiohn.go.jp/
 id: txpo
-last_modified_date: '2026-07-02T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/3.0/
@@ -37,6 +37,20 @@ products:
   original_source:
   - source: txpo
     relation_type: prov:hadPrimarySource
+- id: txpo.kg-bioportal
+  name: TXPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Toxic Process Ontology (TXPO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains TXPO_nodes.tsv and TXPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/TXPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: txpo
+    relation_type: prov:hadPrimarySource
+  node_count: 10304
+  edge_count: 23316
+  latest_version: 2022/12/07
 repository: https://github.com/txpo-ontology/TXPO
 publications:
 - authors:

--- a/resource/uberon/uberon.kg-bioportal.md
+++ b/resource/uberon/uberon.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Uber Anatomy Ontology (UBERON), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains UBERON_nodes.tsv and UBERON_edges.tsv.
+edge_count: 134094
+format: kgx
+id: uberon.kg-bioportal
+latest_version: '2023-07-25'
+name: UBERON KGX graph (KG-Bioportal)
+node_count: 31219
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: uberon
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UBERON.tar.gz
+layout: product_detail
+---

--- a/resource/uberon/uberon.md
+++ b/resource/uberon/uberon.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://uberon.org
 id: uberon
 infores_id: uberon
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -1508,8 +1508,8 @@ products:
   compatibility:
   - standard: biolink
   compression: zip
-  description: "Curated mechanistic drug\u2013disease paths comprising the DrugMechDB\
-    \ dataset packaged as a downloadable archive."
+  description: Curated mechanistic drug–disease paths comprising the DrugMechDB dataset
+    packaged as a downloadable archive.
   dump_format: other
   format: mixed
   id: drugmechdb.graph
@@ -3584,6 +3584,20 @@ products:
     source: uniprot
   - relation_type: prov:wasInfluencedBy
     source: wikipathways
+- id: uberon.kg-bioportal
+  name: UBERON KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Uber Anatomy Ontology (UBERON), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains UBERON_nodes.tsv and UBERON_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UBERON.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: uberon
+    relation_type: prov:hadPrimarySource
+  node_count: 31219
+  edge_count: 134094
+  latest_version: '2023-07-25'
 publications:
 - authors:
   - Mungall CJ

--- a/resource/uniprot/uniprot.kg-bioportal.md
+++ b/resource/uniprot/uniprot.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Uniprot Core Ontology (UNIPROT), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains UNIPROT_nodes.tsv and UNIPROT_edges.tsv.
+edge_count: 396
+format: kgx
+id: uniprot.kg-bioportal
+latest_version: v2012-10-03
+name: UNIPROT KGX graph (KG-Bioportal)
+node_count: 364
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: uniprot
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UNIPROT.tar.gz
+layout: product_detail
+---

--- a/resource/uniprot/uniprot.md
+++ b/resource/uniprot/uniprot.md
@@ -17,7 +17,7 @@ domains:
 homepage_url: https://www.uniprot.org/
 id: uniprot
 infores_id: uniprot
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -97,12 +97,10 @@ products:
     source: pombase
   product_url: https://www.pombase.org/data/names_and_identifiers/gene_IDs_names_products.tsv
   warnings:
-  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
-    header found
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
   - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
+  - File was not able to be retrieved when checked on 2026-03-30_ No Content-Length
+    header found
 - category: MappingProduct
   description: Tab-delimited file with the PomBase systematic identifier for each
     protein-coding gene mapped to the corresponding UniProt accession number
@@ -764,8 +762,8 @@ products:
   compatibility:
   - standard: biolink
   compression: zip
-  description: Curated mechanistic drug–disease paths comprising the DrugMechDB dataset
-    packaged as a downloadable archive.
+  description: "Curated mechanistic drug\u2013disease paths comprising the DrugMechDB\
+    \ dataset packaged as a downloadable archive."
   dump_format: other
   format: mixed
   id: drugmechdb.graph
@@ -3518,8 +3516,6 @@ products:
   - relation_type: prov:wasInformedBy
     source: uniprot
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: No Content-Length
-    header found'
   - 'File was not able to be retrieved when checked on 2026-08-06: No Content-Length
     header found'
 - category: Product
@@ -3654,14 +3650,12 @@ products:
   - relation_type: prov:wasDerivedFrom
     source: uniprot
   warnings:
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 500 error
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 500 error
     when accessing file'
   - 'File was not able to be retrieved when checked on 2026-06-27: HTTP 500 error
     when accessing file. The dbSNO 3.0 download page (download.php) renders its page
     shell but the server errors before emitting download links; the rest of the site
     (index.php, statistics.php) is live (200).'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 500 error
-    when accessing file'
 - category: GraphicalInterface
   description: neXtProt web platform for searching and browsing curated human protein
     entries, proteomics evidence, variants, expression, interactions, localization,
@@ -4672,14 +4666,12 @@ products:
     source: uniprot
   product_url: https://kghub.io/kg-covid-19/
   warnings:
+  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
+    when accessing file'
   - 'Download offline as of 2026-07-01: the KG-Hub reorganization has taken this file
     offline. The kghub.io and kg-hub.berkeleybop.io hosts return HTTP 404 for all
     kg-covid-19 artifacts (current and dated) and the kg-hub-public-data S3 objects
     return HTTP 403. No replacement public download URL is available.'
-  - 'File was not able to be retrieved when checked on 2026-07-30: HTTP 404 error
-    when accessing file'
-  - 'File was not able to be retrieved when checked on 2026-08-06: HTTP 404 error
-    when accessing file'
 - category: GraphProduct
   description: KGX nodes file for JensenLab DISEASES KG
   format: kgx-jsonl
@@ -5120,6 +5112,20 @@ products:
     source: wikidata
   - relation_type: prov:wasInfluencedBy
     source: wikipathways
+- category: GraphProduct
+  compression: targz
+  description: KGX TSV transform of Uniprot Core Ontology (UNIPROT), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains UNIPROT_nodes.tsv and UNIPROT_edges.tsv.
+  edge_count: 396
+  format: kgx
+  id: uniprot.kg-bioportal
+  latest_version: v2012-10-03
+  name: UNIPROT KGX graph (KG-Bioportal)
+  node_count: 364
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: uniprot
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UNIPROT.tar.gz
 publications:
 - authors:
   - Alex Bateman

--- a/resource/uo/uo.kg-bioportal.md
+++ b/resource/uo/uo.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Units of Measurement Ontology (UO), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains UO_nodes.tsv and
+  UO_edges.tsv.
+edge_count: 676
+format: kgx
+id: uo.kg-bioportal
+latest_version: '2026-07-31'
+name: UO KGX graph (KG-Bioportal)
+node_count: 587
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: uo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/UO.tar.gz
+layout: product_detail
+---

--- a/resource/uo/uo.md
+++ b/resource/uo/uo.md
@@ -19,7 +19,7 @@ domains:
 - phenotype
 homepage_url: https://github.com/bio-ontology-research-group/unit-ontology
 id: uo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -758,6 +758,21 @@ products:
     source: obi
   product_file_size: 642902930
   product_url: https://orkg.org/files/rdf-dumps/rdf-export-orkg.nt
+- id: uo.kg-bioportal
+  name: UO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Units of Measurement Ontology (UO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains UO_nodes.tsv
+    and UO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-6/UO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: uo
+    relation_type: prov:hadPrimarySource
+  node_count: 587
+  edge_count: 676
+  latest_version: '2026-07-31'
 publications:
 - authors:
   - Gkoutos GV

--- a/resource/upa/upa.kg-bioportal.md
+++ b/resource/upa/upa.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Unipathway (UPA), produced by KG-Bioportal from
+  the BioPortal submission. The archive contains UPA_nodes.tsv and UPA_edges.tsv.
+edge_count: 19767
+format: kgx
+id: upa.kg-bioportal
+latest_version: UniPathway Release 2015_03
+name: UPA KGX graph (KG-Bioportal)
+node_count: 4861
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: upa
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UPA.tar.gz
+layout: product_detail
+---

--- a/resource/upa/upa.md
+++ b/resource/upa/upa.md
@@ -18,7 +18,7 @@ domains:
   - biological systems
 homepage_url: https://github.com/geneontology/unipathway
 id: upa
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: upa
         relation_type: prov:hadPrimarySource
+  - id: upa.kg-bioportal
+    name: UPA KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Unipathway (UPA), produced by KG-Bioportal from the BioPortal submission. The archive contains UPA_nodes.tsv and UPA_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/UPA.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: upa
+        relation_type: prov:hadPrimarySource
+    node_count: 4861
+    edge_count: 19767
+    latest_version: UniPathway Release 2015_03
 repository: https://github.com/geneontology/unipathway
 publications:
   - authors:

--- a/resource/vario/vario.kg-bioportal.md
+++ b/resource/vario/vario.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Variation Ontology (VARIO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains VARIO_nodes.tsv and VARIO_edges.tsv.
+edge_count: 518
+format: kgx
+id: vario.kg-bioportal
+latest_version: '2018-11-09'
+name: VARIO KGX graph (KG-Bioportal)
+node_count: 532
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: vario
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VARIO.tar.gz
+layout: product_detail
+---

--- a/resource/vario/vario.md
+++ b/resource/vario/vario.md
@@ -18,7 +18,7 @@ domains:
   - biological systems
 homepage_url: http://variationontology.org
 id: vario
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -46,28 +46,41 @@ products:
     original_source:
       - source: vario
         relation_type: prov:hadPrimarySource
+  - id: vario.kg-bioportal
+    name: VARIO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Variation Ontology (VARIO), produced by KG-Bioportal from the BioPortal submission. The archive contains VARIO_nodes.tsv and VARIO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VARIO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: vario
+        relation_type: prov:hadPrimarySource
+    node_count: 532
+    edge_count: 518
+    latest_version: '2018-11-09'
 publications:
-- authors:
-  - Vihinen M
-  doi: 10.1101/gr.157495.113
-  id: https://www.ncbi.nlm.nih.gov/pubmed/24162187
-  journal: Genome Res
-  title: Variation Ontology for annotation of variation effects and mechanisms
-  year: '2014'
-- authors:
-  - Vihinen M
-  doi: 10.1186/2041-1480-5-9
-  id: https://www.ncbi.nlm.nih.gov/pubmed/24533660
-  journal: J Biomed Semantics
-  title: 'Variation ontology: annotator guide'
-  year: '2014'
-- authors:
-  - Vihinen M
-  doi: 10.1007/s00439-015-1529-6
-  id: https://www.ncbi.nlm.nih.gov/pubmed/25616435
-  journal: Hum Genet
-  title: Types and effects of protein variations
-  year: '2015'
+  - authors:
+      - Vihinen M
+    doi: 10.1101/gr.157495.113
+    id: https://www.ncbi.nlm.nih.gov/pubmed/24162187
+    journal: Genome Res
+    title: Variation Ontology for annotation of variation effects and mechanisms
+    year: '2014'
+  - authors:
+      - Vihinen M
+    doi: 10.1186/2041-1480-5-9
+    id: https://www.ncbi.nlm.nih.gov/pubmed/24533660
+    journal: J Biomed Semantics
+    title: 'Variation ontology: annotator guide'
+    year: '2014'
+  - authors:
+      - Vihinen M
+    doi: 10.1007/s00439-015-1529-6
+    id: https://www.ncbi.nlm.nih.gov/pubmed/25616435
+    journal: Hum Genet
+    title: Types and effects of protein variations
+    year: '2015'
 ---
 
 ## Description

--- a/resource/vbo/vbo.kg-bioportal.md
+++ b/resource/vbo/vbo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Vertebrate Breed Ontology (VBO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains VBO_nodes.tsv and VBO_edges.tsv.
+edge_count: 114284
+format: kgx
+id: vbo.kg-bioportal
+latest_version: '2026-04-15'
+name: VBO KGX graph (KG-Bioportal)
+node_count: 20885
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: vbo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VBO.tar.gz
+layout: product_detail
+---

--- a/resource/vbo/vbo.md
+++ b/resource/vbo/vbo.md
@@ -20,7 +20,7 @@ domains:
 - organisms
 homepage_url: https://github.com/monarch-initiative/vertebrate-breed-ontology
 id: vbo
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -88,6 +88,20 @@ products:
   original_source:
   - source: vbo
     relation_type: prov:hadPrimarySource
+- id: vbo.kg-bioportal
+  name: VBO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Vertebrate Breed Ontology (VBO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains VBO_nodes.tsv and VBO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VBO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: vbo
+    relation_type: prov:hadPrimarySource
+  node_count: 20885
+  edge_count: 114284
+  latest_version: '2026-04-15'
 repository: https://github.com/monarch-initiative/vertebrate-breed-ontology
 publications:
 - authors:

--- a/resource/vhog/vhog.kg-bioportal.md
+++ b/resource/vhog/vhog.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Vertebrate Homologous Organ Group Ontology (VHOG),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains VHOG_nodes.tsv
+  and VHOG_edges.tsv.
+edge_count: 1687
+format: kgx
+id: vhog.kg-bioportal
+latest_version: unknown
+name: VHOG KGX graph (KG-Bioportal)
+node_count: 1200
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: vhog
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VHOG.tar.gz
+layout: product_detail
+---

--- a/resource/vhog/vhog.md
+++ b/resource/vhog/vhog.md
@@ -9,7 +9,7 @@ description: Description unavailable.
 domains:
 - anatomy and development
 id: vhog
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -26,6 +26,21 @@ products:
     source: vhog
   product_url: http://purl.obolibrary.org/obo/vhog.owl
   warnings: []
+- id: vhog.kg-bioportal
+  name: VHOG KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Vertebrate Homologous Organ Group Ontology (VHOG),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains VHOG_nodes.tsv
+    and VHOG_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VHOG.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: vhog
+    relation_type: prov:hadPrimarySource
+  node_count: 1200
+  edge_count: 1687
+  latest_version: unknown
 publications: []
 use_instead:
 - uberon

--- a/resource/vo/vo.kg-bioportal.md
+++ b/resource/vo/vo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Vaccine Ontology (VO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains VO_nodes.tsv and VO_edges.tsv.
+edge_count: 105299
+format: kgx
+id: vo.kg-bioportal
+latest_version: '2026-06-12'
+name: VO KGX graph (KG-Bioportal)
+node_count: 15915
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: vo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VO.tar.gz
+layout: product_detail
+---

--- a/resource/vo/vo.md
+++ b/resource/vo/vo.md
@@ -18,7 +18,7 @@ domains:
 - biomedical
 homepage_url: https://violinet.org/vaccineontology
 id: vo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -236,6 +236,20 @@ products:
     source: wikipathways
   product_file_size: 18370248815
   product_url: https://rna-kg.biodata.di.unimi.it/edges.csv
+- id: vo.kg-bioportal
+  name: VO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Vaccine Ontology (VO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains VO_nodes.tsv and VO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: vo
+    relation_type: prov:hadPrimarySource
+  node_count: 15915
+  edge_count: 105299
+  latest_version: '2026-06-12'
 publications:
 - authors:
   - Lin Y

--- a/resource/vsao/vsao.kg-bioportal.md
+++ b/resource/vsao/vsao.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Vertebrate Skeletal Anatomy Ontology (VSAO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains VSAO_nodes.tsv
+  and VSAO_edges.tsv.
+edge_count: 438
+format: kgx
+id: vsao.kg-bioportal
+latest_version: '2012-11-06'
+name: VSAO KGX graph (KG-Bioportal)
+node_count: 358
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: vsao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VSAO.tar.gz
+layout: product_detail
+---

--- a/resource/vsao/vsao.md
+++ b/resource/vsao/vsao.md
@@ -16,7 +16,7 @@ domains:
   - anatomy and development
 homepage_url: https://www.nescent.org/phenoscape/Main_Page
 id: vsao
-last_modified_date: '2026-04-16T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
@@ -33,11 +33,24 @@ products:
     original_source:
       - source: vsao
         relation_type: prov:hadPrimarySource
+  - id: vsao.kg-bioportal
+    name: VSAO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Vertebrate Skeletal Anatomy Ontology (VSAO), produced by KG-Bioportal from the BioPortal submission. The archive contains VSAO_nodes.tsv and VSAO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VSAO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: vsao
+        relation_type: prov:hadPrimarySource
+    node_count: 358
+    edge_count: 438
+    latest_version: '2012-11-06'
 taxon:
   - NCBITaxon:7742
 publications: []
 use_instead:
-- uberon
+  - uberon
 ---
 
 ## Description

--- a/resource/vt/vt.kg-bioportal.md
+++ b/resource/vt/vt.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Vertebrate Trait Ontology (VT), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains VT_nodes.tsv and VT_edges.tsv.
+edge_count: 4953
+format: kgx
+id: vt.kg-bioportal
+latest_version: '2026-07-23'
+name: VT KGX graph (KG-Bioportal)
+node_count: 4116
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: vt
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VT.tar.gz
+layout: product_detail
+---

--- a/resource/vt/vt.md
+++ b/resource/vt/vt.md
@@ -19,7 +19,7 @@ domains:
 - phenotype
 homepage_url: https://github.com/AnimalGenome/vertebrate-trait-ontology
 id: vt
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -37,6 +37,20 @@ products:
   original_source:
   - source: vt
     relation_type: prov:hadPrimarySource
+- id: vt.kg-bioportal
+  name: VT KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Vertebrate Trait Ontology (VT), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains VT_nodes.tsv and VT_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/VT.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: vt
+    relation_type: prov:hadPrimarySource
+  node_count: 4116
+  edge_count: 4953
+  latest_version: '2026-07-23'
 publications:
 - authors:
   - Carissa A Park

--- a/resource/wikipathways/wikipathways.kg-bioportal.md
+++ b/resource/wikipathways/wikipathways.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of WikiPathways (WIKIPATHWAYS), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains WIKIPATHWAYS_nodes.tsv and WIKIPATHWAYS_edges.tsv.
+edge_count: 95
+format: kgx
+id: wikipathways.kg-bioportal
+latest_version: 2013a
+name: WIKIPATHWAYS KGX graph (KG-Bioportal)
+node_count: 65
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: wikipathways
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WIKIPATHWAYS.tar.gz
+layout: product_detail
+---

--- a/resource/wikipathways/wikipathways.md
+++ b/resource/wikipathways/wikipathways.md
@@ -36,7 +36,7 @@ fairsharing_id: FAIRsharing.1x53qk
 homepage_url: https://www.wikipathways.org/
 id: wikipathways
 infores_id: wikipathways
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/share-your-work/public-domain/cc0/
@@ -3026,6 +3026,21 @@ products:
     source: wikidata
   - relation_type: prov:wasInfluencedBy
     source: wikipathways
+- id: wikipathways.kg-bioportal
+  name: WIKIPATHWAYS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of WikiPathways (WIKIPATHWAYS), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains WIKIPATHWAYS_nodes.tsv and
+    WIKIPATHWAYS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/WIKIPATHWAYS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: wikipathways
+    relation_type: prov:hadPrimarySource
+  node_count: 65
+  edge_count: 95
+  latest_version: 2013a
 publications:
 - authors:
   - Agrawal A

--- a/resource/xao/xao.kg-bioportal.md
+++ b/resource/xao/xao.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Xenopus Anatomy Ontology (XAO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains XAO_nodes.tsv and XAO_edges.tsv.
+edge_count: 7240
+format: kgx
+id: xao.kg-bioportal
+latest_version: releases/2024-09-03
+name: XAO KGX graph (KG-Bioportal)
+node_count: 1891
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: xao
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XAO.tar.gz
+layout: product_detail
+---

--- a/resource/xao/xao.md
+++ b/resource/xao/xao.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: http://www.xenbase.org/anatomy/xao.do?method=display
 id: xao
 infores_id: xao
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -198,6 +198,20 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: xao.kg-bioportal
+  name: XAO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Xenopus Anatomy Ontology (XAO), produced by KG-Bioportal
+    from the BioPortal submission. The archive contains XAO_nodes.tsv and XAO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XAO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: xao
+    relation_type: prov:hadPrimarySource
+  node_count: 1891
+  edge_count: 7240
+  latest_version: releases/2024-09-03
 publications:
 - authors:
   - Segerdell E

--- a/resource/xco/xco.kg-bioportal.md
+++ b/resource/xco/xco.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Experimental Conditions Ontology (XCO), produced
+  by KG-Bioportal from the BioPortal submission. The archive contains XCO_nodes.tsv
+  and XCO_edges.tsv.
+edge_count: 2514
+format: kgx
+id: xco.kg-bioportal
+latest_version: '2026-07-29'
+name: XCO KGX graph (KG-Bioportal)
+node_count: 1896
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: xco
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XCO.tar.gz
+layout: product_detail
+---

--- a/resource/xco/xco.md
+++ b/resource/xco/xco.md
@@ -18,7 +18,7 @@ domains:
   - biomedical
 homepage_url: https://rgd.mcw.edu/rgdweb/ontology/view.html?acc_id=XCO:0000000
 id: xco
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: xco
         relation_type: prov:hadPrimarySource
+  - id: xco.kg-bioportal
+    name: XCO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Experimental Conditions Ontology (XCO), produced by KG-Bioportal from the BioPortal submission. The archive contains XCO_nodes.tsv and XCO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XCO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: xco
+        relation_type: prov:hadPrimarySource
+    node_count: 1896
+    edge_count: 2514
+    latest_version: '2026-07-29'
 repository: https://github.com/rat-genome-database/XCO-experimental-condition-ontology
 publications:
   - authors:

--- a/resource/xlmod/xlmod.kg-bioportal.md
+++ b/resource/xlmod/xlmod.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of mass spectrometry cross-linking and derivatization
+  reagents (XLMOD), produced by KG-Bioportal from the BioPortal submission. The archive
+  contains XLMOD_nodes.tsv and XLMOD_edges.tsv.
+edge_count: 2970
+format: kgx
+id: xlmod.kg-bioportal
+latest_version: release/2019-10-28
+name: XLMOD KGX graph (KG-Bioportal)
+node_count: 1149
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: xlmod
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XLMOD.tar.gz
+layout: product_detail
+---

--- a/resource/xlmod/xlmod.md
+++ b/resource/xlmod/xlmod.md
@@ -18,7 +18,7 @@ domains:
   - chemistry and biochemistry
 homepage_url: http://www.psidev.info/groups/controlled-vocabularies
 id: "xlmod"
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: "https://creativecommons.org/licenses/by/3.0/"
@@ -46,6 +46,19 @@ products:
     original_source:
       - source: xlmod
         relation_type: prov:hadPrimarySource
+  - id: xlmod.kg-bioportal
+    name: XLMOD KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of mass spectrometry cross-linking and derivatization reagents (XLMOD), produced by KG-Bioportal from the BioPortal submission. The archive contains XLMOD_nodes.tsv and XLMOD_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XLMOD.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: xlmod
+        relation_type: prov:hadPrimarySource
+    node_count: 1149
+    edge_count: 2970
+    latest_version: release/2019-10-28
 repository: https://github.com/HUPO-PSI/xlmod-CV
 publications:
   - authors:

--- a/resource/xpo/xpo.kg-bioportal.md
+++ b/resource/xpo/xpo.kg-bioportal.md
@@ -1,0 +1,17 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Xenopus Phenotype Ontology (XPO), produced by KG-Bioportal
+  from the BioPortal submission. The archive contains XPO_nodes.tsv and XPO_edges.tsv.
+edge_count: 87933
+format: kgx
+id: xpo.kg-bioportal
+latest_version: '2025-07-25'
+name: XPO KGX graph (KG-Bioportal)
+node_count: 52063
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: xpo
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XPO.tar.gz
+layout: product_detail
+---

--- a/resource/xpo/xpo.md
+++ b/resource/xpo/xpo.md
@@ -21,7 +21,7 @@ domains:
 homepage_url: https://github.com/obophenotype/xenopus-phenotype-ontology
 id: xpo
 infores_id: xpo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -199,6 +199,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: xpo.kg-bioportal
+  name: XPO KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Xenopus Phenotype Ontology (XPO), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains XPO_nodes.tsv
+    and XPO_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/XPO.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: xpo
+    relation_type: prov:hadPrimarySource
+  node_count: 52063
+  edge_count: 87933
+  latest_version: '2025-07-25'
 publications:
 - authors:
   - Fisher ME

--- a/resource/zea/zea.kg-bioportal.md
+++ b/resource/zea/zea.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Maize Gross Anatomy Ontology (ZEA), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains ZEA_nodes.tsv and
+  ZEA_edges.tsv.
+edge_count: 217
+format: kgx
+id: zea.kg-bioportal
+latest_version: '1.2'
+name: ZEA KGX graph (KG-Bioportal)
+node_count: 195
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: zea
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZEA.tar.gz
+layout: product_detail
+---

--- a/resource/zea/zea.md
+++ b/resource/zea/zea.md
@@ -16,13 +16,28 @@ domains:
 - anatomy and development
 homepage_url: http://www.maizemap.org/
 id: zea
-last_modified_date: '2026-07-03T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: ''
   label: Not specified
 name: Maize gross anatomy
-products: []
+products:
+- id: zea.kg-bioportal
+  name: ZEA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Maize Gross Anatomy Ontology (ZEA), produced by
+    KG-Bioportal from the BioPortal submission. The archive contains ZEA_nodes.tsv
+    and ZEA_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZEA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: zea
+    relation_type: prov:hadPrimarySource
+  node_count: 195
+  edge_count: 217
+  latest_version: '1.2'
 publications: []
 taxon:
 - NCBITaxon:4575

--- a/resource/zeco/zeco.kg-bioportal.md
+++ b/resource/zeco/zeco.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Zebrafish Experimental Conditions Ontology (ZECO),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains ZECO_nodes.tsv
+  and ZECO_edges.tsv.
+edge_count: 222
+format: kgx
+id: zeco.kg-bioportal
+latest_version: '2022-02-14'
+name: ZECO KGX graph (KG-Bioportal)
+node_count: 220
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: zeco
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZECO.tar.gz
+layout: product_detail
+---

--- a/resource/zeco/zeco.md
+++ b/resource/zeco/zeco.md
@@ -18,7 +18,7 @@ domains:
   - environment
 homepage_url: https://github.com/ybradford/zebrafish-experimental-conditions-ontology
 id: zeco
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -56,6 +56,19 @@ products:
     original_source:
       - source: zeco
         relation_type: prov:hadPrimarySource
+  - id: zeco.kg-bioportal
+    name: ZECO KGX graph (KG-Bioportal)
+    category: GraphProduct
+    description: KGX TSV transform of Zebrafish Experimental Conditions Ontology (ZECO), produced by KG-Bioportal from the BioPortal submission. The archive contains ZECO_nodes.tsv and ZECO_edges.tsv.
+    product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZECO.tar.gz
+    format: kgx
+    compression: targz
+    original_source:
+      - source: zeco
+        relation_type: prov:hadPrimarySource
+    node_count: 220
+    edge_count: 222
+    latest_version: '2022-02-14'
 repository: https://github.com/ybradford/zebrafish-experimental-conditions-ontology
 taxon:
   - NCBITaxon:7954

--- a/resource/zfa/zfa.kg-bioportal.md
+++ b/resource/zfa/zfa.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Zebrafish Anatomy and Development Ontology (ZFA),
+  produced by KG-Bioportal from the BioPortal submission. The archive contains ZFA_nodes.tsv
+  and ZFA_edges.tsv.
+edge_count: 13190
+format: kgx
+id: zfa.kg-bioportal
+latest_version: '2026-07-16'
+name: ZFA KGX graph (KG-Bioportal)
+node_count: 3341
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: zfa
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZFA.tar.gz
+layout: product_detail
+---

--- a/resource/zfa/zfa.md
+++ b/resource/zfa/zfa.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources
 id: zfa
 infores_id: zfa
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -386,6 +386,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: zfa.kg-bioportal
+  name: ZFA KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Zebrafish Anatomy and Development Ontology (ZFA),
+    produced by KG-Bioportal from the BioPortal submission. The archive contains ZFA_nodes.tsv
+    and ZFA_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZFA.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: zfa
+    relation_type: prov:hadPrimarySource
+  node_count: 3341
+  edge_count: 13190
+  latest_version: '2026-07-16'
 publications:
 - authors:
   - Van Slyke CE

--- a/resource/zfs/zfs.kg-bioportal.md
+++ b/resource/zfs/zfs.kg-bioportal.md
@@ -1,0 +1,18 @@
+---
+category: GraphProduct
+compression: targz
+description: KGX TSV transform of Zebrafish Developmental Stages (ZFS), produced by
+  KG-Bioportal from the BioPortal submission. The archive contains ZFS_nodes.tsv and
+  ZFS_edges.tsv.
+edge_count: 13189
+format: kgx
+id: zfs.kg-bioportal
+latest_version: '2026-07-16'
+name: ZFS KGX graph (KG-Bioportal)
+node_count: 3340
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: zfs
+product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZFS.tar.gz
+layout: product_detail
+---

--- a/resource/zfs/zfs.md
+++ b/resource/zfs/zfs.md
@@ -19,7 +19,7 @@ domains:
 homepage_url: https://wiki.zfin.org/display/general/Anatomy+Atlases+and+Resources
 id: zfs
 infores_id: zfs
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-08-06T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/
@@ -197,6 +197,21 @@ products:
     source: phenopacket-store
   product_file_size: 230046094
   product_url: https://data.monarchinitiative.org/monarch-kg-dev/latest/monarch-kg.tar.gz
+- id: zfs.kg-bioportal
+  name: ZFS KGX graph (KG-Bioportal)
+  category: GraphProduct
+  description: KGX TSV transform of Zebrafish Developmental Stages (ZFS), produced
+    by KG-Bioportal from the BioPortal submission. The archive contains ZFS_nodes.tsv
+    and ZFS_edges.tsv.
+  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.07/ZFS.tar.gz
+  format: kgx
+  compression: targz
+  original_source:
+  - source: zfs
+    relation_type: prov:hadPrimarySource
+  node_count: 3340
+  edge_count: 13189
+  latest_version: '2026-07-16'
 publications: []
 repository: https://github.com/cerivs/zebrafish-anatomical-ontology
 taxon:

--- a/tests/test_kg_bioportal_sync.py
+++ b/tests/test_kg_bioportal_sync.py
@@ -1,0 +1,389 @@
+"""Tests for KG-Bioportal transform sync behavior."""
+
+import textwrap
+
+import frontmatter
+import pytest
+import yaml
+
+from util.sync_kg_bioportal import KGBioportalSync, name_similarity
+
+FLUSH_PAGE = """\
+---
+id: agro
+name: Agronomy Ontology
+category: Ontology
+domains:
+- agriculture
+last_modified_date: '2026-01-01T00:00:00Z'
+products:
+- id: agro.owl
+  name: AgrO
+  category: OntologyProduct
+  product_url: http://purl.obolibrary.org/obo/agro.owl
+---
+## Description
+
+Agronomy.
+"""
+
+INDENTED_PAGE = """\
+---
+id: zeco
+name: Zebrafish Experimental Conditions Ontology
+category: Ontology
+domains:
+  - environment
+last_modified_date: '2026-01-01T00:00:00Z'
+products:
+  - id: zeco.owl
+    name: zeco.owl
+    category: OntologyProduct
+    product_url: http://purl.obolibrary.org/obo/zeco.owl
+---
+## Description
+
+Zebrafish.
+"""
+
+SYNC_MAP = """\
+confirmed:
+  OBOREL: ro
+  MISSINGTARGET: nonexistent
+rejected:
+  - RO
+"""
+
+
+def write_page(registry_root, resource_id, text):
+    resource_dir = registry_root / resource_id
+    resource_dir.mkdir(parents=True, exist_ok=True)
+    page = resource_dir / f"{resource_id}.md"
+    page.write_text(textwrap.dedent(text), encoding="utf-8")
+    return page
+
+
+@pytest.fixture
+def syncer(tmp_path):
+    registry_root = tmp_path / "resource"
+    write_page(registry_root, "agro", FLUSH_PAGE)
+    write_page(registry_root, "zeco", INDENTED_PAGE)
+    write_page(
+        registry_root,
+        "ro",
+        "---\nid: ro\nname: Relation Ontology\ncategory: Ontology\n---\nRO.\n",
+    )
+    map_path = tmp_path / "sync_map.yaml"
+    map_path.write_text(SYNC_MAP, encoding="utf-8")
+    return KGBioportalSync(
+        registry_root=str(registry_root),
+        map_path=str(map_path),
+        report_path=str(tmp_path / "report.tsv"),
+    )
+
+
+@pytest.fixture
+def agro_entry():
+    return {
+        "id": "AGRO",
+        "status": "OK",
+        "reason": "",
+        "name": "AGRonomy Ontology",
+        "version": "2026-01-01",
+        "nodecount": 5102,
+        "edgecount": 8691,
+        "submission_id": "12",
+        "download_url": "https://example.org/releases/data-2026.07/AGRO.tar.gz",
+    }
+
+
+# --------------------------------------------------------------------- matching
+
+
+def test_name_similarity_accepts_reworded_names_and_rejects_collisions():
+    # Genuine matches that read very differently.
+    assert name_similarity("Uber Anatomy Ontology", "Uberon multi-species anatomy ontology") > 0.3
+    assert name_similarity("Relations Ontology", "Relation Ontology") > 0.3
+    assert name_similarity("Microarray and Gene Expression Data Ontology",
+                           "Microarray experimental conditions") > 0.3
+    # Acronym collisions in the live manifest.
+    assert name_similarity("Radiomics Ontology", "Relation Ontology") == 0.0
+    assert name_similarity("Atlas Ontology Model", "ATOM") == 0.0
+    assert name_similarity("PatientSafetyOntology", "Plant Stress Ontology") == 0.0
+    # phenotypic/phenotype falls just under the per-token threshold, which is why
+    # PATO is carried in the sync map rather than matched automatically.
+    assert name_similarity("Phenotypic Quality Ontology", "Phenotype And Trait Ontology") == 0.0
+
+
+def test_acronym_match_requires_similar_names(syncer, agro_entry):
+    assert syncer.resolve_match(agro_entry) == ("agro", "acronym")
+
+    collision = dict(agro_entry, id="ZECO", name="Zone Enforcement Compliance Ontology")
+    assert syncer.resolve_match(collision) == (None, "name_mismatch")
+
+
+def test_confirmed_map_entry_overrides_acronym(syncer, agro_entry):
+    # OBOREL is not a resource id, but the map points it at ro.
+    assert syncer.resolve_match(dict(agro_entry, id="OBOREL", name="Relations Ontology")) == (
+        "ro",
+        "confirmed",
+    )
+
+
+def test_rejected_acronym_is_never_written(syncer, agro_entry):
+    # RO would otherwise match the ro resource outright.
+    assert syncer.resolve_match(dict(agro_entry, id="RO", name="Relation Ontology")) == (
+        None,
+        "rejected",
+    )
+
+
+def test_confirmed_map_entry_pointing_at_a_missing_resource_is_reported(syncer, agro_entry):
+    assert syncer.resolve_match(dict(agro_entry, id="MISSINGTARGET")) == (
+        None,
+        "confirmed_missing",
+    )
+
+
+def test_entry_without_a_matching_resource_is_skipped(syncer, agro_entry):
+    assert syncer.resolve_match(dict(agro_entry, id="NOSUCHTHING")) == (None, "no_resource")
+
+
+def test_failed_entry_skips_the_name_check(syncer, agro_entry):
+    """Skiplist entries carry no name, but must still be able to remove a product."""
+    entry = dict(agro_entry, status="Skipped", reason="too_large", name="")
+    assert syncer.resolve_match(entry) == ("agro", "acronym")
+
+
+def test_successful_transform_wins_over_a_failed_duplicate(syncer, agro_entry):
+    failed = dict(agro_entry, id="AGRO2", status="Failed")
+    resolutions = [(failed, "agro", "acronym"), (agro_entry, "agro", "acronym")]
+    assert syncer.pick_winners(resolutions) == [(agro_entry, "agro")]
+
+
+def test_curated_match_wins_over_a_heuristic_duplicate(syncer, agro_entry):
+    heuristic = dict(agro_entry, id="ZAGRO")
+    resolutions = [(heuristic, "agro", "acronym"), (agro_entry, "agro", "confirmed")]
+    assert syncer.pick_winners(resolutions) == [(agro_entry, "agro")]
+
+
+# --------------------------------------------------------------------- products
+
+
+def test_build_product_shape(syncer, agro_entry):
+    product = syncer.build_product(agro_entry, "agro")
+
+    assert product["id"] == "agro.kg-bioportal"
+    assert product["name"] == "AGRO KGX graph (KG-Bioportal)"
+    assert product["category"] == "GraphProduct"
+    assert product["product_url"] == agro_entry["download_url"]
+    assert product["format"] == "kgx"
+    assert product["compression"] == "targz"
+    assert product["node_count"] == 5102
+    assert product["edge_count"] == 8691
+    assert product["latest_version"] == "2026-01-01"
+    assert product["original_source"] == [
+        {"source": "agro", "relation_type": "prov:hadPrimarySource"}
+    ]
+    # Naming the aggregator here would make propagate_products copy every
+    # transform onto the kg-bioportal page.
+    assert "kg-bioportal" not in [
+        association["source"] for association in product["original_source"]
+    ]
+    assert "secondary_source" not in product
+
+
+def test_build_product_drops_placeholder_version(syncer, agro_entry):
+    assert "latest_version" not in syncer.build_product(dict(agro_entry, version="NA"), "agro")
+
+
+def test_merge_preserves_curated_fields_and_reports_no_change_on_rerun(syncer, agro_entry):
+    product = syncer.build_product(agro_entry, "agro")
+    products = [dict(product, product_file_size=1234, warnings=["curated"])]
+
+    assert syncer.merge_product(products, syncer.build_product(agro_entry, "agro")) is False
+    assert products[0]["product_file_size"] == 1234
+    assert products[0]["warnings"] == ["curated"]
+
+
+def test_merge_drops_file_size_when_the_release_asset_moves(syncer, agro_entry):
+    products = [dict(syncer.build_product(agro_entry, "agro"), product_file_size=1234)]
+    moved = dict(agro_entry, download_url="https://example.org/releases/data-2026.08/AGRO.tar.gz")
+
+    assert syncer.merge_product(products, syncer.build_product(moved, "agro")) is True
+    assert "product_file_size" not in products[0]
+    assert products[0]["product_url"] == moved["download_url"]
+
+
+def test_merge_clears_a_managed_field_that_disappeared(syncer, agro_entry):
+    products = [syncer.build_product(agro_entry, "agro")]
+    unversioned = dict(agro_entry, version="NA")
+
+    assert syncer.merge_product(products, syncer.build_product(unversioned, "agro")) is True
+    assert "latest_version" not in products[0]
+
+
+def test_merge_leaves_other_products_alone(syncer, agro_entry):
+    products = [{"id": "agro.owl", "name": "AgrO"}]
+
+    assert syncer.merge_product(products, syncer.build_product(agro_entry, "agro")) is True
+    assert [product["id"] for product in products] == ["agro.owl", "agro.kg-bioportal"]
+
+
+def test_remove_product_only_touches_the_synced_id(syncer):
+    products = [{"id": "agro.owl"}, {"id": "agro.kg-bioportal"}]
+
+    assert syncer.remove_product(products, "agro.kg-bioportal") is True
+    assert [product["id"] for product in products] == ["agro.owl"]
+    assert syncer.remove_product(products, "agro.kg-bioportal") is False
+
+
+# ------------------------------------------------------------------------ pages
+
+
+def test_apply_entry_adds_updates_then_removes(syncer, agro_entry):
+    page = syncer.resource_file("agro")
+
+    assert syncer.apply_entry(agro_entry, "agro", dry_run=False) == "added"
+    metadata = frontmatter.load(page).metadata
+    product = next(p for p in metadata["products"] if p["id"] == "agro.kg-bioportal")
+    assert product["node_count"] == 5102
+    assert metadata["last_modified_date"] != "2026-01-01T00:00:00Z"
+    # The page's own product is untouched.
+    assert metadata["products"][0]["id"] == "agro.owl"
+
+    assert syncer.apply_entry(agro_entry, "agro", dry_run=False) == "skipped"
+
+    grown = dict(agro_entry, nodecount=6000)
+    assert syncer.apply_entry(grown, "agro", dry_run=False) == "updated"
+    metadata = frontmatter.load(page).metadata
+    product = next(p for p in metadata["products"] if p["id"] == "agro.kg-bioportal")
+    assert product["node_count"] == 6000
+
+    failed = dict(agro_entry, status="Failed", reason="transform_error")
+    assert syncer.apply_entry(failed, "agro", dry_run=False) == "removed"
+    metadata = frontmatter.load(page).metadata
+    assert [p["id"] for p in metadata["products"]] == ["agro.owl"]
+
+
+def test_apply_entry_dry_run_writes_nothing(syncer, agro_entry):
+    page = syncer.resource_file("agro")
+    before = page.read_text(encoding="utf-8")
+
+    assert syncer.apply_entry(agro_entry, "agro", dry_run=True) == "added"
+    assert page.read_text(encoding="utf-8") == before
+
+
+def test_failed_entry_on_an_untouched_page_is_a_no_op(syncer, agro_entry):
+    page = syncer.resource_file("agro")
+    before = page.read_text(encoding="utf-8")
+
+    failed = dict(agro_entry, status="Failed", reason="transform_error")
+    assert syncer.apply_entry(failed, "agro", dry_run=False) == "skipped"
+    assert page.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.parametrize(
+    ("resource_id", "expected_style", "expected_marker"),
+    [("agro", "flush", "\n- id: agro.kg-bioportal"), ("zeco", "indented", "\n  - id: zeco.")],
+)
+def test_page_style_is_preserved(syncer, agro_entry, resource_id, expected_style, expected_marker):
+    page = syncer.resource_file(resource_id)
+    assert syncer.page_style(page) == expected_style
+
+    entry = dict(agro_entry, id=resource_id.upper())
+    syncer.apply_entry(entry, resource_id, dry_run=False)
+
+    text = page.read_text(encoding="utf-8")
+    assert expected_marker in text
+    assert syncer.page_style(page) == expected_style
+
+
+def test_page_style_uses_the_majority_when_a_page_mixes_both(tmp_path):
+    page = tmp_path / "mixed.md"
+    page.write_text(
+        "---\n"
+        "id: mixed\n"
+        "domains:\n"
+        "  - agriculture\n"
+        "contacts:\n"
+        "  - category: Individual\n"
+        "publications:\n"
+        "- title: Flush\n"
+        "---\n"
+        "- a body bullet\n"
+        "- another body bullet\n",
+        encoding="utf-8",
+    )
+    assert KGBioportalSync.page_style(page) == "indented"
+
+
+def test_markdown_body_is_preserved(syncer, agro_entry):
+    page = syncer.resource_file("agro")
+    syncer.apply_entry(agro_entry, "agro", dry_run=False)
+    assert "Agronomy." in page.read_text(encoding="utf-8")
+
+
+# ----------------------------------------------------------------------- report
+
+
+def test_sync_all_reports_entries_a_curator_could_resolve(syncer, agro_entry, monkeypatch):
+    entries = [
+        agro_entry,
+        # OK, acronym matches a resource, but the names disagree.
+        {
+            "id": "ZECO",
+            "status": "OK",
+            "name": "Zone Enforcement Compliance Ontology",
+            "download_url": "https://example.org/ZECO.tar.gz",
+        },
+        # OK, no resource by that acronym, but the name matches one exactly.
+        {
+            "id": "OBOREL2",
+            "status": "OK",
+            "name": "Relation Ontology",
+            "download_url": "https://example.org/OBOREL2.tar.gz",
+        },
+        # OK, and nothing in the registry resembles it -- not worth reporting.
+        {
+            "id": "UNRELATED",
+            "status": "OK",
+            "name": "Some Other Ontology",
+            "download_url": "https://example.org/UNRELATED.tar.gz",
+        },
+    ]
+    monkeypatch.setattr(
+        syncer, "fetch_manifest", lambda: {"ontologies": entries, "totals": {}}
+    )
+
+    stats = syncer.sync_all()
+
+    assert stats["added"] == 1
+    assert stats["unmatched"] == 2
+    rows = syncer.report_path.read_text(encoding="utf-8").strip().splitlines()
+    assert rows[0].split("\t") == [
+        "acronym",
+        "kg_bioportal_name",
+        "reason",
+        "suggested_resource",
+    ]
+    reported = {row.split("\t")[0]: row.split("\t") for row in rows[1:]}
+    assert set(reported) == {"ZECO", "OBOREL2"}
+    assert reported["OBOREL2"][3] == "ro"
+
+
+# ------------------------------------------------------------------- sync map
+
+
+def test_shipped_sync_map_is_internally_consistent():
+    """The map must not both confirm and reject an acronym, or point nowhere."""
+    syncer = KGBioportalSync()
+    with open(syncer.map_path, encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+
+    confirmed = {str(key).upper() for key in data.get("confirmed") or {}}
+    rejected = {str(value).upper() for value in data.get("rejected") or []}
+    assert not confirmed & rejected
+
+    for acronym, resource_id in (data.get("confirmed") or {}).items():
+        assert resource_id in syncer.resource_names, f"{acronym} points at missing {resource_id}"

--- a/util/kg_bioportal_sync_map.yaml
+++ b/util/kg_bioportal_sync_map.yaml
@@ -1,0 +1,64 @@
+# KG-Bioportal sync: curated acronym-to-resource decisions
+#
+# util/sync_kg_bioportal.py adds a KGX GraphProduct to a KG-Registry resource for
+# each ontology KG-Bioportal successfully transformed. It matches a BioPortal
+# acronym to a resource by lowercasing the acronym, but only accepts that match
+# when the two names are similar enough to rule out a collision.
+#
+# This file records the decisions that heuristic cannot make on its own. Entries
+# the sync could not resolve are written to reports/kg_bioportal_unmatched.tsv
+# after every run, with a suggested resource where one exists -- that report is
+# the worklist for adding to this file.
+
+# BioPortal acronym -> KG-Registry resource id, for pairs the name check rejects
+# or would never see. BioPortal acronyms and KG-Registry ids drift apart in both
+# directions, so these are checked before anything else.
+confirmed:
+  # Same ontology, different acronym on BioPortal.
+  APOLLO-SV: apollo_sv    # Apollo Structured Vocabulary
+  AURA: bio101            # KB_Bio_101
+  FB-CV: fbcv             # FlyBase Controlled Vocabulary
+  FB-SP: fbsp             # Fly taxonomy
+  GMM: gomapman           # GoMapMan
+  MHCRO: mro              # MHC Restriction Ontology (BioPortal's MRO is unrelated)
+  NPOKB: npo              # Neuron Phenotype Ontology (BioPortal's NPO is unrelated)
+  OBI_BCGO: bcgo          # Beta Cell Genomics Ontology (BioPortal's BCGO is unrelated)
+  OBOREL: ro              # Relations Ontology (BioPortal's RO is unrelated)
+  PLANTSO: pso            # Plant Stress Ontology (BioPortal's PSO is unrelated)
+  PTO: to                 # Plant Trait Ontology
+  PTRANS: trans           # Pathogen Transmission Ontology (BioPortal's TRANS is unrelated)
+  VANDF: ndfrt            # Veterans Health Administration National Drug File
+
+  # Acronym matches the resource id, but the names are worded too differently
+  # for the automatic name check to accept.
+  EPIO: epio              # "EpilepsyOntology" vs. "Epilepsy Ontology"
+  HGNC: hgnc              # "HUGO Gene Nomenclature" vs. the bare acronym
+  FALDO: faldo            # spelled-out name vs. the acronym alone
+  MIXS: mixs              # "Minimal Information about any Sequence Ontology" vs. "MIxS"
+  PATO: pato              # "Phenotypic Quality Ontology" vs. "Phenotype And Trait Ontology"
+
+# BioPortal acronyms that must never be written, whatever the name check says.
+rejected:
+  # Acronym collisions: BioPortal uses the acronym for a different ontology than
+  # the identically-named KG-Registry resource.
+  - ATOM       # "Atlas Ontology Model", not the Anti-tumor Biomaterial knowledge graph
+  - BCGO       # "Breast Cancer Grading Ontology", not Beta Cell Genomics Ontology
+  - COG        # "Common Ontology of Genome", not Clusters of Orthologous Genes
+  - EO         # "Ethnicity Ontoloy", not Plant Environment Ontology
+  - EPO        # "Early Pregnancy Ontology", not Epidemiology Ontology
+  - GRO        # "Gene Regulation Ontology", not Cereal Plant Gross Anatomy
+  - MRO        # "Defen", not MHC Restriction Ontology
+  - NDFRT      # NDF-RT proper, not the Veterans Health Administration drug file
+  - NEO        # "Neurologic Examination Ontology", not Noctua Entity Ontology
+  - NPO        # "NanoParticle Ontology", not Neuron Phenotype Ontology
+  - PSO        # "PatientSafetyOntology", not Plant Stress Ontology
+  - RGD        # "RRB Group D", not the Rat Genome Database
+  - RO         # "Radiomics Ontology", not the Relation Ontology
+  - TRANS      # "Nurse Transitional", not Pathogen Transmission Ontology
+
+  # Duplicate submissions: BioPortal hosts the same ontology under a second
+  # acronym that already matches by other means, so only one can supply the
+  # resource's single KG-Bioportal product.
+  - EPILONT    # duplicate of EPIO -> epio
+  - HPO        # Hypertension-Ontology, already covered by HTN -> htn
+  - LION       # LipidOntology, already covered by LIPRO -> lipro

--- a/util/sync_kg_bioportal.py
+++ b/util/sync_kg_bioportal.py
@@ -1,0 +1,789 @@
+#!/usr/bin/env python3
+"""Sync script for KG-Bioportal ontology transforms.
+
+KG-Bioportal (https://ncbo.github.io/kg-bioportal/graphs/) transforms BioPortal
+ontologies to KGX TSV. It publishes ~1300 transform records, which is far too many
+to carry as a product inventory on a single KG-Registry page, and most of those
+records describe ontologies KG-Registry does not track at all.
+
+So this sync does not mirror the manifest into the ``kg-bioportal`` resource page
+the way ``sync_obo_foundry.py`` mirrors OBO Foundry. Instead it works like a
+side-channel annotation pass: for every successfully transformed ontology that
+*already* has a KG-Registry resource page, it adds (or refreshes) a single
+GraphProduct on that page pointing at the KGX release asset. The ``kg-bioportal``
+resource page itself just links to the graph browser.
+
+Deliberate omissions:
+
+* Failed and skipped transforms are never written. KG-Bioportal records those so
+  its own site can explain the gap; there is no artifact for KG-Registry to list.
+* New resources are never created. KG-Bioportal draws part of its graph listing
+  from KG-Registry, so minting resources from its manifest would be a circular
+  sync.
+* The synced products do **not** name ``kg-bioportal`` in ``original_source`` or
+  ``secondary_source``. ``propagate_products`` (util/extract-metadata.py) copies
+  every product onto the page of each resource it cites as a source, so naming the
+  aggregator there would rebuild the 1000-entry inventory this design exists to
+  avoid. The KG-Bioportal provenance lives in the product name, description, and
+  release URL instead.
+
+Acronym-to-resource matching is deliberately conservative: see ``resolve_match``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import logging
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+import frontmatter  # type: ignore
+import yaml
+
+try:
+    from util.common import CustomRuamelYAMLHandler, dump_frontmatter_text
+    from util.source_associations import make_original_source_associations
+except ModuleNotFoundError:
+    from common import CustomRuamelYAMLHandler, dump_frontmatter_text
+    from source_associations import make_original_source_associations
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+ONTO_STATS_URL = (
+    "https://github.com/ncbo/kg-bioportal/releases/latest/download/onto_stats.yaml"
+)
+TOTAL_STATS_URL = (
+    "https://github.com/ncbo/kg-bioportal/releases/latest/download/total_stats.yaml"
+)
+# Suffix appended to a resource id to form the id of its KG-Bioportal product.
+PRODUCT_SUFFIX = "kg-bioportal"
+
+# Fields on a synced product that this script owns. Anything else on an existing
+# product (product_file_size from the size-retrieval pass, curator warnings, ...)
+# is left alone.
+MANAGED_PRODUCT_FIELDS = (
+    "id",
+    "name",
+    "category",
+    "description",
+    "product_url",
+    "format",
+    "compression",
+    "node_count",
+    "edge_count",
+    "latest_version",
+    "original_source",
+)
+
+# Tokens that carry no discriminating signal when comparing two ontology names.
+NAME_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "classification",
+        "controlled",
+        "data",
+        "database",
+        "for",
+        "in",
+        "of",
+        "ontologies",
+        "ontology",
+        "resource",
+        "system",
+        "taxonomy",
+        "terminology",
+        "the",
+        "thesaurus",
+        "to",
+        "version",
+        "vocabulary",
+    }
+)
+
+# Minimum name similarity for an acronym match to be accepted without curation.
+# Calibrated against the current manifest: every genuine acronym collision in it
+# (RO/Radiomics vs. Relation Ontology, PSO/PatientSafety vs. Plant Stress, ...)
+# scores 0.0, while the loosest genuine match scores 0.33.
+MIN_NAME_SIMILARITY = 0.3
+
+# Minimum per-token similarity for two name tokens to count as the same word.
+# 0.85 accepts inflections like relations/relation and planarian/planaria while
+# rejecting atom/atlas. It sits just above phenotypic/phenotype (0.84), which is
+# why PATO needs an entry in the sync map.
+MIN_TOKEN_SIMILARITY = 0.85
+
+
+def name_tokens(name: str) -> List[str]:
+    """Split an ontology name into lowercase content tokens."""
+    return [
+        token
+        for token in re.split(r"[^a-z0-9]+", (name or "").lower())
+        if token and token not in NAME_STOPWORDS
+    ]
+
+
+def name_similarity(first: str, second: str) -> float:
+    """Score how much two ontology names overlap, from 0.0 to 1.0.
+
+    Coverage is computed in both directions and the better one wins, so a name
+    that is a subset of the other ("Uber Anatomy Ontology" against "Uberon
+    multi-species anatomy ontology") still scores well.
+    """
+    first_tokens = name_tokens(first)
+    second_tokens = name_tokens(second)
+    if not first_tokens or not second_tokens:
+        return 0.0
+
+    def coverage(left: List[str], right: List[str]) -> float:
+        matched = sum(
+            1
+            for token in left
+            if any(
+                SequenceMatcher(None, token, other).ratio() >= MIN_TOKEN_SIMILARITY
+                for other in right
+            )
+        )
+        return matched / len(left)
+
+    return max(coverage(first_tokens, second_tokens), coverage(second_tokens, first_tokens))
+
+
+def normalized_name(name: str) -> str:
+    """Reduce a name to comparable alphanumerics."""
+    return re.sub(r"[^a-z0-9]", "", (name or "").lower())
+
+
+class KGBioportalSync:
+    """Annotate KG-Registry resources with their KG-Bioportal KGX transforms."""
+
+    def __init__(
+        self,
+        registry_root: Optional[str] = None,
+        cache_ttl_hours: int = 24,
+        map_path: Optional[str] = None,
+        report_path: Optional[str] = None,
+    ):
+        script_dir = Path(__file__).resolve().parent
+        self.repo_root = script_dir.parent
+        self.registry_root = (
+            Path(registry_root) if registry_root is not None else self.repo_root / "resource"
+        )
+        self.cache_ttl_hours = cache_ttl_hours
+        self.cache_dir = self.repo_root / "cache"
+        self.cache_file = self.cache_dir / "kg_bioportal_cache.yaml"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        self.map_path = (
+            Path(map_path) if map_path is not None else script_dir / "kg_bioportal_sync_map.yaml"
+        )
+        self.report_path = (
+            Path(report_path)
+            if report_path is not None
+            else self.repo_root / "reports" / "kg_bioportal_unmatched.tsv"
+        )
+
+        self.yaml_handler = CustomRuamelYAMLHandler()
+        self.confirmed_matches, self.rejected_acronyms = self._load_sync_map()
+        self.resource_names = self._load_resource_names()
+        self.resources_by_name = self._index_resources_by_name()
+
+    # ----------------------------------------------------------------- inputs
+
+    def _load_sync_map(self) -> Tuple[Dict[str, str], set]:
+        """Load curator decisions about which acronym belongs to which resource."""
+        confirmed: Dict[str, str] = {}
+        rejected: set = set()
+        if not self.map_path.exists():
+            logger.warning("No KG-Bioportal sync map at %s", self.map_path)
+            return confirmed, rejected
+
+        try:
+            data = yaml.safe_load(self.map_path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            logger.warning("Failed to load KG-Bioportal sync map: %s", exc)
+            return confirmed, rejected
+
+        for acronym, resource_id in (data.get("confirmed") or {}).items():
+            if isinstance(resource_id, str) and resource_id.strip():
+                confirmed[str(acronym).upper()] = resource_id.strip()
+        for acronym in data.get("rejected") or []:
+            rejected.add(str(acronym).upper())
+
+        overlap = set(confirmed) & rejected
+        if overlap:
+            logger.warning(
+                "Acronyms listed as both confirmed and rejected are treated as rejected: %s",
+                ", ".join(sorted(overlap)),
+            )
+            for acronym in overlap:
+                confirmed.pop(acronym, None)
+
+        logger.info(
+            "Loaded KG-Bioportal sync map: %s confirmed, %s rejected",
+            len(confirmed),
+            len(rejected),
+        )
+        return confirmed, rejected
+
+    def _load_resource_names(self) -> Dict[str, str]:
+        """Map each existing resource id to its display name."""
+        names: Dict[str, str] = {}
+        if not self.registry_root.exists():
+            return names
+
+        for resource_dir in sorted(self.registry_root.iterdir()):
+            if not resource_dir.is_dir():
+                continue
+            resource_file = resource_dir / f"{resource_dir.name}.md"
+            if not resource_file.exists():
+                continue
+            try:
+                metadata = frontmatter.load(resource_file).metadata
+            except Exception as exc:
+                logger.warning("Failed to read %s: %s", resource_file, exc)
+                continue
+            name = metadata.get("name") if isinstance(metadata, dict) else None
+            names[resource_dir.name] = str(name) if name else resource_dir.name
+        return names
+
+    def _index_resources_by_name(self) -> Dict[str, List[str]]:
+        index: Dict[str, List[str]] = {}
+        for resource_id, name in self.resource_names.items():
+            index.setdefault(normalized_name(name), []).append(resource_id)
+        return index
+
+    def resource_file(self, resource_id: str) -> Path:
+        return self.registry_root / resource_id / f"{resource_id}.md"
+
+    # ------------------------------------------------------------ manifest IO
+
+    def _is_cache_valid(self) -> bool:
+        if not self.cache_file.exists():
+            return False
+        cache_age_hours = (time.time() - os.path.getmtime(self.cache_file)) / 3600
+        if cache_age_hours < self.cache_ttl_hours:
+            logger.info(
+                "KG-Bioportal cache is valid (age: %.1f hours, TTL: %s hours)",
+                cache_age_hours,
+                self.cache_ttl_hours,
+            )
+            return True
+        logger.info(
+            "KG-Bioportal cache expired (age: %.1f hours, TTL: %s hours)",
+            cache_age_hours,
+            self.cache_ttl_hours,
+        )
+        return False
+
+    def _load_from_cache(self) -> Optional[Dict[str, Any]]:
+        try:
+            data = yaml.safe_load(self.cache_file.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Failed to load KG-Bioportal cache: %s", exc)
+            return None
+        if isinstance(data, dict) and isinstance(data.get("ontologies"), list):
+            logger.info(
+                "Loaded %s KG-Bioportal transform records from cache", len(data["ontologies"])
+            )
+            return data
+        return None
+
+    def _save_to_cache(self, data: Dict[str, Any]) -> None:
+        try:
+            self.cache_file.write_text(
+                yaml.safe_dump(data, default_flow_style=False, sort_keys=False),
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            logger.warning("Failed to save KG-Bioportal cache: %s", exc)
+
+    @staticmethod
+    def _fetch_yaml(url: str) -> Any:
+        with urlopen(url, timeout=60) as response:  # noqa: S310
+            return yaml.safe_load(response.read().decode("utf-8"))
+
+    def fetch_manifest(self) -> Dict[str, Any]:
+        """Return the KG-Bioportal manifest as ``{ontologies: [...], totals: {...}}``."""
+        if self._is_cache_valid():
+            cached = self._load_from_cache()
+            if cached is not None:
+                return cached
+
+        logger.info("Fetching fresh KG-Bioportal manifest from %s", ONTO_STATS_URL)
+        try:
+            onto_stats = self._fetch_yaml(ONTO_STATS_URL)
+            if not isinstance(onto_stats, dict) or not isinstance(
+                onto_stats.get("ontologies"), list
+            ):
+                raise ValueError("Expected onto_stats.yaml with a top-level 'ontologies' list")
+
+            try:
+                totals = self._fetch_yaml(TOTAL_STATS_URL)
+            except (HTTPError, URLError, yaml.YAMLError) as exc:
+                # The per-ontology records are what the sync actually needs; the
+                # totals are only used for logging, so a miss here is not fatal.
+                logger.warning("Failed to fetch KG-Bioportal totals: %s", exc)
+                totals = {}
+
+            manifest = {
+                "ontologies": onto_stats["ontologies"],
+                "totals": totals if isinstance(totals, dict) else {},
+            }
+            self._save_to_cache(manifest)
+            logger.info(
+                "Successfully fetched %s KG-Bioportal transform records",
+                len(manifest["ontologies"]),
+            )
+            return manifest
+        except (HTTPError, URLError, ValueError, yaml.YAMLError) as exc:
+            logger.error("Failed to fetch KG-Bioportal manifest: %s", exc)
+            if self.cache_file.exists():
+                logger.warning("Attempting to use expired KG-Bioportal cache as fallback")
+                cached = self._load_from_cache()
+                if cached is not None:
+                    return cached
+            raise
+
+    # ------------------------------------------------------------- matching
+
+    def resolve_match(self, entry: Dict[str, Any]) -> Tuple[Optional[str], str]:
+        """Decide which KG-Registry resource an ontology entry belongs to.
+
+        Returns ``(resource_id, reason)``. ``resource_id`` is None when the entry
+        should not be written, and ``reason`` says why -- ``no_resource`` and
+        ``name_mismatch`` mean "a curator could promote this via the sync map",
+        while ``rejected`` means a curator already said no.
+
+        Three ways an entry can match, in order of authority:
+
+        1. ``confirmed`` in the sync map. BioPortal acronyms are not KG-Registry
+           ids, and the two drift apart in both directions -- the Relation
+           Ontology is ``OBOREL`` on BioPortal, and BioPortal's ``RO`` is the
+           unrelated Radiomics Ontology -- so curated pairs win outright.
+        2. ``rejected`` in the sync map: never written.
+        3. The lowercased acronym is an existing resource id *and* the two names
+           are similar enough to rule out an acronym collision.
+        """
+        acronym = str(entry.get("id", "")).strip().upper()
+        if not acronym:
+            return None, "no_acronym"
+
+        if acronym in self.rejected_acronyms:
+            return None, "rejected"
+
+        confirmed_id = self.confirmed_matches.get(acronym)
+        if confirmed_id:
+            if confirmed_id in self.resource_names:
+                return confirmed_id, "confirmed"
+            logger.warning(
+                "Sync map points %s at resource '%s', which does not exist", acronym, confirmed_id
+            )
+            return None, "confirmed_missing"
+
+        resource_id = acronym.lower()
+        if resource_id not in self.resource_names:
+            return None, "no_resource"
+
+        # A non-OK entry can only ever remove a product this sync itself wrote,
+        # so it does not need the name check -- and skiplist entries carry no
+        # name to check against anyway.
+        if str(entry.get("status", "")).upper() != "OK":
+            return resource_id, "acronym"
+
+        similarity = name_similarity(entry.get("name", ""), self.resource_names[resource_id])
+        if similarity < MIN_NAME_SIMILARITY:
+            return None, "name_mismatch"
+        return resource_id, "acronym"
+
+    def suggest_resource(self, entry: Dict[str, Any]) -> str:
+        """Suggest a resource for an unmatched entry, for the review report."""
+        candidates = self.resources_by_name.get(normalized_name(entry.get("name", "")), [])
+        return ",".join(candidates)
+
+    @staticmethod
+    def _resolution_rank(resolution: Tuple[Dict[str, Any], str]) -> Tuple[int, int, str]:
+        """Rank competing entries for one resource; lower sorts first (wins)."""
+        entry, reason = resolution
+        is_ok = str(entry.get("status", "")).upper() == "OK"
+        return (
+            0 if is_ok else 1,
+            0 if reason == "confirmed" else 1,
+            str(entry.get("id", "")),
+        )
+
+    def pick_winners(
+        self, resolutions: List[Tuple[Dict[str, Any], str, str]]
+    ) -> List[Tuple[Dict[str, Any], str]]:
+        """Reduce resolved entries to one per resource.
+
+        BioPortal hosts the same ontology under more than one acronym -- the
+        Epilepsy Ontology is both EPIO and EPILONT -- and every entry resolving
+        to a given resource would write the same product id. Choose one rather
+        than letting manifest order decide which wins.
+        """
+        by_resource: Dict[str, List[Tuple[Dict[str, Any], str]]] = {}
+        for entry, resource_id, reason in resolutions:
+            by_resource.setdefault(resource_id, []).append((entry, reason))
+
+        winners: List[Tuple[Dict[str, Any], str]] = []
+        for resource_id, candidates in sorted(by_resource.items()):
+            candidates.sort(key=self._resolution_rank)
+            winner = candidates[0]
+            if len(candidates) > 1:
+                logger.warning(
+                    "Resource %s matched %s KG-Bioportal entries (%s); using %s",
+                    resource_id,
+                    len(candidates),
+                    ", ".join(str(entry.get("id")) for entry, _ in candidates),
+                    winner[0].get("id"),
+                )
+            winners.append((winner[0], resource_id))
+        return winners
+
+    # -------------------------------------------------------------- products
+
+    def build_product(self, entry: Dict[str, Any], resource_id: str) -> Dict[str, Any]:
+        """Build the GraphProduct describing one KG-Bioportal transform."""
+        acronym = str(entry["id"]).strip().upper()
+        source_name = str(entry.get("name") or acronym).strip()
+
+        product: Dict[str, Any] = {
+            "id": f"{resource_id}.{PRODUCT_SUFFIX}",
+            "name": f"{acronym} KGX graph (KG-Bioportal)",
+            "category": "GraphProduct",
+            "description": (
+                f"KGX TSV transform of {source_name} ({acronym}), produced by KG-Bioportal "
+                f"from the BioPortal submission. The archive contains {acronym}_nodes.tsv "
+                f"and {acronym}_edges.tsv."
+            ),
+            "product_url": entry.get("download_url"),
+            "format": "kgx",
+            "compression": "targz",
+            "original_source": make_original_source_associations([resource_id]),
+        }
+
+        for field, source_field in (("node_count", "nodecount"), ("edge_count", "edgecount")):
+            value = entry.get(source_field)
+            if isinstance(value, int):
+                product[field] = value
+
+        version = str(entry.get("version") or "").strip()
+        if version and version != "NA":
+            product["latest_version"] = version
+
+        return {key: value for key, value in product.items() if value not in (None, "", [])}
+
+    def merge_product(self, products: List[Any], synced_product: Dict[str, Any]) -> bool:
+        """Insert or refresh the KG-Bioportal product in ``products``, in place.
+
+        Curator-added and build-added fields on an existing product are kept;
+        only the fields this sync owns are overwritten. Returns whether anything
+        changed. The list is mutated rather than rebuilt so the round-trip YAML
+        handler keeps the rest of the page's formatting.
+        """
+        product_id = synced_product["id"]
+
+        for product in products:
+            if not isinstance(product, dict) or product.get("id") != product_id:
+                continue
+            before = copy.deepcopy(dict(product))
+            # A new release means a new asset URL, which invalidates any file size
+            # the retrieval pass recorded for the old one.
+            if product.get("product_url") != synced_product.get("product_url"):
+                product.pop("product_file_size", None)
+            product.update(synced_product)
+            # Managed fields that are absent from this run's product (e.g. a
+            # version that became "NA") must not linger from the previous run.
+            for field in MANAGED_PRODUCT_FIELDS:
+                if field not in synced_product:
+                    product.pop(field, None)
+            return dict(product) != before
+
+        products.append(synced_product)
+        return True
+
+    @staticmethod
+    def remove_product(products: List[Any], product_id: str) -> bool:
+        """Drop a KG-Bioportal product that no longer has a published artifact."""
+        for index, product in enumerate(products):
+            if isinstance(product, dict) and product.get("id") == product_id:
+                del products[index]
+                return True
+        return False
+
+    # ----------------------------------------------------------------- output
+
+    @staticmethod
+    def _today_iso() -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT00:00:00Z")
+
+    @staticmethod
+    def page_style(resource_file: Path) -> str:
+        """Detect which YAML sequence style a resource page is written in.
+
+        Resource pages exist in two shapes, roughly half the registry each, and
+        the difference is purely how the writer that last touched the page emits
+        sequences. ``yaml.safe_dump`` (sync_obo_foundry, propagate_products)
+        writes top-level list items flush at column zero; the ruamel handler in
+        util/common.py (validate, prettify, populate_infores_ids) indents them.
+        This sync adds one product to an otherwise untouched page, so it writes
+        back in whichever style it found -- picking either one unconditionally
+        would reflow every list on half the pages it visits.
+
+        The tell is the first line under each top-level key that opens a
+        sequence. Counting ``- `` lines outright would not work: in the flush
+        style, sequences nested inside a list item are themselves indented.
+        Some hand-edited pages mix both styles, so the majority wins.
+        """
+        try:
+            text = resource_file.read_text(encoding="utf-8")
+        except OSError:
+            return "indented"
+        if not text.startswith("---"):
+            return "indented"
+        end = text.find("\n---", 3)
+        lines = (text[3:end] if end != -1 else text).splitlines()
+
+        flush = indented = 0
+        for index, line in enumerate(lines[:-1]):
+            if not re.match(r"^[A-Za-z_][\w-]*:\s*$", line):
+                continue
+            following = lines[index + 1]
+            if following.startswith("- "):
+                flush += 1
+            elif re.match(r"^ +- ", following):
+                indented += 1
+
+        return "flush" if flush > indented else "indented"
+
+    def load_resource(self, resource_file: Path, style: str) -> Any:
+        """Load a page with the loader matching how it will be written back."""
+        if style == "indented":
+            return frontmatter.load(resource_file, handler=self.yaml_handler)
+        # safe_dump cannot represent the ruamel handler's CommentedMap, so pages
+        # written back with it must be loaded through the plain loader.
+        return frontmatter.load(resource_file)
+
+    def write_resource(self, post: Any, resource_file: Path, style: str, dry_run: bool) -> None:
+        post.metadata["last_modified_date"] = self._today_iso()
+        if dry_run:
+            return
+        if style == "indented":
+            text = dump_frontmatter_text(post, self.yaml_handler) + "\n"
+        else:
+            yaml_content = yaml.safe_dump(
+                dict(post.metadata),
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            ).strip()
+            body = post.content.rstrip()
+            text = f"---\n{yaml_content}\n---\n{body}\n" if body else f"---\n{yaml_content}\n---\n"
+        resource_file.write_text(text, encoding="utf-8")
+
+    def apply_entry(self, entry: Dict[str, Any], resource_id: str, dry_run: bool) -> str:
+        """Write, refresh, or remove one resource's KG-Bioportal product."""
+        resource_file = self.resource_file(resource_id)
+        style = self.page_style(resource_file)
+        post = self.load_resource(resource_file, style)
+        metadata = post.metadata
+        product_id = f"{resource_id}.{PRODUCT_SUFFIX}"
+
+        if str(entry.get("status", "")).upper() != "OK":
+            products = metadata.get("products")
+            if not isinstance(products, list) or not self.remove_product(products, product_id):
+                return "skipped"
+            if not products:
+                metadata.pop("products", None)
+            logger.info("Removing stale KG-Bioportal product from %s", resource_id)
+            self.write_resource(post, resource_file, style, dry_run)
+            return "removed"
+
+        if not entry.get("download_url"):
+            logger.warning("KG-Bioportal entry %s is OK but has no download URL", entry.get("id"))
+            return "skipped"
+
+        if not isinstance(metadata.get("products"), list):
+            metadata["products"] = []
+        products = metadata["products"]
+        was_present = any(
+            isinstance(product, dict) and product.get("id") == product_id for product in products
+        )
+        if not self.merge_product(products, self.build_product(entry, resource_id)):
+            return "skipped"
+
+        logger.info(
+            "%s KG-Bioportal product on %s", "Updating" if was_present else "Adding", resource_id
+        )
+        self.write_resource(post, resource_file, style, dry_run)
+        return "updated" if was_present else "added"
+
+    def write_report(self, unmatched: List[Dict[str, str]]) -> None:
+        """Record entries a curator could resolve through the sync map."""
+        self.report_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.report_path, "w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle, delimiter="\t")
+            writer.writerow(["acronym", "kg_bioportal_name", "reason", "suggested_resource"])
+            for row in unmatched:
+                writer.writerow(
+                    [
+                        row["acronym"],
+                        row["name"],
+                        row["reason"],
+                        row["suggested_resource"],
+                    ]
+                )
+        logger.info(
+            "Wrote %s unmatched KG-Bioportal entries to %s", len(unmatched), self.report_path
+        )
+
+    # -------------------------------------------------------------------- run
+
+    def sync_all(self, dry_run: bool = False, limit: Optional[int] = None) -> Dict[str, int]:
+        logger.info("Starting KG-Bioportal sync")
+        stats = {
+            "processed": 0,
+            "added": 0,
+            "updated": 0,
+            "removed": 0,
+            "skipped": 0,
+            "failed": 0,
+            "unmatched": 0,
+        }
+
+        manifest = self.fetch_manifest()
+        entries = manifest["ontologies"]
+        totals = manifest.get("totals") or {}
+        if totals:
+            logger.info(
+                "KG-Bioportal transform of %s: %s ontologies, %s failed, %s skipped",
+                totals.get("transform_date", "unknown date"),
+                totals.get("totalcount", "?"),
+                totals.get("failedcount", "?"),
+                totals.get("skippedcount", "?"),
+            )
+        if limit:
+            entries = entries[:limit]
+
+        unmatched: List[Dict[str, str]] = []
+        resolutions: List[Tuple[Dict[str, Any], str, str]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            stats["processed"] += 1
+            resource_id, reason = self.resolve_match(entry)
+            if resource_id is None:
+                # "no_resource" is the overwhelmingly common case -- KG-Bioportal
+                # covers all of BioPortal -- and is not worth reporting on.
+                if reason in ("name_mismatch", "confirmed_missing"):
+                    stats["unmatched"] += 1
+                    unmatched.append(
+                        {
+                            "acronym": str(entry.get("id", "")),
+                            "name": str(entry.get("name", "")),
+                            "reason": reason,
+                            "suggested_resource": self.suggest_resource(entry),
+                        }
+                    )
+                elif reason == "no_resource":
+                    suggestion = self.suggest_resource(entry)
+                    if suggestion and str(entry.get("status", "")).upper() == "OK":
+                        stats["unmatched"] += 1
+                        unmatched.append(
+                            {
+                                "acronym": str(entry.get("id", "")),
+                                "name": str(entry.get("name", "")),
+                                "reason": reason,
+                                "suggested_resource": suggestion,
+                            }
+                        )
+                continue
+
+            resolutions.append((entry, resource_id, reason))
+
+        for entry, resource_id in self.pick_winners(resolutions):
+            try:
+                stats[self.apply_entry(entry, resource_id, dry_run=dry_run)] += 1
+            except Exception as exc:
+                logger.error(
+                    "Failed to sync KG-Bioportal entry %s to %s: %s",
+                    entry.get("id"),
+                    resource_id,
+                    exc,
+                )
+                stats["failed"] += 1
+
+        if dry_run or limit:
+            # A limited run has only seen part of the manifest; writing the report
+            # from it would drop entries the last full run recorded.
+            logger.info("Skipping the unmatched report (%s entries found)", len(unmatched))
+        else:
+            self.write_report(unmatched)
+
+        logger.info("KG-Bioportal sync completed. Stats: %s", stats)
+        return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Add KG-Bioportal KGX transform products to KG-Registry resources"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be done without writing files"
+    )
+    parser.add_argument(
+        "--registry-root", type=str, help="Path to resource directory (default: ../resource)"
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--limit", type=int, help="Limit number of manifest entries to process (for testing)"
+    )
+    parser.add_argument(
+        "--no-cache", action="store_true", help="Disable cache and fetch fresh data"
+    )
+    parser.add_argument(
+        "--cache-ttl", type=int, default=24, help="Cache time-to-live in hours (default: 24)"
+    )
+
+    args = parser.parse_args()
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    cache_ttl = 0 if args.no_cache else args.cache_ttl
+    try:
+        syncer = KGBioportalSync(registry_root=args.registry_root, cache_ttl_hours=cache_ttl)
+        stats = syncer.sync_all(dry_run=args.dry_run, limit=args.limit)
+
+        print("\nSync Summary:")
+        print(f"  Processed: {stats['processed']}")
+        print(f"  Added: {stats['added']}")
+        print(f"  Updated: {stats['updated']}")
+        print(f"  Removed: {stats['removed']}")
+        print(f"  Skipped (no change): {stats['skipped']}")
+        print(f"  Needs curation: {stats['unmatched']}")
+        print(f"  Failed: {stats['failed']}")
+
+        if stats["processed"] == 0:
+            sys.exit(1)
+    except Exception as exc:
+        logger.error("KG-Bioportal sync failed: %s", exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #129.

KG-Bioportal transforms BioPortal ontologies to KGX and publishes each result as a GitHub release asset. Its manifest currently covers 1292 records — 1108 OK, 141 failed, 43 skipped. That is far too many to carry as a product inventory on one page, and most of those ontologies have no KG-Registry resource at all.

So this is not shaped like the OBO Foundry sync, which mints and maintains whole resources. `resource/kg-bioportal/` is a hand-written **Aggregator** page that links to the [graph browser](https://ncbo.github.io/kg-bioportal/graphs/), and `util/sync_kg_bioportal.py` is an annotation pass: for each successful transform whose ontology *already* has a resource page, it adds one `GraphProduct` there pointing at the KGX archive.

**231 products added across 231 resource pages** on the first run. The `kg-bioportal` page itself carries 4 products (browser, manifest, release assets, pipeline code), not 1100.

## Three deliberate omissions

- **Failed and skipped transforms are never written.** There is no artifact to list. An existing product is *removed* if a transform stops succeeding.
- **No resources are created.** KG-Bioportal's browser reads KG-Registry's own JSON-LD dump, so minting resources from its manifest would be a circular sync.
- **The synced products do not name `kg-bioportal` as a source.** `propagate_products` copies a product onto the page of every resource it cites, so naming the aggregator would rebuild the thousand-entry inventory this design exists to avoid. Provenance lives in the product name, description, and release URL instead. (The `kg-bioportal` page's own products *do* cite `bioportal` and correctly propagated there — 3 entries.)

## Acronym matching needed curation

BioPortal acronyms collide with KG-Registry ids in both directions: BioPortal's `RO` is the Radiomics Ontology while the OBO Relation Ontology is `OBOREL`; `PSO` is a patient-safety ontology while the Plant Stress Ontology we call `pso` is `PLANTSO`. Matching on the lowercased acronym alone would attach the wrong graph to about a dozen resources.

An acronym match is therefore gated on a name-similarity check (token coverage with fuzzy per-token matching), and `util/kg_bioportal_sync_map.yaml` records the decisions that check cannot make — 18 confirmed pairs and 16 rejected acronyms, each annotated with what the acronym actually names. Anything unresolved lands in `reports/kg_bioportal_unmatched.tsv` as a curation worklist, currently empty.

When several manifest entries resolve to the same resource (BioPortal hosts some ontologies twice), successful transforms beat unsuccessful ones and curated matches beat heuristic ones, so the choice does not depend on manifest order.

## Frontmatter formatting

Resource pages exist in two YAML shapes, split roughly 2649/2379 across the registry — `yaml.safe_dump` writes top-level list items flush, the ruamel handler in `util/common.py` indents them. Writing either unconditionally reflowed every list on half the pages touched (the first full run was 57k changed lines). The sync now detects and preserves each page's style: **3805 insertions / 630 deletions**, about 15 lines per page. Seven genuinely mixed-style pages still get normalized.

## Example product

```yaml
- id: agro.kg-bioportal
  name: AGRO KGX graph (KG-Bioportal)
  category: GraphProduct
  description: KGX TSV transform of AGRonomy Ontology (AGRO), produced by KG-Bioportal
    from the BioPortal submission. The archive contains AGRO_nodes.tsv and AGRO_edges.tsv.
  product_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.02-7/AGRO.tar.gz
  format: kgx
  compression: targz
  original_source:
  - source: agro
    relation_type: prov:hadPrimarySource
  node_count: 5102
  edge_count: 8691
```

On re-runs only the fields the sync owns are rewritten; `product_file_size` and curator additions survive. A `product_file_size` recorded against a superseded release URL is dropped, since it no longer describes the file.

## Also included

- Make targets `sync-kg-bioportal{,-dry-run,-test}`, wired into `all`, `reports/metadata-grid.csv`, and `clean-cache`
- `docs/kg-bioportal-sync.md` plus a row and note in `docs/external-syncs.md`
- `tests/test_kg_bioportal_sync.py` — 25 tests covering matching, collision rejection, product merge/removal, dry-run, style preservation, the report, and a consistency check on the shipped sync map
- The 231 generated `*.kg-bioportal.md` product detail pages

## Verification

- `uv run pytest tests/` — 134 passed. `tests/test_integrity.py::test_root_resource_publication_identifiers_use_supported_formats` fails, but it fails on a clean checkout of `main` too and is unrelated to this change.
- `uv run python util/extract-metadata.py validate` over all touched pages — clean apart from two pre-existing publication-reference errors on `emapa` and `ontoneo`.
- The sync is idempotent: a second run reports 0 added / 0 updated / 0 removed.
- Spot-checked release asset URLs and the browser/manifest URLs — all 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
