### PR TITLE
Add upstream canine and population genomics sources referenced by Sniff

### DIFF
--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -815,6 +815,15 @@ entries:
     source_path: resource/cancer-registry-kg/cancer-registry-kg.md
     status: valid
     warnings: []
+  resource/canvas/canvas.md#publication[0]#DOI:10.64898/2026.04.13.718238:
+    checked_at: '2026-08-12T18:06:23Z'
+    errors: []
+    fingerprint: 2ed3f90478c6623e47b647b38df55689bffcf060ae65f0d5f83e2774e9a03bb5
+    publication_index: 0
+    reference_id: DOI:10.64898/2026.04.13.718238
+    source_path: resource/canvas/canvas.md
+    status: valid
+    warnings: []
   resource/cardiokg/cardiokg.md#publication[0]#DOI:10.1038/s44161-025-00757-4:
     checked_at: '2026-06-12T20:32:32Z'
     errors: []
@@ -1561,6 +1570,15 @@ entries:
     source_path: resource/darkkinasekb/darkkinasekb.md
     status: valid
     warnings: []
+  resource/darwins-ark/darwins-ark.md#publication[0]#DOI:10.1073/pnas.2421752122:
+    checked_at: '2026-08-12T18:06:29Z'
+    errors: []
+    fingerprint: 4f96d4e8684b009f9f0f67ca36d34febfdceb879dcc0108816e703c34dcbfe28
+    publication_index: 0
+    reference_id: DOI:10.1073/pnas.2421752122
+    source_path: resource/darwins-ark/darwins-ark.md
+    status: valid
+    warnings: []
   resource/dbpedia/dbpedia.md#publication[0]#DOI:10.1007/978-3-540-76298-0_52:
     checked_at: '2026-08-06T18:17:00Z'
     errors: []
@@ -1892,6 +1910,24 @@ entries:
     publication_index: 0
     reference_id: DOI:10.3233/SW-150177
     source_path: resource/doco/doco.md
+    status: valid
+    warnings: []
+  resource/dog10k/dog10k.md#publication[0]#DOI:10.1186/s13059-023-03023-7:
+    checked_at: '2026-08-12T18:06:26Z'
+    errors: []
+    fingerprint: da424e5f838945adb390f0f17c613689f173b03eb1eb1f37f8ed12c66c373af3
+    publication_index: 0
+    reference_id: DOI:10.1186/s13059-023-03023-7
+    source_path: resource/dog10k/dog10k.md
+    status: valid
+    warnings: []
+  resource/dog10k/dog10k.md#publication[1]#DOI:10.1093/nar/gkae928:
+    checked_at: '2026-08-12T18:06:26Z'
+    errors: []
+    fingerprint: 84e166106c94fe4f519652b35102be2fb3ba65511def7f333ed3432acf49c872
+    publication_index: 1
+    reference_id: DOI:10.1093/nar/gkae928
+    source_path: resource/dog10k/dog10k.md
     status: valid
     warnings: []
   resource/doid/doid.md#publication[0]#PMID:25348409:
@@ -2983,6 +3019,15 @@ entries:
     publication_index: 0
     reference_id: DOI:10.5281/zenodo.6678278
     source_path: resource/gno/gno.md
+    status: valid
+    warnings: []
+  resource/gnomad/gnomad.md#publication[0]#DOI:10.1038/s41586-020-2308-7:
+    checked_at: '2026-08-12T18:06:18Z'
+    errors: []
+    fingerprint: e69aac594912dbe386a2074e05c9dcfd6a67b879e471fe3a57bf464718e4ca90
+    publication_index: 0
+    reference_id: DOI:10.1038/s41586-020-2308-7
+    source_path: resource/gnomad/gnomad.md
     status: valid
     warnings: []
   resource/gnps/gnps.md#publication[0]#DOI:10.1038/nbt.3597:

--- a/references_cache/DOI_10.1038_s41586-020-2308-7.md
+++ b/references_cache/DOI_10.1038_s41586-020-2308-7.md
@@ -1,0 +1,199 @@
+---
+reference_id: DOI:10.1038/s41586-020-2308-7
+title: "The mutational constraint spectrum quantified from variation in 141,456 humans"
+authors:
+- Konrad J. Karczewski
+- Laurent C. Francioli
+- Grace Tiao
+- Beryl B. Cummings
+- Jessica Alföldi
+- Qingbo Wang
+- Ryan L. Collins
+- Kristen M. Laricchia
+- Andrea Ganna
+- Daniel P. Birnbaum
+- Laura D. Gauthier
+- Harrison Brand
+- Matthew Solomonson
+- Nicholas A. Watts
+- Daniel Rhodes
+- Moriel Singer-Berk
+- Eleina M. England
+- Eleanor G. Seaby
+- Jack A. Kosmicki
+- Raymond K. Walters
+- Katherine Tashman
+- Yossi Farjoun
+- Eric Banks
+- Timothy Poterba
+- Arcturus Wang
+- Cotton Seed
+- Nicola Whiffin
+- Jessica X. Chong
+- Kaitlin E. Samocha
+- Emma Pierce-Hoffman
+- Zachary Zappala
+- Anne H. O’Donnell-Luria
+- Eric Vallabh Minikel
+- Ben Weisburd
+- Monkol Lek
+- James S. Ware
+- Christopher Vittal
+- Irina M. Armean
+- Louis Bergelson
+- Kristian Cibulskis
+- Kristen M. Connolly
+- Miguel Covarrubias
+- Stacey Donnelly
+- Steven Ferriera
+- Stacey Gabriel
+- Jeff Gentry
+- Namrata Gupta
+- Thibault Jeandet
+- Diane Kaplan
+- Christopher Llanwarne
+- Ruchi Munshi
+- Sam Novod
+- Nikelle Petrillo
+- David Roazen
+- Valentin Ruano-Rubio
+- Andrea Saltzman
+- Molly Schleicher
+- Jose Soto
+- Kathleen Tibbetts
+- Charlotte Tolonen
+- Gordon Wade
+- Michael E. Talkowski
+- Carlos A. Aguilar Salinas
+- Tariq Ahmad
+- Christine M. Albert
+- Diego Ardissino
+- Gil Atzmon
+- John Barnard
+- Laurent Beaugerie
+- Emelia J. Benjamin
+- Michael Boehnke
+- Lori L. Bonnycastle
+- Erwin P. Bottinger
+- Donald W. Bowden
+- Matthew J. Bown
+- John C. Chambers
+- Juliana C. Chan
+- Daniel Chasman
+- Judy Cho
+- Mina K. Chung
+- Bruce Cohen
+- Adolfo Correa
+- Dana Dabelea
+- Mark J. Daly
+- Dawood Darbar
+- Ravindranath Duggirala
+- Josée Dupuis
+- Patrick T. Ellinor
+- Roberto Elosua
+- Jeanette Erdmann
+- Tõnu Esko
+- Martti Färkkilä
+- Jose Florez
+- Andre Franke
+- Gad Getz
+- Benjamin Glaser
+- Stephen J. Glatt
+- David Goldstein
+- Clicerio Gonzalez
+- Leif Groop
+- Christopher Haiman
+- Craig Hanis
+- Matthew Harms
+- Mikko Hiltunen
+- Matti M. Holi
+- Christina M. Hultman
+- Mikko Kallela
+- Jaakko Kaprio
+- Sekar Kathiresan
+- Bong-Jo Kim
+- Young Jin Kim
+- George Kirov
+- Jaspal Kooner
+- Seppo Koskinen
+- Harlan M. Krumholz
+- Subra Kugathasan
+- Soo Heon Kwak
+- Markku Laakso
+- Terho Lehtimäki
+- Ruth J. F. Loos
+- Steven A. Lubitz
+- Ronald C. W. Ma
+- Daniel G. MacArthur
+- Jaume Marrugat
+- Kari M. Mattila
+- Steven McCarroll
+- Mark I. McCarthy
+- Dermot McGovern
+- Ruth McPherson
+- James B. Meigs
+- Olle Melander
+- Andres Metspalu
+- Benjamin M. Neale
+- Peter M. Nilsson
+- Michael C. O’Donovan
+- Dost Ongur
+- Lorena Orozco
+- Michael J. Owen
+- Colin N. A. Palmer
+- Aarno Palotie
+- Kyong Soo Park
+- Carlos Pato
+- Ann E. Pulver
+- Nazneen Rahman
+- Anne M. Remes
+- John D. Rioux
+- Samuli Ripatti
+- Dan M. Roden
+- Danish Saleheen
+- Veikko Salomaa
+- Nilesh J. Samani
+- Jeremiah Scharf
+- Heribert Schunkert
+- Moore B. Shoemaker
+- Pamela Sklar
+- Hilkka Soininen
+- Harry Sokol
+- Tim Spector
+- Patrick F. Sullivan
+- Jaana Suvisaari
+- E. Shyong Tai
+- Yik Ying Teo
+- Tuomi Tiinamaija
+- Ming Tsuang
+- Dan Turner
+- Teresa Tusie-Luna
+- Erkki Vartiainen
+- Marquis P. Vawter
+- James S. Ware
+- Hugh Watkins
+- Rinse K. Weersma
+- Maija Wessman
+- James G. Wilson
+- Ramnik J. Xavier
+- Benjamin M. Neale
+- Mark J. Daly
+- Daniel G. MacArthur
+journal: Nature
+year: '2020'
+doi: 10.1038/s41586-020-2308-7
+content_type: abstract_only
+---
+
+# The mutational constraint spectrum quantified from variation in 141,456 humans
+**Authors:** Konrad J. Karczewski, Laurent C. Francioli, Grace Tiao, Beryl B. Cummings, Jessica Alföldi, Qingbo Wang, Ryan L. Collins, Kristen M. Laricchia, Andrea Ganna, Daniel P. Birnbaum, Laura D. Gauthier, Harrison Brand, Matthew Solomonson, Nicholas A. Watts, Daniel Rhodes, Moriel Singer-Berk, Eleina M. England, Eleanor G. Seaby, Jack A. Kosmicki, Raymond K. Walters, Katherine Tashman, Yossi Farjoun, Eric Banks, Timothy Poterba, Arcturus Wang, Cotton Seed, Nicola Whiffin, Jessica X. Chong, Kaitlin E. Samocha, Emma Pierce-Hoffman, Zachary Zappala, Anne H. O’Donnell-Luria, Eric Vallabh Minikel, Ben Weisburd, Monkol Lek, James S. Ware, Christopher Vittal, Irina M. Armean, Louis Bergelson, Kristian Cibulskis, Kristen M. Connolly, Miguel Covarrubias, Stacey Donnelly, Steven Ferriera, Stacey Gabriel, Jeff Gentry, Namrata Gupta, Thibault Jeandet, Diane Kaplan, Christopher Llanwarne, Ruchi Munshi, Sam Novod, Nikelle Petrillo, David Roazen, Valentin Ruano-Rubio, Andrea Saltzman, Molly Schleicher, Jose Soto, Kathleen Tibbetts, Charlotte Tolonen, Gordon Wade, Michael E. Talkowski, Carlos A. Aguilar Salinas, Tariq Ahmad, Christine M. Albert, Diego Ardissino, Gil Atzmon, John Barnard, Laurent Beaugerie, Emelia J. Benjamin, Michael Boehnke, Lori L. Bonnycastle, Erwin P. Bottinger, Donald W. Bowden, Matthew J. Bown, John C. Chambers, Juliana C. Chan, Daniel Chasman, Judy Cho, Mina K. Chung, Bruce Cohen, Adolfo Correa, Dana Dabelea, Mark J. Daly, Dawood Darbar, Ravindranath Duggirala, Josée Dupuis, Patrick T. Ellinor, Roberto Elosua, Jeanette Erdmann, Tõnu Esko, Martti Färkkilä, Jose Florez, Andre Franke, Gad Getz, Benjamin Glaser, Stephen J. Glatt, David Goldstein, Clicerio Gonzalez, Leif Groop, Christopher Haiman, Craig Hanis, Matthew Harms, Mikko Hiltunen, Matti M. Holi, Christina M. Hultman, Mikko Kallela, Jaakko Kaprio, Sekar Kathiresan, Bong-Jo Kim, Young Jin Kim, George Kirov, Jaspal Kooner, Seppo Koskinen, Harlan M. Krumholz, Subra Kugathasan, Soo Heon Kwak, Markku Laakso, Terho Lehtimäki, Ruth J. F. Loos, Steven A. Lubitz, Ronald C. W. Ma, Daniel G. MacArthur, Jaume Marrugat, Kari M. Mattila, Steven McCarroll, Mark I. McCarthy, Dermot McGovern, Ruth McPherson, James B. Meigs, Olle Melander, Andres Metspalu, Benjamin M. Neale, Peter M. Nilsson, Michael C. O’Donovan, Dost Ongur, Lorena Orozco, Michael J. Owen, Colin N. A. Palmer, Aarno Palotie, Kyong Soo Park, Carlos Pato, Ann E. Pulver, Nazneen Rahman, Anne M. Remes, John D. Rioux, Samuli Ripatti, Dan M. Roden, Danish Saleheen, Veikko Salomaa, Nilesh J. Samani, Jeremiah Scharf, Heribert Schunkert, Moore B. Shoemaker, Pamela Sklar, Hilkka Soininen, Harry Sokol, Tim Spector, Patrick F. Sullivan, Jaana Suvisaari, E. Shyong Tai, Yik Ying Teo, Tuomi Tiinamaija, Ming Tsuang, Dan Turner, Teresa Tusie-Luna, Erkki Vartiainen, Marquis P. Vawter, James S. Ware, Hugh Watkins, Rinse K. Weersma, Maija Wessman, James G. Wilson, Ramnik J. Xavier, Benjamin M. Neale, Mark J. Daly, Daniel G. MacArthur
+**Journal:** Nature (2020)
+**DOI:** [10.1038/s41586-020-2308-7](https://doi.org/10.1038/s41586-020-2308-7)
+
+## Content
+
+Abstract
+
+                    Genetic variants that inactivate protein-coding genes are a powerful source of information about the phenotypic consequences of gene disruption: genes that are crucial for the function of an organism will be depleted of such variants in natural populations, whereas non-essential genes will tolerate their accumulation. However, predicted loss-of-function variants are enriched for annotation errors, and tend to be found at extremely low frequencies, so their analysis requires careful variant annotation and very large sample sizes
+                    1
+                    . Here we describe the aggregation of 125,748 exomes and 15,708 genomes from human sequencing studies into the Genome Aggregation Database (gnomAD). We identify 443,769 high-confidence predicted loss-of-function variants in this cohort after filtering for artefacts caused by sequencing and annotation errors. Using an improved model of human mutation rates, we classify human protein-coding genes along a spectrum that represents tolerance to inactivation, validate this classification using data from model organisms and engineered human cells, and show that it can be used to improve the power of gene discovery for both common and rare diseases.

--- a/references_cache/DOI_10.1073_pnas.2421752122.md
+++ b/references_cache/DOI_10.1073_pnas.2421752122.md
@@ -1,0 +1,26 @@
+---
+reference_id: DOI:10.1073/pnas.2421752122
+title: Genetic testing predicts appearance but not behavior in dogs
+authors:
+- Kathryn A. Lord
+- Vista Sohrab
+- Kasia Bryc
+- Michelle E. White
+- Brittney Kenney
+- Kathleen Morrill Pirovich
+- Frances L. Chen
+- Elinor K. Karlsson
+journal: Proceedings of the National Academy of Sciences
+year: '2025'
+doi: 10.1073/pnas.2421752122
+content_type: abstract_only
+---
+
+# Genetic testing predicts appearance but not behavior in dogs
+**Authors:** Kathryn A. Lord, Vista Sohrab, Kasia Bryc, Michelle E. White, Brittney Kenney, Kathleen Morrill Pirovich, Frances L. Chen, Elinor K. Karlsson
+**Journal:** Proceedings of the National Academy of Sciences (2025)
+**DOI:** [10.1073/pnas.2421752122](https://doi.org/10.1073/pnas.2421752122)
+
+## Content
+
+Genetic tests for behavioral and personality traits in dogs are now being marketed to pet owners, but their predictive accuracy has not been validated. To evaluate the reliability of such tests, we analyzed data from Darwin’s Ark, a community science initiative that includes over 3,000 dogs with both genetic data and individual-level behavioral phenotypes. None of the candidate variants had significant associations or predictive power for behavioral traits as previously reported. However, we found strong associations with aesthetic traits that differentiate breeds, such as height, leg length, and ear shape. Our results suggest that earlier studies using breed-average phenotypes, rather than individually measured phenotypes, were confounded by population structure. Behavior in dogs is polygenic and complex, and thus cannot be accurately predicted using tests that consider only a few genetic variants. Furthermore, behavior in dogs is only moderately heritable, and environmental influences inherently limit the potential accuracy of genomic predictions. Developing meaningful, accurate genetic predictions for complex traits that can improve dog health and welfare will require very large cohorts of individually phenotyped dogs.

--- a/references_cache/DOI_10.1093_nar_gkae928.md
+++ b/references_cache/DOI_10.1093_nar_gkae928.md
@@ -1,0 +1,28 @@
+---
+reference_id: DOI:10.1093/nar/gkae928
+title: "Dog10K: an integrated Dog10K database summarizing canine multi-omics"
+authors:
+- Tong Zhou
+- Shao-Yan Pu
+- Shao-Jie Zhang
+- Qi-Jun Zhou
+- Min Zeng
+- Jing-Sheng Lu
+- Xuemei Lu
+- Ya-Nan Wang
+- Guo-Dong Wang
+journal: Nucleic Acids Research
+year: '2025'
+doi: 10.1093/nar/gkae928
+content_type: abstract_only
+---
+
+# Dog10K: an integrated Dog10K database summarizing canine multi-omics
+**Authors:** Tong Zhou, Shao-Yan Pu, Shao-Jie Zhang, Qi-Jun Zhou, Min Zeng, Jing-Sheng Lu, Xuemei Lu, Ya-Nan Wang, Guo-Dong Wang
+**Journal:** Nucleic Acids Research (2025)
+**DOI:** [10.1093/nar/gkae928](https://doi.org/10.1093/nar/gkae928)
+
+## Content
+
+Abstract
+The diversity observed in canine breed phenotypes, together with their risk for heritabily disorders of relevance to dogs and humans, makes the species an ideal subject for studies aimed at understanding the genetic basis of complex traits and human biomedical models. Dog10K is an ongoing international collaboration that aims to uncover the genetic basis of phenotypic diversity, disease, behavior, and domestication history of dogs. To best present and make the extensive data accessible and user friendly, we have established the Dog10K (http://dog10k.kiz.ac.cn/) database, a comprehensive-omics resource summarizing multiple types of data. This database integrates single nucleotide variants (SNVs) from 1987 canine genomes, de-novo mutations (DNMs) from 43 dog breeds with &gt;40× sequence, RNA-seq data of 105057 single nuclei from hippocampus, 74067 single cells from leukocytes and 30 blood samples from published canid studies. We provide clear visualization, statistics, browse, searching, and downloading functions for all data. We have integrated three analysis tools, Selscan, LiftOver and AgeConversion, to aid researchers in custom exploration of the comprehensive-omics data. The Dog10K database will serve as a foundational platform for analyzing, presenting and utilizing canine multi-omics data.

--- a/references_cache/DOI_10.1186_s13059-023-03023-7.md
+++ b/references_cache/DOI_10.1186_s13059-023-03023-7.md
@@ -1,0 +1,74 @@
+---
+reference_id: DOI:10.1186/s13059-023-03023-7
+title: "Genome sequencing of 2000 canids by the Dog10K consortium advances the understanding of demography, genome function and architecture"
+authors:
+- Jennifer R. S. Meadows
+- Jeffrey M. Kidd
+- Guo-Dong Wang
+- Heidi G. Parker
+- Peter Z. Schall
+- Matteo Bianchi
+- Matthew J. Christmas
+- Katia Bougiouri
+- Reuben M. Buckley
+- Christophe Hitte
+- Anthony K. Nguyen
+- Chao Wang
+- Vidhya Jagannathan
+- Julia E. Niskanen
+- Laurent A. F. Frantz
+- Meharji Arumilli
+- Sruthi Hundi
+- Kerstin Lindblad-Toh
+- Catarina Ginja
+- Kadek Karang Agustina
+- Catherine André
+- Adam R. Boyko
+- Brian W. Davis
+- Michaela Drögemüller
+- Xin-Yao Feng
+- Konstantinos Gkagkavouzis
+- Giorgos Iliopoulos
+- Alexander C. Harris
+- Marjo K. Hytönen
+- Daniela C. Kalthoff
+- Yan-Hu Liu
+- Petros Lymberakis
+- Nikolaos Poulakakis
+- Ana Elisabete Pires
+- Fernando Racimo
+- Fabian Ramos-Almodovar
+- Peter Savolainen
+- Semina Venetsani
+- Imke Tammen
+- Alexandros Triantafyllidis
+- Bridgett vonHoldt
+- Robert K. Wayne
+- Greger Larson
+- Frank W. Nicholas
+- Hannes Lohi
+- Tosso Leeb
+- Ya-Ping Zhang
+- Elaine A. Ostrander
+journal: Genome Biology
+year: '2023'
+doi: 10.1186/s13059-023-03023-7
+content_type: abstract_only
+---
+
+# Genome sequencing of 2000 canids by the Dog10K consortium advances the understanding of demography, genome function and architecture
+**Authors:** Jennifer R. S. Meadows, Jeffrey M. Kidd, Guo-Dong Wang, Heidi G. Parker, Peter Z. Schall, Matteo Bianchi, Matthew J. Christmas, Katia Bougiouri, Reuben M. Buckley, Christophe Hitte, Anthony K. Nguyen, Chao Wang, Vidhya Jagannathan, Julia E. Niskanen, Laurent A. F. Frantz, Meharji Arumilli, Sruthi Hundi, Kerstin Lindblad-Toh, Catarina Ginja, Kadek Karang Agustina, Catherine André, Adam R. Boyko, Brian W. Davis, Michaela Drögemüller, Xin-Yao Feng, Konstantinos Gkagkavouzis, Giorgos Iliopoulos, Alexander C. Harris, Marjo K. Hytönen, Daniela C. Kalthoff, Yan-Hu Liu, Petros Lymberakis, Nikolaos Poulakakis, Ana Elisabete Pires, Fernando Racimo, Fabian Ramos-Almodovar, Peter Savolainen, Semina Venetsani, Imke Tammen, Alexandros Triantafyllidis, Bridgett vonHoldt, Robert K. Wayne, Greger Larson, Frank W. Nicholas, Hannes Lohi, Tosso Leeb, Ya-Ping Zhang, Elaine A. Ostrander
+**Journal:** Genome Biology (2023)
+**DOI:** [10.1186/s13059-023-03023-7](https://doi.org/10.1186/s13059-023-03023-7)
+
+## Content
+
+Abstract
+Background
+The international Dog10K project aims to sequence and analyze several thousand canine genomes. Incorporating 20 × data from 1987 individuals, including 1611 dogs (321 breeds), 309 village dogs, 63 wolves, and four coyotes, we identify genomic variation across the canid family, setting the stage for detailed studies of domestication, behavior, morphology, disease susceptibility, and genome architecture and function.
+
+Results
+We report the analysis of > 48 M single-nucleotide, indel, and structural variants spanning the autosomes, X chromosome, and mitochondria. We discover more than 75% of variation for 239 sampled breeds. Allele sharing analysis indicates that 94.9% of breeds form monophyletic clusters and 25 major clades. German Shepherd Dogs and related breeds show the highest allele sharing with independent breeds from multiple clades. On average, each breed dog differs from the UU_Cfam_GSD_1.0 reference at 26,960 deletions and 14,034 insertions greater than 50 bp, with wolves having 14% more variants. Discovered variants include retrogene insertions from 926 parent genes. To aid functional prioritization, single-nucleotide variants were annotated with SnpEff and Zoonomia phyloP constraint scores. Constrained positions were negatively correlated with allele frequency. Finally, the utility of the Dog10K data as an imputation reference panel is assessed, generating high-confidence calls across varied genotyping platform densities including for breeds not included in the Dog10K collection.
+
+Conclusions
+We have developed a dense dataset of 1987 sequenced canids that reveals patterns of allele sharing, identifies likely functional variants, informs breed structure, and enables accurate imputation. Dog10K data are publicly available.

--- a/references_cache/DOI_10.64898_2026.04.13.718238.md
+++ b/references_cache/DOI_10.64898_2026.04.13.718238.md
@@ -1,0 +1,23 @@
+---
+reference_id: DOI:10.64898/2026.04.13.718238
+title: "CanVAS: A Harmonized and Imputed Canine Variant Atlas"
+authors:
+- David M. Brundage
+year: '2026'
+doi: 10.64898/2026.04.13.718238
+content_type: abstract_only
+---
+
+# CanVAS: A Harmonized and Imputed Canine Variant Atlas
+**Authors:** David M. Brundage
+**DOI:** [10.64898/2026.04.13.718238](https://doi.org/10.64898/2026.04.13.718238)
+
+## Content
+
+Abstract
+
+                  The domestic dog (
+                  Canis lupus familiaris
+                  ) is a powerful model for genetic studies of complex disease, but canine genotype data are distributed across independent studies using incompatible genotyping platforms, genome builds, strand conventions, and allele coding schemes. Here we present CanVAS, a quality-controlled, harmonized, and imputed canine genotype resource integrating 15 publicly available datasets into a single analysis-ready PLINK file set on the CanFam4 (UU_Cfam_GSD_1.0) reference assembly. The typed backbone contains 15,451 dogs from over 375 breeds, village dog populations, dingoes, wolves, and coyotes, genotyped across 77,215 shared SNPs. Imputation against the Dog10K whole-genome sequencing reference panel (1,929 dogs) using Beagle 5.4 expanded the resource to 9.7 million variants (DR2 ≥ 0.3, MAF ≥ 0.01), including approximately 3 million rare variants (MAF
+                  <
+                  0.05). We describe the complete harmonization pipeline and validate the resource through population structure analysis and genome-wide runs-of-homozygosity analysis, recovering known breed-level differences in genomic inbreeding.

--- a/resource/canvas/canvas.md
+++ b/resource/canvas/canvas.md
@@ -1,0 +1,77 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Individual
+    label: David M. Brundage
+    contact_details:
+      - contact_type: github
+        value: Brundage-VAIL
+creation_date: '2026-08-12T00:00:00Z'
+description: A harmonized and imputed canine variant atlas, unifying genotypes from fifteen previously incomparable dog cohorts into a single set of 9.67 million variants on the CanFam4 reference assembly.
+domains:
+  - genomics
+  - organisms
+homepage_url: https://github.com/Brundage-VAIL/CanVAS
+id: canvas
+last_modified_date: '2026-08-12T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC-BY-4.0
+name: CanVAS
+products:
+  - category: Product
+    description: The imputed CanVAS genotype set as a PLINK binary fileset, restricted to variants with minor allele frequency at or above 1%, in CanFam4 coordinates.
+    format: mixed
+    id: canvas.imputed
+    name: CanVAS imputed genotypes
+    latest_version: v1
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: canvas
+    secondary_source:
+      - relation_type: prov:wasDerivedFrom
+        source: dog10k
+      - relation_type: prov:wasDerivedFrom
+        source: darwins-ark
+    product_url: https://zenodo.org/records/19186944
+  - category: Product
+    description: The CanVAS backbone genotype set, comprising sites genotyped in at least 90% of samples prior to imputation, as a PLINK binary fileset in CanFam4 coordinates.
+    format: mixed
+    id: canvas.backbone
+    name: CanVAS backbone genotypes
+    latest_version: v1
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: canvas
+    product_url: https://zenodo.org/records/19186944
+  - category: Product
+    description: Sample-level metadata for the CanVAS cohort, including breed assignment and contributing study for each dog.
+    format: tsv
+    id: canvas.metadata
+    name: CanVAS sample metadata
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: canvas
+    product_url: https://zenodo.org/records/19186944
+publications:
+  - id: https://doi.org/10.64898/2026.04.13.718238
+    doi: doi:10.64898/2026.04.13.718238
+    title: 'CanVAS: A Harmonized and Imputed Canine Variant Atlas'
+    journal: bioRxiv
+    year: '2026'
+    preferred: true
+    authors:
+      - David M. Brundage
+repository: https://github.com/Brundage-VAIL/CanVAS
+taxon:
+  - NCBITaxon:9615
+version: v1
+---
+
+CanVAS is a harmonized and imputed canine variant atlas that unifies genotype data from fifteen research cohorts which had previously been incomparable because they used different genotyping arrays and reference genomes.
+
+The atlas covers 15,451 dogs across more than 375 breeds, together with village dog populations and wild canids, and reports 9.67 million variants. Genotypes were harmonized to CanFam4 reference coordinates, standardized for probe identifiers and strand conventions, and imputed against the Dog10K reference panel using Beagle 5.4.
+
+CanVAS supplies the variant layer underlying the Sniff Atlas.

--- a/resource/darwins-ark/darwins-ark.md
+++ b/resource/darwins-ark/darwins-ark.md
@@ -1,0 +1,78 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Organization
+    label: Darwin's Ark
+    contact_details:
+      - contact_type: url
+        value: https://darwinsark.org/
+      - contact_type: github
+        value: DarwinsArk
+creation_date: '2026-08-12T00:00:00Z'
+description: A community science project collecting owner-reported behavioral and physical survey data alongside whole genome sequence data for pet dogs, and releasing the combined dataset openly.
+domains:
+  - genomics
+  - organisms
+  - phenotype
+homepage_url: https://darwinsark.org/
+id: darwins-ark
+last_modified_date: '2026-08-12T00:00:00Z'
+layout: resource_detail
+name: Darwin's Ark
+products:
+  - category: Product
+    description: A PLINK binary fileset of genotypes from 3,277 dog whole genomes, with sample identifiers matching the dog identifiers used in the Darwin's Ark survey data files. Sequencing data are deposited under BioProject PRJNA675863.
+    format: mixed
+    id: darwins-ark.genotypes
+    name: Darwin's Ark dog genotypes
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: darwins-ark
+    product_url: https://datadryad.org/dataset/doi:10.5061/dryad.83bk3jb4r
+  - category: Product
+    description: Owner-reported survey data covering behavioral and physical traits for dogs enrolled in Darwin's Ark, keyed to the same dog identifiers as the genotype data.
+    format: csv
+    id: darwins-ark.surveys
+    name: Darwin's Ark survey data
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: darwins-ark
+    product_url: https://datadryad.org/dataset/doi:10.5061/dryad.83bk3jb4r
+  - category: GraphicalInterface
+    description: The Darwin's Ark website, where owners enroll dogs, complete behavioral surveys, and browse project results.
+    format: http
+    id: darwins-ark.website
+    name: Darwin's Ark website
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: darwins-ark
+    product_url: https://darwinsark.org/
+publications:
+  - id: https://doi.org/10.1073/pnas.2421752122
+    doi: doi:10.1073/pnas.2421752122
+    title: Genetic testing predicts appearance but not behavior in dogs
+    journal: Proceedings of the National Academy of Sciences
+    year: '2025'
+    preferred: true
+    authors:
+      - Kathryn A. Lord
+      - Vista Sohrab
+      - Kasia Bryc
+      - Michelle E. White
+      - Brittney Kenney
+      - Kathleen Morrill Pirovich
+      - Frances L. Chen
+      - Elinor K. Karlsson
+repository: https://github.com/DarwinsArk
+synonyms:
+  - Darwin's Dogs
+taxon:
+  - NCBITaxon:9615
+---
+
+Darwin's Ark is a community science project that pairs owner-reported survey data on dog behavior and physical traits with whole genome sequence data, and releases the combined dataset openly for reuse. It is run by researchers associated with UMass Chan Medical School and the Broad Institute.
+
+The most recent open release covers genotypes from 3,277 dog whole genomes, distributed as a PLINK binary fileset keyed to the project's survey data, with underlying sequencing deposited under BioProject PRJNA675863.
+
+The associated analysis examined 151 genetic variants that had been marketed as predictors of canine behavior and found that none reliably predicted how an individual dog actually behaves, while variants associated with aesthetic traits that differentiate breeds, such as height, leg length, and ear shape, did show strong associations. Darwin's Ark contributes mixed-breed genomes to the canine variant resources built downstream of it, including CanVAS and the Sniff Atlas.

--- a/resource/dog10k/dog10k.md
+++ b/resource/dog10k/dog10k.md
@@ -1,0 +1,127 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Organization
+    label: Dog10K Consortium
+    contact_details:
+      - contact_type: url
+        value: http://www.dog10kgenomes.org/
+creation_date: '2026-08-12T00:00:00Z'
+description: An international consortium sequencing canine genomes across breeds, village dogs, and wild canids, producing a reference catalogue of canine genetic variation that serves as an imputation reference panel.
+domains:
+  - genomics
+  - organisms
+homepage_url: http://www.dog10kgenomes.org/
+id: dog10k
+last_modified_date: '2026-08-12T00:00:00Z'
+layout: resource_detail
+name: Dog10K
+products:
+  - category: Product
+    description: Variant call files and associated annotations from the Dog10K consortium, covering single nucleotide variants, copy number variants, and structural variants across sequenced canids.
+    format: vcf
+    id: dog10k.variants
+    name: Dog10K variant files
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: dog10k
+    product_url: https://kiddlabshare.med.umich.edu/dog10K/
+  - category: Product
+    description: An archived release of Dog10K variant data and annotations deposited on Zenodo.
+    format: vcf
+    id: dog10k.zenodo
+    name: Dog10K variant data archive
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: dog10k
+    product_url: https://zenodo.org/record/8084059
+  - category: GraphicalInterface
+    description: The Dog10K database web interface, providing browsing of canine multi-omics data including variation, de novo mutations, single-cell RNA sequencing, and transcriptomic data.
+    format: http
+    id: dog10k.browser
+    name: Dog10K database
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: dog10k
+    product_url: https://dog10k.kiz.ac.cn/
+publications:
+  - id: https://doi.org/10.1186/s13059-023-03023-7
+    doi: doi:10.1186/s13059-023-03023-7
+    title: Genome sequencing of 2000 canids by the Dog10K consortium advances the understanding of demography, genome function and architecture
+    journal: Genome Biology
+    year: '2023'
+    preferred: true
+    authors:
+      - Jennifer R. S. Meadows
+      - Jeffrey M. Kidd
+      - Guo-Dong Wang
+      - Heidi G. Parker
+      - Peter Z. Schall
+      - Matteo Bianchi
+      - Matthew J. Christmas
+      - Katia Bougiouri
+      - Reuben M. Buckley
+      - Christophe Hitte
+      - Anthony K. Nguyen
+      - Chao Wang
+      - Vidhya Jagannathan
+      - Julia E. Niskanen
+      - Laurent A. F. Frantz
+      - Meharji Arumilli
+      - Sruthi Hundi
+      - Kerstin Lindblad-Toh
+      - Catarina Ginja
+      - Kadek Karang Agustina
+      - Catherine André
+      - Adam R. Boyko
+      - Brian W. Davis
+      - Michaela Drögemüller
+      - Xin-Yao Feng
+      - Konstantinos Gkagkavouzis
+      - Giorgos Iliopoulos
+      - Alexander C. Harris
+      - Marjo K. Hytönen
+      - Daniela C. Kalthoff
+      - Yan-Hu Liu
+      - Petros Lymberakis
+      - Nikolaos Poulakakis
+      - Ana Elisabete Pires
+      - Fernando Racimo
+      - Fabian Ramos-Almodovar
+      - Peter Savolainen
+      - Semina Venetsani
+      - Imke Tammen
+      - Alexandros Triantafyllidis
+      - Bridgett vonHoldt
+      - Robert K. Wayne
+      - Greger Larson
+      - Frank W. Nicholas
+      - Hannes Lohi
+      - Tosso Leeb
+      - Ya-Ping Zhang
+      - Elaine A. Ostrander
+  - id: https://doi.org/10.1093/nar/gkae928
+    doi: doi:10.1093/nar/gkae928
+    title: 'Dog10K: an integrated Dog10K database summarizing canine multi-omics'
+    journal: Nucleic Acids Research
+    year: '2025'
+    authors:
+      - Tong Zhou
+      - Shao-Yan Pu
+      - Shao-Jie Zhang
+      - Qi-Jun Zhou
+      - Min Zeng
+      - Jing-Sheng Lu
+      - Xuemei Lu
+      - Ya-Nan Wang
+      - Guo-Dong Wang
+taxon:
+  - NCBITaxon:9615
+---
+
+Dog10K is an international consortium of canine genomics researchers formed to sequence 10,000 canids at high coverage, with the aim of uncovering the genetic basis of phenotypic diversity, disease, behavior, and domestication history in dogs.
+
+The Dog10K.v1 release provides genome sequence data and analysis for 2,000 canids spanning hundreds of breeds, village dogs, and wild canids. The resulting variant catalogue is widely reused as a reference panel for imputing genome-wide genotypes from sparse genotyping arrays, which is the role it plays for CanVAS and, downstream of that, for the Sniff Atlas.
+
+The Dog10K database additionally aggregates canine multi-omics data, including variation, de novo mutations from 404 trios, single-cell RNA sequencing, and transcriptomic data. Raw sequencing data are shared through the Genome Sequence Archive and the Sequence Read Archive.

--- a/resource/gnomad/gnomad.md
+++ b/resource/gnomad/gnomad.md
@@ -1,0 +1,250 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Organization
+    label: gnomAD Project, Broad Institute
+    contact_details:
+      - contact_type: url
+        value: https://gnomad.broadinstitute.org/policies
+creation_date: '2026-08-12T00:00:00Z'
+description: A reference catalogue of human genetic variation, aggregating and harmonizing exome and genome sequencing data from large-scale sequencing projects to provide population allele frequencies and gene-level constraint metrics.
+domains:
+  - genomics
+  - biomedical
+  - precision medicine
+homepage_url: https://gnomad.broadinstitute.org/
+id: gnomad
+last_modified_date: '2026-08-12T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://creativecommons.org/publicdomain/zero/1.0/
+  label: CC0 1.0
+name: Genome Aggregation Database (gnomAD)
+products:
+  - category: GraphicalInterface
+    description: The gnomAD browser, providing search and display of variants, genes, transcripts, and regions with population allele frequencies and constraint metrics.
+    format: http
+    id: gnomad.browser
+    name: gnomAD browser
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: gnomad
+    product_url: https://gnomad.broadinstitute.org/
+  - category: Product
+    description: Bulk downloads of gnomAD variant data, coverage, and constraint files, distributed as VCF and Hail Table formats. Also mirrored on the AWS Registry of Open Data.
+    format: vcf
+    id: gnomad.downloads
+    name: gnomAD data downloads
+    latest_version: 4.1.1
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: gnomad
+    product_url: https://gnomad.broadinstitute.org/downloads
+  - category: ProgrammingInterface
+    description: A public GraphQL API for programmatic queries against gnomAD variant and gene data.
+    format: graphql
+    id: gnomad.api
+    is_public: true
+    name: gnomAD GraphQL API
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: gnomad
+    product_url: https://gnomad.broadinstitute.org/api
+publications:
+  - id: https://doi.org/10.1038/s41586-020-2308-7
+    doi: doi:10.1038/s41586-020-2308-7
+    title: The mutational constraint spectrum quantified from variation in 141,456 humans
+    journal: Nature
+    year: '2020'
+    preferred: true
+    authors:
+      - Konrad J. Karczewski
+      - Laurent C. Francioli
+      - Grace Tiao
+      - Beryl B. Cummings
+      - Jessica Alföldi
+      - Qingbo Wang
+      - Ryan L. Collins
+      - Kristen M. Laricchia
+      - Andrea Ganna
+      - Daniel P. Birnbaum
+      - Laura D. Gauthier
+      - Harrison Brand
+      - Matthew Solomonson
+      - Nicholas A. Watts
+      - Daniel Rhodes
+      - Moriel Singer-Berk
+      - Eleina M. England
+      - Eleanor G. Seaby
+      - Jack A. Kosmicki
+      - Raymond K. Walters
+      - Katherine Tashman
+      - Yossi Farjoun
+      - Eric Banks
+      - Timothy Poterba
+      - Arcturus Wang
+      - Cotton Seed
+      - Nicola Whiffin
+      - Jessica X. Chong
+      - Kaitlin E. Samocha
+      - Emma Pierce-Hoffman
+      - Zachary Zappala
+      - Anne H. O’Donnell-Luria
+      - Eric Vallabh Minikel
+      - Ben Weisburd
+      - Monkol Lek
+      - James S. Ware
+      - Christopher Vittal
+      - Irina M. Armean
+      - Louis Bergelson
+      - Kristian Cibulskis
+      - Kristen M. Connolly
+      - Miguel Covarrubias
+      - Stacey Donnelly
+      - Steven Ferriera
+      - Stacey Gabriel
+      - Jeff Gentry
+      - Namrata Gupta
+      - Thibault Jeandet
+      - Diane Kaplan
+      - Christopher Llanwarne
+      - Ruchi Munshi
+      - Sam Novod
+      - Nikelle Petrillo
+      - David Roazen
+      - Valentin Ruano-Rubio
+      - Andrea Saltzman
+      - Molly Schleicher
+      - Jose Soto
+      - Kathleen Tibbetts
+      - Charlotte Tolonen
+      - Gordon Wade
+      - Michael E. Talkowski
+      - Carlos A. Aguilar Salinas
+      - Tariq Ahmad
+      - Christine M. Albert
+      - Diego Ardissino
+      - Gil Atzmon
+      - John Barnard
+      - Laurent Beaugerie
+      - Emelia J. Benjamin
+      - Michael Boehnke
+      - Lori L. Bonnycastle
+      - Erwin P. Bottinger
+      - Donald W. Bowden
+      - Matthew J. Bown
+      - John C. Chambers
+      - Juliana C. Chan
+      - Daniel Chasman
+      - Judy Cho
+      - Mina K. Chung
+      - Bruce Cohen
+      - Adolfo Correa
+      - Dana Dabelea
+      - Mark J. Daly
+      - Dawood Darbar
+      - Ravindranath Duggirala
+      - Josée Dupuis
+      - Patrick T. Ellinor
+      - Roberto Elosua
+      - Jeanette Erdmann
+      - Tõnu Esko
+      - Martti Färkkilä
+      - Jose Florez
+      - Andre Franke
+      - Gad Getz
+      - Benjamin Glaser
+      - Stephen J. Glatt
+      - David Goldstein
+      - Clicerio Gonzalez
+      - Leif Groop
+      - Christopher Haiman
+      - Craig Hanis
+      - Matthew Harms
+      - Mikko Hiltunen
+      - Matti M. Holi
+      - Christina M. Hultman
+      - Mikko Kallela
+      - Jaakko Kaprio
+      - Sekar Kathiresan
+      - Bong-Jo Kim
+      - Young Jin Kim
+      - George Kirov
+      - Jaspal Kooner
+      - Seppo Koskinen
+      - Harlan M. Krumholz
+      - Subra Kugathasan
+      - Soo Heon Kwak
+      - Markku Laakso
+      - Terho Lehtimäki
+      - Ruth J. F. Loos
+      - Steven A. Lubitz
+      - Ronald C. W. Ma
+      - Daniel G. MacArthur
+      - Jaume Marrugat
+      - Kari M. Mattila
+      - Steven McCarroll
+      - Mark I. McCarthy
+      - Dermot McGovern
+      - Ruth McPherson
+      - James B. Meigs
+      - Olle Melander
+      - Andres Metspalu
+      - Benjamin M. Neale
+      - Peter M. Nilsson
+      - Michael C. O’Donovan
+      - Dost Ongur
+      - Lorena Orozco
+      - Michael J. Owen
+      - Colin N. A. Palmer
+      - Aarno Palotie
+      - Kyong Soo Park
+      - Carlos Pato
+      - Ann E. Pulver
+      - Nazneen Rahman
+      - Anne M. Remes
+      - John D. Rioux
+      - Samuli Ripatti
+      - Dan M. Roden
+      - Danish Saleheen
+      - Veikko Salomaa
+      - Nilesh J. Samani
+      - Jeremiah Scharf
+      - Heribert Schunkert
+      - Moore B. Shoemaker
+      - Pamela Sklar
+      - Hilkka Soininen
+      - Harry Sokol
+      - Tim Spector
+      - Patrick F. Sullivan
+      - Jaana Suvisaari
+      - E. Shyong Tai
+      - Yik Ying Teo
+      - Tuomi Tiinamaija
+      - Ming Tsuang
+      - Dan Turner
+      - Teresa Tusie-Luna
+      - Erkki Vartiainen
+      - Marquis P. Vawter
+      - James S. Ware
+      - Hugh Watkins
+      - Rinse K. Weersma
+      - Maija Wessman
+      - James G. Wilson
+      - Ramnik J. Xavier
+      - Benjamin M. Neale
+      - Mark J. Daly
+      - Daniel G. MacArthur
+synonyms:
+  - gnomAD
+taxon:
+  - NCBITaxon:9606
+version: 4.1.1
+---
+
+The Genome Aggregation Database (gnomAD) is a resource developed by an international coalition of investigators to aggregate and harmonize exome and genome sequencing data from a wide variety of large-scale sequencing projects. It is hosted by the Broad Institute.
+
+The v4.1 dataset, aligned to GRCh38, spans 730,947 exome sequences and 76,215 whole-genome sequences from unrelated individuals of diverse ancestries. gnomAD is widely used as a population reference for variant interpretation, providing allele frequencies stratified by genetic ancestry group alongside gene-level constraint metrics.
+
+Primary data from the gnomAD exomes and genomes are released free of restrictions under the Creative Commons Zero Public Domain Dedication, though the project requests attribution where possible.

--- a/resource/omia/omia.md
+++ b/resource/omia/omia.md
@@ -1,0 +1,80 @@
+---
+activity_status: active
+category: DataSource
+contacts:
+  - category: Organization
+    label: Sydney School of Veterinary Science, University of Sydney
+    contact_details:
+      - contact_type: url
+        value: https://omia.org/home/
+creation_date: '2026-08-12T00:00:00Z'
+description: A catalogue of inherited disorders, other single-locus traits, and associated genes and variants in animals, covering 786 mostly vertebrate species.
+domains:
+  - organisms
+  - genomics
+  - phenotype
+  - agriculture
+homepage_url: https://omia.org/
+id: omia
+last_modified_date: '2026-08-12T00:00:00Z'
+layout: resource_detail
+name: Online Mendelian Inheritance in Animals (OMIA)
+products:
+  - category: GraphicalInterface
+    description: The OMIA web interface, providing browsing and search of phenes, species, genes, and likely causal variants.
+    format: http
+    id: omia.browser
+    name: OMIA web interface
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: omia
+    product_url: https://omia.org/home/
+  - category: Product
+    description: A full dump of the OMIA database as MySQL SQL statements. The OMIA team asks to be contacted to discuss co-authorship arrangements for publications relying on this dump or on extended data.
+    compression: gzip
+    format: mysql
+    id: omia.sql-dump
+    name: OMIA SQL database dump
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: omia
+    product_url: https://omia.org/static/omia.sql.gz
+  - category: Product
+    description: A full dump of the OMIA database in XML format.
+    compression: gzip
+    format: xml
+    id: omia.xml-dump
+    name: OMIA XML database dump
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: omia
+    product_url: https://omia.org/static/omia.xml.gz
+  - category: Product
+    description: VCF exports of OMIA likely causal variants, given in the coordinates of the relevant species reference assemblies.
+    format: vcf
+    id: omia.vcf-exports
+    name: OMIA variant VCF exports
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: omia
+    product_url: https://omia.org/download/vcf_exports/
+  - category: MappingProduct
+    description: A CSV mapping OMIA internal gene identifiers to NCBI Gene identifiers.
+    format: csv
+    id: omia.gene-mappings
+    name: OMIA to NCBI Gene mappings
+    original_source:
+      - relation_type: prov:hadPrimarySource
+        source: omia
+      - relation_type: prov:hadPrimarySource
+        source: ncbigene
+    product_url: https://omia.org/download/csv/genes/
+synonyms:
+  - OMIA
+---
+
+Online Mendelian Inheritance in Animals (OMIA) is a catalogue of inherited disorders, other single-locus traits, and associated genes and variants in animals. It is curated at the Sydney School of Veterinary Science, University of Sydney, founded by Frank Nicholas and curated by Imke Tammen.
+
+OMIA covers 786 mostly vertebrate species, with 6,046 traits recorded in total, of which 2,120 are single-gene traits and 1,518 are single-gene diseases, alongside 1,793 known likely causal variants. Dogs account for the largest share of entries, with 1,014 traits, which makes OMIA the reference catalogue for canine inherited disease.
+
+OMIA has been a free internet resource for over 30 years. Note that the site does not carry an explicit license statement, so no license is recorded here; the project asks users to cite OMIA, to acknowledge software support from the Sydney Informatics Hub, and to make contact to discuss co-authorship for publications that rely on the full MySQL dump or extended data.

--- a/resource/sniff/sniff.md
+++ b/resource/sniff/sniff.md
@@ -47,6 +47,10 @@ products:
         source: ensembl
       - relation_type: prov:wasDerivedFrom
         source: mondo
+      - relation_type: prov:wasDerivedFrom
+        source: omia
+      - relation_type: prov:wasDerivedFrom
+        source: gnomad
     product_file_size: 3726803
     product_url: https://sniffdog-data.s3.amazonaws.com/federation/kgx/sniff_nodes.tsv
   - category: GraphProduct
@@ -72,6 +76,8 @@ products:
         source: ensembl
       - relation_type: prov:wasDerivedFrom
         source: mondo
+      - relation_type: prov:wasDerivedFrom
+        source: omia
     product_file_size: 5247253
     product_url: https://sniffdog-data.s3.amazonaws.com/federation/kgx/sniff_edges.tsv
   - category: Product
@@ -93,6 +99,13 @@ products:
     original_source:
       - relation_type: prov:hadPrimarySource
         source: sniff
+    secondary_source:
+      - relation_type: prov:wasDerivedFrom
+        source: canvas
+      - relation_type: prov:wasDerivedFrom
+        source: dog10k
+      - relation_type: prov:wasDerivedFrom
+        source: darwins-ark
     latest_version: 1.0.1
     product_url: https://zenodo.org/records/20566358
   - category: GraphicalInterface


### PR DESCRIPTION
Closes #694. Follow-up to #693, which is now merged — this PR is based on `main`.

Adds the five upstream sources that #693 could only name in prose, then wires Sniff's products to them.

## New resources

| ID | Name | Category | License |
| --- | --- | --- | --- |
| `gnomad` | Genome Aggregation Database (gnomAD) | DataSource | CC0 1.0 |
| `omia` | Online Mendelian Inheritance in Animals (OMIA) | DataSource | *none recorded* |
| `canvas` | CanVAS | DataSource | CC-BY-4.0 |
| `dog10k` | Dog10K | DataSource | *none recorded* |
| `darwins-ark` | Darwin's Ark | DataSource | *none recorded* |

Each carries products (browsers, dumps, APIs, archived datasets) plus cached publication references.

gnomAD is worth noting independently: it was already referenced in prose by `resource/genecards/genecards.md` with no entry of its own.

## Provenance wiring

Rather than blanket-linking all five to everything, each source is attached to the product it actually feeds, following the counts in Sniff's own [manifest](https://sniffdog-data.s3.amazonaws.com/federation/kgx/manifest.json):

- **KGX nodes** → `omia` (disease nodes) and `gnomad` (the 16,116 constrained gene nodes)
- **KGX edges** → `omia` (the 192 canine disease edges)
- **Atlas sites VCF** → `canvas`, `dog10k`, `darwins-ark` — these feed the variant catalogue, not the graph

`canvas` additionally links to `dog10k` (its Beagle 5.4 imputation panel) and `darwins-ark` (a contributing cohort).

## Verification

- All DOIs confirmed to resolve.
- Publication titles and author lists were injected programmatically from `references_cache` rather than typed by hand, so they match the fetched records exactly.
- `make validate-file` passes with no errors **and no warnings** on all six touched files.
- Every `source:` reference was checked to resolve to an existing `resource/` directory.

## Judgement calls worth a reviewer's eye

- **No license on `omia` and `dog10k`.** Neither states one. OMIA says it is "freely available" but carries no license text and asks to be contacted about co-authorship for work relying on the full MySQL dump — that is not an SPDX license, so the field is left unset rather than guessed. This is called out in the OMIA description.
- **ID spelling `darwins-ark`** (hyphenated), matching the dominant convention in `resource/`.
- **PLINK filesets recorded as `format: mixed`.** `FormatEnum` has no PLINK value, and a `.bed`/`.bim`/`.fam` set is genuinely multi-file.
- The Golden Retriever Lifetime Study remains prose-only; it is a cohort study rather than a data resource.

## Correction to the issue

Issue #694 lists the Dog10K database paper as `10.1093/nar/gkae1041`. The correct DOI is **`10.1093/nar/gkae928`**, which is what this PR uses.

## Separate schema nit

Both this PR and #693 hit the same snag: the `new-resource` issue template offers a **Product Format** option of `other`, which `FormatEnum` does not accept, so anything curated from that dropdown fails validation. Worth fixing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)