### PR TITLE
Add AOP-Wiki RDF resource and fix the dead OpenRiskNet SPARQL URLs

### DIFF
--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -233,6 +233,24 @@ entries:
     source_path: resource/aop-db/aop-db.md
     status: valid
     warnings: []
+  resource/aopwiki-rdf/aopwiki-rdf.md#publication[0]#DOI:10.1089/aivt.2021.0010:
+    checked_at: '2026-08-17T17:39:15Z'
+    errors: []
+    fingerprint: 376f23cbfae0386fbac6ae0e2328f4a80ef715724a8304378f6adcfa875e824f
+    publication_index: 0
+    reference_id: DOI:10.1089/aivt.2021.0010
+    source_path: resource/aopwiki-rdf/aopwiki-rdf.md
+    status: valid
+    warnings: []
+  resource/aopwiki-rdf/aopwiki-rdf.md#publication[1]#DOI:10.5281/zenodo.13353286:
+    checked_at: '2026-08-17T17:40:02Z'
+    errors: []
+    fingerprint: 49166ec6b569dc133cdbf8438821388f808a99ae020e5bed42e15c46a5a6d5e1
+    publication_index: 1
+    reference_id: DOI:10.5281/zenodo.13353286
+    source_path: resource/aopwiki-rdf/aopwiki-rdf.md
+    status: valid
+    warnings: []
   resource/apo/apo.md#publication[0]#PMID:20157474:
     checked_at: '2026-08-06T18:16:32Z'
     errors: []

--- a/references_cache/DOI_10.1089_aivt.2021.0010.md
+++ b/references_cache/DOI_10.1089_aivt.2021.0010.md
@@ -1,0 +1,19 @@
+---
+reference_id: DOI:10.1089/aivt.2021.0010
+title: Providing Adverse Outcome Pathways from the AOP-Wiki in a Semantic Web Format to Increase Usability and Accessibility of the Content
+authors:
+- Marvin Martens
+- Chris T. Evelo
+- Egon L. Willighagen
+journal: Applied In Vitro Toxicology
+year: '2022'
+doi: 10.1089/aivt.2021.0010
+content_type: unavailable
+---
+
+# Providing Adverse Outcome Pathways from the AOP-Wiki in a Semantic Web Format to Increase Usability and Accessibility of the Content
+**Authors:** Marvin Martens, Chris T. Evelo, Egon L. Willighagen
+**Journal:** Applied In Vitro Toxicology (2022)
+**DOI:** [10.1089/aivt.2021.0010](https://doi.org/10.1089/aivt.2021.0010)
+
+## Content

--- a/references_cache/DOI_10.5281_zenodo.13353286.md
+++ b/references_cache/DOI_10.5281_zenodo.13353286.md
@@ -1,0 +1,42 @@
+---
+reference_id: DOI:10.5281/zenodo.13353286
+title: Adverse Outcome Pathway Wiki RDF
+authors:
+- "Martens, Marvin"
+- "Willighagen, Egon"
+- "Evelo, Chris"
+journal: Zenodo
+year: '2026'
+doi: 10.5281/zenodo.13353286
+content_type: abstract_only
+supplementary_files:
+  - filename: AOPWikiRDF-Enriched.ttl
+    download_url: "https://zenodo.org/api/records/21736838/files/AOPWikiRDF-Enriched.ttl/content"
+    size_bytes: 199118
+    checksum: md5:b015703040d5cfba3f09e9f1c5549853
+  - filename: ServiceDescription.ttl
+    download_url: "https://zenodo.org/api/records/21736838/files/ServiceDescription.ttl/content"
+    size_bytes: 1549
+    checksum: md5:247f1c82b380dbaf6c79d46a6864e039
+  - filename: AOPWikiRDF-Void.ttl
+    download_url: "https://zenodo.org/api/records/21736838/files/AOPWikiRDF-Void.ttl/content"
+    size_bytes: 3473
+    checksum: md5:75819541f43ac00ce72211f135db470d
+  - filename: AOPWikiRDF-Genes.ttl
+    download_url: "https://zenodo.org/api/records/21736838/files/AOPWikiRDF-Genes.ttl/content"
+    size_bytes: 5164739
+    checksum: md5:87523cace13b5cd47efab2d0674590f0
+  - filename: AOPWikiRDF.ttl
+    download_url: "https://zenodo.org/api/records/21736838/files/AOPWikiRDF.ttl/content"
+    size_bytes: 20394511
+    checksum: md5:0931efd2b6ba5cf75bc3bff7666a966f
+---
+
+# Adverse Outcome Pathway Wiki RDF
+**Authors:** Martens, Marvin, Willighagen, Egon, Evelo, Chris
+**Journal:** Zenodo (2026)
+**DOI:** [10.5281/zenodo.13353286](https://doi.org/10.5281/zenodo.13353286)
+
+## Content
+
+This dataset is the RDF generated from the AOP-Wiki data release (aopwiki.org/downloads). It was generated using a Python conversion pipeline that is available on GitHub (github.com/marvinm2/AOPWikiRDF), and the process and additional description of the RDF have been published (doi.org/10.1089/aivt.2021.0010).

--- a/resource/aopwiki-rdf/aopwiki-rdf.md
+++ b/resource/aopwiki-rdf/aopwiki-rdf.md
@@ -1,0 +1,213 @@
+---
+activity_status: active
+category: KnowledgeGraph
+collection:
+  - aop
+contacts:
+  - category: Individual
+    contact_details:
+      - contact_type: github
+        value: marvinm2
+      - contact_type: url
+        value: https://orcid.org/0000-0003-2230-0840
+    label: Marvin Martens
+  - category: Individual
+    contact_details:
+      - contact_type: url
+        value: https://orcid.org/0000-0001-7542-0286
+    label: Egon Willighagen
+creation_date: '2026-08-17T00:00:00Z'
+description: AOP-Wiki RDF is an RDF representation of the AOP-Wiki, the authoring interface of the Adverse Outcome Pathway Knowledge Base. The AOP-Wiki XML export is converted to RDF/Turtle every week using the AOP Ontology (aopo) together with Dublin Core, CHEMINF and NCIT, and is enriched with gene mappings (gene names in key events matched to HGNC symbols and resolved to Ensembl, NCBI Gene, UniProt and Protein Ontology identifiers through BridgeDb) and chemical cross-references. AOPs, key events, key event relationships, biological events, stressors and chemicals get identifiers.org URIs and are linked to ChEBI, GO, PATO, UBERON, CL, NCBITaxon and HGNC. The 2026.08.15 release has about 340,000 triples, covering 595 AOPs, 1,595 key events, 2,360 key event relationships, 754 stressors and 430 chemicals. The data is served from a public SPARQL endpoint with a SNORQL query interface on top of it. A grlc REST API built from the same curated query library, a second endpoint holding every quarterly AOP-Wiki snapshot since 2018 as named graphs, and a dashboard for version-over-version trends are also available.
+domains:
+  - toxicology
+  - environment
+  - pathways
+  - chemistry and biochemistry
+homepage_url: https://aopwiki.rdf.bigcat-bioinformatics.org/
+id: aopwiki-rdf
+language: en
+last_modified_date: '2026-08-17T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by-sa/4.0/
+  label: CC BY-SA 4.0
+name: AOP-Wiki RDF
+products:
+  - category: ProgrammingInterface
+    connection_url: https://aopwiki.rdf.bigcat-bioinformatics.org/sparql
+    description: Public SPARQL 1.1 endpoint (Virtuoso 7.2.11) serving the AOP-Wiki RDF graph, including the gene-mapping and cross-reference enrichments. Supports SELECT, CONSTRUCT, ASK and DESCRIBE over HTTP GET/POST with JSON, XML, CSV and Turtle result serializations, and federated queries via SERVICE. Reloaded weekly from the generated Turtle files.
+    format: http
+    id: aopwiki-rdf.sparql
+    is_public: true
+    name: AOP-Wiki RDF SPARQL Endpoint
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://aopwiki.rdf.bigcat-bioinformatics.org/sparql
+  - category: GraphicalInterface
+    description: SNORQL web interface ("AOP-Wiki RDF Explorer") for interactive SPARQL querying of the AOP-Wiki RDF endpoint. Provides a CodeMirror SPARQL editor with syntax highlighting, a browsable library of curated and parameterized example queries, endpoint health indication, result browsing with dereferenceable URIs, and CSV/JSON/XML export.
+    format: http
+    id: aopwiki-rdf.snorql
+    name: AOP-Wiki RDF SNORQL Interface
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://aopwiki.rdf.bigcat-bioinformatics.org/
+    repository: https://github.com/marvinm2/AOP-Wiki-Snorql-UI
+  - category: GraphProduct
+    description: The AOP-Wiki RDF dataset in RDF/Turtle, covering AOPs, key events, key event relationships, biological events, stressors and chemicals converted from the AOP-Wiki XML export, together with the gene mappings (HGNC approved symbols resolved to Ensembl, NCBI Gene, UniProt and Protein Ontology identifiers via BridgeDb) and the chemical and protein cross-reference enrichments. Distributed as Turtle files in the data/ directory of the conversion repository (AOPWikiRDF.ttl, AOPWikiRDF-Genes.ttl, AOPWikiRDF-Enriched.ttl); all of them are loaded together into the SPARQL endpoint and are meant to be used as one dataset. Regenerated weekly.
+    format: ttl
+    id: aopwiki-rdf.ttl
+    latest_version: '2026.08.15'
+    license:
+      id: https://creativecommons.org/licenses/by-sa/4.0/
+      label: CC BY-SA 4.0
+    name: AOP-Wiki RDF Turtle Dataset
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+      - relation_type: prov:used
+        source: hgnc
+      - relation_type: prov:used
+        source: ensembl
+      - relation_type: prov:used
+        source: ncbigene
+      - relation_type: prov:used
+        source: pr
+      - relation_type: prov:used
+        source: uniprot
+    product_url: https://github.com/marvinm2/AOPWikiRDF/tree/master/data
+    repository: https://github.com/marvinm2/AOPWikiRDF
+  - category: Product
+    description: VoID metadata describing the AOP-Wiki RDF dataset, its triple counts, licence, provenance, update frequency and SPARQL endpoint.
+    format: ttl
+    id: aopwiki-rdf.void
+    name: AOP-Wiki RDF VoID Description
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://raw.githubusercontent.com/marvinm2/AOPWikiRDF/master/data/AOPWikiRDF-Void.ttl
+  - category: ProcessProduct
+    description: Python conversion pipeline that transforms the AOP-Wiki XML export into RDF/Turtle, performs the three-stage gene-mapping algorithm, and runs Turtle syntax and URI-resolvability quality control. Executed weekly by GitHub Actions (Saturdays 08:00 UTC). Code is MIT licensed.
+    format: http
+    id: aopwiki-rdf.converter
+    license:
+      id: https://opensource.org/licenses/MIT
+      label: MIT License
+    name: AOP-Wiki XML to RDF Conversion Tool
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://github.com/marvinm2/AOPWikiRDF
+    repository: https://github.com/marvinm2/AOPWikiRDF
+  - category: ProgrammingInterface
+    connection_url: https://aopwiki-multirdf.vhp4safety.nl/sparql
+    description: Companion SPARQL endpoint holding every quarterly AOP-Wiki snapshot from 2018-04-01 onwards as separate named graphs (http://aopwiki.org/graph/YYYY-MM-DD), 33 versions at present, for tracking how AOP-Wiki content evolves over time.
+    format: http
+    id: aopwiki-rdf.multiversion-sparql
+    is_public: true
+    name: AOP-Wiki RDF Multi-Version SPARQL Endpoint
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://aopwiki-multirdf.vhp4safety.nl/sparql
+    repository: https://github.com/marvinm2/AOP-Wiki_multi-endpoint
+  - category: GraphicalInterface
+    description: Web dashboard visualizing the content and growth of AOP-Wiki RDF across all quarterly versions, with entity counts, key event component and ontology usage breakdowns, network statistics, completeness metrics and an interactive AOP network view. Every plot exposes the SPARQL query behind it and offers CSV export.
+    format: http
+    id: aopwiki-rdf.dashboard
+    name: AOP-Wiki RDF Dashboard
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://aopwiki-dashboard.vhp4safety.nl
+    repository: https://github.com/marvinm2/AOP-Wiki-RDF-dashboard
+  - category: ProgrammingInterface
+    connection_url: https://aopwiki.api.bigcat-bioinformatics.org/
+    description: grlc-generated REST API that exposes the curated AOP-Wiki SPARQL example queries as parameterized HTTP endpoints with a Swagger/OpenAPI description, for users who prefer REST over writing SPARQL.
+    format: http
+    id: aopwiki-rdf.grlc-api
+    is_public: true
+    name: AOP-Wiki RDF grlc REST API
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://aopwiki.api.bigcat-bioinformatics.org/
+    repository: https://github.com/marvinm2/AOP-Wiki-Queries
+  - category: DocumentationProduct
+    description: Curated library of documented SPARQL example queries for AOP-Wiki RDF, organised by category (metadata, AOPs, key events, KERs, stressors, chemicals, data export, federated queries). Consumed by both the SNORQL interface and the grlc REST API.
+    format: http
+    id: aopwiki-rdf.queries
+    name: AOP-Wiki SPARQL Query Library
+    original_source:
+      - relation_type: prov:wasDerivedFrom
+        source: aop-wiki
+    product_url: https://github.com/marvinm2/AOP-Wiki-Queries
+    repository: https://github.com/marvinm2/AOP-Wiki-Queries
+publications:
+  - authors:
+      - Marvin Martens
+      - Chris T. Evelo
+      - Egon L. Willighagen
+    doi: 10.1089/aivt.2021.0010
+    id: doi:10.1089/aivt.2021.0010
+    journal: Applied In Vitro Toxicology
+    preferred: true
+    title: Providing Adverse Outcome Pathways from the AOP-Wiki in a Semantic Web Format to Increase Usability and Accessibility of the Content
+    year: '2022'
+  - authors:
+      - Marvin Martens
+      - Egon Willighagen
+      - Chris Evelo
+    doi: 10.5281/zenodo.13353286
+    id: doi:10.5281/zenodo.13353286
+    journal: Zenodo
+    title: Adverse Outcome Pathway Wiki RDF
+    year: '2026'
+repository: https://github.com/marvinm2/AOPWikiRDF
+synonyms:
+  - AOPWikiRDF
+  - AOP-Wiki RDF Explorer
+version: '2026.08.15'
+---
+
+# AOP-Wiki RDF
+
+## Overview
+
+AOP-Wiki RDF is a semantic web representation of the [AOP-Wiki](/resource/aop-wiki),
+the community authoring and curation interface of the Adverse Outcome Pathway
+Knowledge Base (AOP-KB). The weekly AOP-Wiki XML export is converted to RDF/Turtle
+using the AOP Ontology (aopo) alongside Dublin Core, CHEMINF and NCIT, making the
+mechanistic toxicology content of the AOP-Wiki queryable with SPARQL.
+
+## Content
+
+The 2026.08.15 release contains roughly 340,000 triples across three Turtle files
+that are loaded together as a single dataset:
+
+- `AOPWikiRDF.ttl` — triples derived directly from the AOP-Wiki XML export
+- `AOPWikiRDF-Genes.ttl` — gene mapping enrichment
+- `AOPWikiRDF-Enriched.ttl` — chemical and protein cross-reference enrichment
+
+This covers 595 AOPs, 1,595 key events, 2,360 key event relationships, 754 stressors
+and 430 chemicals. AOPs, key events, key event relationships, biological events,
+stressors and chemicals receive identifiers.org URIs and are linked out to ChEBI, GO,
+PATO, UBERON, CL, NCBITaxon and HGNC. Gene names appearing in key events are matched
+to HGNC approved symbols and resolved to Ensembl, NCBI Gene, UniProt and Protein
+Ontology identifiers through BridgeDb.
+
+## Access
+
+- A public Virtuoso SPARQL endpoint, reloaded weekly, with a SNORQL query interface
+  ("AOP-Wiki RDF Explorer") on top of it
+- A grlc-generated REST API built from the same curated SPARQL query library, for
+  users who prefer REST over writing SPARQL
+- A companion multi-version endpoint holding every quarterly AOP-Wiki snapshot since
+  2018-04-01 as separate named graphs, for tracking content change over time
+- A dashboard visualizing content and growth across all quarterly versions
+
+## Licensing
+
+The generated RDF dataset files are released under CC BY-SA 4.0. The conversion code
+in the AOPWikiRDF repository is separately licensed under the MIT License.


### PR DESCRIPTION
Closes #697. Closes #696.

## #697 — Add the AOP-Wiki RDF resource

Adds a Resource entry for [AOP-Wiki RDF](https://aopwiki.rdf.bigcat-bioinformatics.org/), the weekly RDF/Turtle conversion of the AOP-Wiki XML export, enriched with BridgeDb-resolved gene mappings and chemical cross-references.

@marvinm2 supplied a complete pre-built entry in the issue, so this is largely their metadata with validation applied on top.

**Products:** the SPARQL endpoint, SNORQL interface, Turtle dataset, VoID description, conversion pipeline, multi-version snapshot endpoint, dashboard, grlc REST API, and the curated SPARQL query library.

**Validation**

- `make validate-file` passes clean. All enum values check out against the schema: `KnowledgeGraph` category, the four domains, the `aop` collection, contact types, the nine product categories, `http`/`ttl` formats, and the `prov:*` relation types.
- All 12 submitted URLs return HTTP 200.
- Referenced resources (`aop-wiki`, `hgnc`, `ensembl`, `uniprot`, plus the added `ncbigene` and `pr`) all exist in the registry.
- Checked against the upstream VoID file: `pav:version "2026.08.15"`, triple counts 138,781 + 8,262 + 191,650 = 338,693 (matching the stated "about 340,000"), weekly accrual, CC BY-SA 4.0.
- The repo's `data/LICENSE-DATA` confirms CC BY-SA 4.0 for the dataset and MIT for the conversion code, as submitted.

**Corrections to the submitted metadata**

1. `doi:` fields carried a `doi:` prefix; the schema and repo convention want the bare DOI. The `id:` fields keep the CURIE form.
2. The Zenodo publication title was a descriptive gloss. DataCite gives the actual record title, **"Adverse Outcome Pathway Wiki RDF"** — swapped in, along with the `journal` and `year` the reference validator flagged as missing.
3. Per `AGENTS.md`, a product mentioning another Resource needs it in `original_source`. The Turtle dataset's description names NCBI Gene and Protein Ontology, so `ncbigene` and `pr` were added. (BridgeDb has no registry entry, so it stays as prose.)
4. Added a markdown body, since the submission was frontmatter only.

## #696 — Repoint the dead OpenRiskNet SPARQL URLs

Both `aop-wiki` and `aop-db` advertised SPARQL access through OpenRiskNet service pages for services no longer hosted there.

**AOP-DB** — the endpoint moved to BiGCaT at Maastricht University. `connection_url` and `product_url` now both point at `https://aopdb.rdf.bigcat-bioinformatics.org/sparql/`, which I confirmed answers SPARQL queries and reports 12,707,791 triples. The description drops the OpenRiskNet hosting claim but keeps the provenance note. The propagated copy of this product on the AOP-Wiki page is updated to match.

**AOP-Wiki** — the `aop-wiki.sparql` product is **removed** rather than repointed. Its `connection_url` (`aopwiki-rdf.prod.openrisknet.org`) times out, and the live replacement is the SPARQL endpoint of the new `aopwiki-rdf` Resource above. Since those products already name `aop-wiki` in `original_source`, the tooling will propagate them onto this page, so duplicating them by hand would be redundant.

This is why the two issues share a PR: the AOP-Wiki removal is only correct once `aopwiki-rdf` exists, so merging them separately would briefly leave AOP-Wiki with no SPARQL product at all. Happy to split if you'd rather review them apart.

## Generated files

Only source-of-truth resource `.md` files are touched, following the pattern of #693. The per-product pages and registry artifacts are left to the Update Registry Files action. Note that `resource/aop-wiki/aop-wiki.sparql.md` becomes stale — it is frontmatter-only, so `remove_stale_product_pages` in `extract-metadata.py` will delete it on the next registry update rather than warn and keep it.

## One inconsistency worth flagging

The Zenodo deposit's own metadata records **CC BY 4.0**, while the repo's `LICENSE-DATA` and the VoID file both say **CC BY-SA 4.0**. I went with CC BY-SA 4.0 here — two upstream sources agree and it's what the submitter stated — but @marvinm2 may want to fix the license field on the Zenodo record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)