### PR TITLE
Add Sniff canine genetics knowledge graph

### DIFF
--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -7259,6 +7259,15 @@ entries:
     source_path: resource/smpdb/smpdb.md
     status: valid
     warnings: []
+  resource/sniff/sniff.md#publication[0]#DOI:10.5281/zenodo.20566358:
+    checked_at: '2026-08-12T16:39:17Z'
+    errors: []
+    fingerprint: c2932215311e19fea3a99c26f8027fdba11a3c9841b3ad6a779bb708ab1a527f
+    publication_index: 0
+    reference_id: DOI:10.5281/zenodo.20566358
+    source_path: resource/sniff/sniff.md
+    status: valid
+    warnings: []
   resource/snodb/snodb.md#publication[0]#PMID:36165892:
     checked_at: '2026-08-06T18:19:02Z'
     errors: []

--- a/references_cache/DOI_10.5281_zenodo.20566358.md
+++ b/references_cache/DOI_10.5281_zenodo.20566358.md
@@ -1,0 +1,50 @@
+---
+reference_id: DOI:10.5281/zenodo.20566358
+title: "Sniff Atlas v1.0.1: an open, breed-stratified catalogue of common canine coding variants with calibrated protein-language-model pathogenicity and an evidence-graded knowledge graph"
+authors:
+- "Gehring, Matt"
+journal: Zenodo
+year: '2026'
+doi: 10.5281/zenodo.20566358
+keywords:
+- canine genomics
+- dog
+- CanFam4
+- allele frequency
+- breed
+- pathogenicity prediction
+- ESM2
+- knowledge graph
+- gnomAD
+- variant catalogue
+- Biolink
+- Canis Familiaris
+content_type: abstract_only
+supplementary_files:
+  - filename: sniff_atlas.sites.vcf.gz
+    download_url: "https://zenodo.org/api/records/20572692/files/sniff_atlas.sites.vcf.gz/content"
+    size_bytes: 189117079
+    checksum: md5:8b0c4f02ce6653f158eb0c64278e3471
+  - filename: sniff_atlas.sites.vcf.gz.tbi
+    download_url: "https://zenodo.org/api/records/20572692/files/sniff_atlas.sites.vcf.gz.tbi/content"
+    size_bytes: 1384822
+    checksum: md5:710e9a76de5df6d8b157bc403120634e
+  - filename: README.md
+    download_url: "https://zenodo.org/api/records/20572692/files/README.md/content"
+    size_bytes: 6212
+    checksum: md5:155ed8c1eb3340ac7af2ec09dc729e75
+  - filename: sniff-atlas-v1.0.1.tar.gz
+    download_url: "https://zenodo.org/api/records/20572692/files/sniff-atlas-v1.0.1.tar.gz/content"
+    size_bytes: 1753039854
+    checksum: md5:bb4ca86f3461028b3a1763d9fcd7307b
+---
+
+# Sniff Atlas v1.0.1: an open, breed-stratified catalogue of common canine coding variants with calibrated protein-language-model pathogenicity and an evidence-graded knowledge graph
+**Authors:** Gehring, Matt
+**Journal:** Zenodo (2026)
+**DOI:** [10.5281/zenodo.20566358](https://doi.org/10.5281/zenodo.20566358)
+
+## Content
+
+An open, breed-stratified catalogue of the common and low-frequency coding-variant landscape of the domestic dog across 188 breeds: allele frequencies for 9,667,790 imputed variants (14,478 dogs, CanFam4) — ~6.7M common (MAF >= 5%) plus ~3.0M lower-frequency (MAF 1-5%) — with SnpEff annotation and three complementary deleteriousness layers (ESM2, Pangolin, Zoonomia 241-way phyloP; ESM2 calibrated at AUC 0.935 vs OMIA), an evidence-graded Biolink knowledge graph, and a bcftools-queryable sites VCF. Scope: MAF >= 1% (the CanVAS imputation floor; sub-1% variants are out of scope). Independently validated against the NHGRI (National Human Genome Research Institute) 722 directly-sequenced whole-genome catalogue (Plassais et al. 2019). Derived from CanVAS (doi:10.5281/zenodo.19186944, Brundage 2026); raw genotypes not redistributed. See README/VALIDATION/CITATIONS inside the archive. Aggregate data only (no individual dog identifiers); OMIA-derived clinical layer held for v1.1.
+Erratum (2026-06-07): In the bundled knowledge_graph/, ten known-disease-variant nodes (tag-SNP proxies and unshipped sentinel entries) were assigned mismapped CanFam4 coordinates and must not be used as authoritative disease-variant positions. This affects only those knowledge-graph variant coordinates; the core breed-stratified allele-frequency atlas, the pathogenicity scores, and the sites VCF are CanFam4-native and unaffected. Corrected in the source repository and in the forthcoming v1.1. In v1.0.x, treat knowledge_graph variant positions as advisory only.

--- a/resource/sniff/sniff.md
+++ b/resource/sniff/sniff.md
@@ -1,0 +1,142 @@
+---
+activity_status: active
+category: KnowledgeGraph
+contacts:
+  - category: Individual
+    label: Matt Gehring
+    orcid: 0009-0001-9531-2861
+    contact_details:
+      - contact_type: email
+        value: matt@sniff.world
+      - contact_type: url
+        value: https://sniff.world/about/
+creation_date: '2026-08-12T00:00:00Z'
+description: An open canine genetics atlas covering breed-stratified variant data, canine disease associations, and dog-to-human gene orthology, published with an evidence-graded, Biolink-conformant knowledge graph.
+domains:
+  - genomics
+  - organisms
+  - biomedical
+  - phenotype
+homepage_url: https://sniff.world/
+id: sniff
+last_modified_date: '2026-08-12T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: Sniff
+products:
+  - category: GraphProduct
+    description: A Biolink-conformant KGX TSV node file for the Sniff cross-species substrate, covering dog and human genes and canine and human diseases. Part of the facts-only federation bundle intended for ingest into other knowledge graphs.
+    format: kgx
+    id: sniff.federation-nodes
+    name: Sniff KGX federation export, nodes
+    node_categories:
+      - biolink:Gene
+      - biolink:Disease
+    node_count: 36915
+    compatibility:
+      - standard: biolink
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: sniff
+    secondary_source:
+      - relation_type: prov:wasDerivedFrom
+        source: clinvar
+      - relation_type: prov:wasDerivedFrom
+        source: ensembl
+      - relation_type: prov:wasDerivedFrom
+        source: mondo
+    product_file_size: 3726803
+    product_url: https://sniffdog-data.s3.amazonaws.com/federation/kgx/sniff_nodes.tsv
+  - category: GraphProduct
+    description: A Biolink-conformant KGX TSV edge file for the Sniff cross-species substrate, covering dog-to-human orthology and canine disease associations. Every edge carries provenance and an evidence level, and all edges with a knowledge level of prediction are excluded.
+    format: kgx
+    id: sniff.federation-edges
+    name: Sniff KGX federation export, edges
+    edge_count: 19823
+    predicates:
+      - biolink:orthologous_to
+      - biolink:causes
+      - biolink:gene_associated_with_condition
+      - biolink:associated_with_increased_likelihood_of
+    compatibility:
+      - standard: biolink
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: sniff
+    secondary_source:
+      - relation_type: prov:wasDerivedFrom
+        source: clinvar
+      - relation_type: prov:wasDerivedFrom
+        source: ensembl
+      - relation_type: prov:wasDerivedFrom
+        source: mondo
+    product_file_size: 5247253
+    product_url: https://sniffdog-data.s3.amazonaws.com/federation/kgx/sniff_edges.tsv
+  - category: Product
+    description: A JSON manifest for the Sniff KGX federation export, providing node and edge counts, per-predicate and per-evidence-tier breakdowns, build provenance, and SHA256 checksums for verification of the bundle.
+    format: json
+    id: sniff.federation-manifest
+    name: Sniff KGX federation export manifest
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: sniff
+    product_file_size: 4365
+    product_url: https://sniffdog-data.s3.amazonaws.com/federation/kgx/manifest.json
+  - category: Product
+    description: A sites-only VCF of the Sniff Atlas variant catalogue, containing allele frequencies for 9,667,790 imputed variants across 14,478 dogs and 188 breeds on the CanFam4 assembly, restricted to variants with allele frequency at or above 1%.
+    compression: gzip
+    format: vcf
+    id: sniff.atlas-vcf
+    name: Sniff Atlas sites VCF (v1.0.1)
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: sniff
+    latest_version: 1.0.1
+    product_url: https://zenodo.org/records/20566358
+  - category: GraphicalInterface
+    description: The Sniff web interface, providing browsers for breeds, genes, diseases, variants, and contributing studies, an interactive atlas view, and a natural-language query view.
+    format: http
+    id: sniff.browser
+    name: Sniff web interface
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: sniff
+    product_url: https://sniff.world/
+  - category: ProgrammingInterface
+    description: A Model Context Protocol server exposing Sniff data for programmatic and agent-based access.
+    format: http
+    id: sniff.mcp
+    name: sniff-mcp
+    license:
+      id: https://opensource.org/licenses/MIT
+      label: MIT
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: sniff
+    product_url: https://github.com/Sniffscore/sniff-mcp
+    repository: https://github.com/Sniffscore/sniff-mcp
+publications:
+  - id: https://doi.org/10.5281/zenodo.20566358
+    doi: doi:10.5281/zenodo.20566358
+    title: 'Sniff Atlas v1.0.1: an open, breed-stratified catalogue of common canine coding variants with calibrated protein-language-model pathogenicity and an evidence-graded knowledge graph'
+    authors:
+      - Matt Gehring
+    journal: Zenodo
+    year: '2026'
+    preferred: true
+repository: https://github.com/Sniffscore
+taxon:
+  - NCBITaxon:9615
+  - NCBITaxon:9606
+version: 1.0.1
+---
+
+Sniff is an open canine genetics resource that catalogues genetic variation across dog breeds and links canine conditions to their human disease counterparts. It is built and maintained by Matt Gehring at Candor Systems LLC as an independent, non-commercial project.
+
+The v1.0.1 Atlas release provides allele frequencies for 9,667,790 imputed variants drawn from 14,478 dogs across 188 breeds on the CanFam4 assembly, restricted to variants at 1% allele frequency or above, with pathogenicity predictions from three complementary tools.
+
+Layered on the variant catalogue is an evidence-graded knowledge graph, released separately as a Biolink-conformant KGX TSV bundle of 36,915 nodes and 19,823 edges. Nodes are genes and diseases; edges cover dog-to-human orthology, gene-disease causation, and canine disease associations established from OMIA. Orthology edges are stratified into high-corroborated, high, and moderate evidence tiers, and the export deliberately excludes any edge with a knowledge level of prediction, so that predictions never enter a downstream graph as facts.
+
+Sniff aggregates and cross-links data from several upstream resources, including CanVAS, OMIA, Dog10K, Darwin's Ark, the Golden Retriever Lifetime Study, ClinVar, Ensembl, gnomAD, and Mondo. Contributing studies are individually credited on the Sniff site.


### PR DESCRIPTION
Closes #692

Adds a Resource entry for [Sniff](https://sniff.world/), an open canine genetics atlas that catalogues breed-stratified variant data and links canine conditions to their human disease counterparts. Maintained by Matt Gehring at Candor Systems LLC.

## What's here

`resource/sniff/sniff.md`, categorized as a `KnowledgeGraph`, with six products:

| Product | Category | Format |
| --- | --- | --- |
| KGX federation export, nodes | GraphProduct | kgx |
| KGX federation export, edges | GraphProduct | kgx |
| KGX federation export manifest | Product | json |
| Sniff Atlas sites VCF (v1.0.1) | Product | vcf |
| Sniff web interface | GraphicalInterface | http |
| sniff-mcp | ProgrammingInterface | http |

The KGX bundle is the piece most relevant to the registry: 36,915 nodes (`biolink:Gene`, `biolink:Disease`) and 19,823 edges (`biolink:orthologous_to`, `biolink:causes`, `biolink:gene_associated_with_condition`, `biolink:associated_with_increased_likelihood_of`), tagged `compatibility: biolink`. It is facts-only — edges with `knowledge_level=prediction` are excluded upstream — and every edge carries provenance and an evidence level.

Node and edge counts, predicates, categories, and file sizes were taken from the [published manifest](https://sniffdog-data.s3.amazonaws.com/federation/kgx/manifest.json) and live `content-length` headers rather than from prose on the site.

## Provenance links

`secondary_source` links the KGX products to the upstream resources already in the registry: `clinvar`, `ensembl`, and `mondo`. Sniff also builds on CanVAS, OMIA, Dog10K, Darwin's Ark, and gnomAD, which don't have registry entries yet — those are named in the description text and could be wired up later.

## Notes

- No `infores_id` is claimed; `infores:sniff` is not yet registered with Translator/Monarch per the upstream manifest.
- Licensed CC BY 4.0; the MCP server is separately MIT, recorded on that product.
- `taxon` covers both dog (NCBITaxon:9615) and human (NCBITaxon:9606), since the graph is explicitly cross-species.
- Zenodo DOI added to `publications`, with its reference cached in `references_cache/`.

`make validate-file` passes with no errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)