### PR TITLE
Fix the dead OpenRiskNet SPARQL URLs on AOP-Wiki and AOP-DB

### DIFF
--- a/resource/aop-db/aop-db.md
+++ b/resource/aop-db/aop-db.md
@@ -23,7 +23,7 @@ domains:
 - pathways
 homepage_url: https://www.epa.gov/healthresearch/adverse-outcome-pathway-database-aop-db
 id: aop-db
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-08-17T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.epa.gov/healthresearch/adverse-outcome-pathway-database-aop-db
@@ -41,10 +41,11 @@ products:
     source: aop-db
   product_url: https://www.epa.gov/healthresearch/adverse-outcome-pathway-database-aop-db
 - category: ProgrammingInterface
-  connection_url: https://aopdb.rdf.bigcat-bioinformatics.org/
-  description: OpenRiskNet Virtuoso SPARQL endpoint loaded with RDF of the EPA AOP-DB
-    for querying integrated AOP, gene, chemical, disease, tissue, pathway, orthology,
-    ontology, and gene interaction relationships.
+  connection_url: https://aopdb.rdf.bigcat-bioinformatics.org/sparql/
+  description: Public Virtuoso SPARQL endpoint loaded with RDF of the EPA AOP-DB for
+    querying integrated AOP, gene, chemical, disease, tissue, pathway, orthology, ontology,
+    and gene interaction relationships. Originally deployed under the OpenRiskNet project
+    and now hosted by the BiGCaT department at Maastricht University.
   format: http
   id: aop-db.sparql
   is_public: true
@@ -54,7 +55,7 @@ products:
     source: aop-db
   - relation_type: prov:hadPrimarySource
     source: aop-wiki
-  product_url: https://openrisknet.org/e-infrastructure/services/147/
+  product_url: https://aopdb.rdf.bigcat-bioinformatics.org/sparql/
 - category: Product
   description: The EPA has developed the Adverse Outcome Pathway Database (AOP-DB)
     to better characterize adverse outcomes of toxicological interest that are relevant

--- a/resource/aop-wiki/aop-wiki.md
+++ b/resource/aop-wiki/aop-wiki.md
@@ -23,7 +23,7 @@ domains:
 - pathways
 homepage_url: https://aopwiki.org/
 id: aop-wiki
-last_modified_date: '2026-05-26T00:00:00Z'
+last_modified_date: '2026-08-17T00:00:00Z'
 layout: resource_detail
 license:
   id: https://aopwiki.org/
@@ -40,19 +40,6 @@ products:
   - relation_type: prov:hadPrimarySource
     source: aop-wiki
   product_url: https://aopwiki.org/
-- category: ProgrammingInterface
-  connection_url: https://aopwiki-rdf.prod.openrisknet.org/
-  description: OpenRiskNet SPARQL endpoint loaded with RDF converted from AOP-Wiki
-    quarterly XML dumps for querying AOPs, key events, key event relationships, and
-    stressors.
-  format: http
-  id: aop-wiki.sparql
-  is_public: true
-  name: AOP-Wiki SPARQL Endpoint
-  original_source:
-  - relation_type: prov:hadPrimarySource
-    source: aop-wiki
-  product_url: https://openrisknet.org/e-infrastructure/services/133/
 - category: Product
   description: Quarterly permanent XML snapshot (versioned) of AOP-Wiki content suitable
     for citation and archival use
@@ -163,10 +150,11 @@ products:
     source: toxcast
   product_url: https://catalog.data.gov/dataset/adverse-outcome-pathway-database-aop-db-version-2
 - category: ProgrammingInterface
-  connection_url: https://aopdb.rdf.bigcat-bioinformatics.org/
-  description: OpenRiskNet Virtuoso SPARQL endpoint loaded with RDF of the EPA AOP-DB
-    for querying integrated AOP, gene, chemical, disease, tissue, pathway, orthology,
-    ontology, and gene interaction relationships.
+  connection_url: https://aopdb.rdf.bigcat-bioinformatics.org/sparql/
+  description: Public Virtuoso SPARQL endpoint loaded with RDF of the EPA AOP-DB for
+    querying integrated AOP, gene, chemical, disease, tissue, pathway, orthology, ontology,
+    and gene interaction relationships. Originally deployed under the OpenRiskNet project
+    and now hosted by the BiGCaT department at Maastricht University.
   format: http
   id: aop-db.sparql
   is_public: true
@@ -176,7 +164,7 @@ products:
     source: aop-db
   - relation_type: prov:hadPrimarySource
     source: aop-wiki
-  product_url: https://openrisknet.org/e-infrastructure/services/147/
+  product_url: https://aopdb.rdf.bigcat-bioinformatics.org/sparql/
 - category: GraphProduct
   description: RDF knowledge graph (Turtle) repackaging AOP-Wiki data as an open knowledge
     graph

--- a/resource/aopwiki-rdf/aopwiki-rdf.md
+++ b/resource/aopwiki-rdf/aopwiki-rdf.md
@@ -236,9 +236,9 @@ version: 2026.08.15
 
 ## Overview
 
-AOP-Wiki RDF is a semantic web representation of the [AOP-Wiki](/resource/aop-wiki),
-the community authoring and curation interface of the Adverse Outcome Pathway
-Knowledge Base (AOP-KB). The weekly AOP-Wiki XML export is converted to RDF/Turtle
+AOP-Wiki RDF is a semantic web representation of the AOP-Wiki, the community
+authoring and curation interface of the Adverse Outcome Pathway Knowledge Base
+(AOP-KB). The weekly AOP-Wiki XML export is converted to RDF/Turtle
 using the AOP Ontology (aopo) alongside Dublin Core, CHEMINF and NCIT, making the
 mechanistic toxicology content of the AOP-Wiki queryable with SPARQL.
 


### PR DESCRIPTION
Closes #696.

Re-applies two commits that were pushed to `add-aopwiki-rdf` after #698 had already been merged, so they never reached `main`. #698 merged with only its first commit (`834af598`); these are the other two, cherry-picked onto current `main` and re-verified against it.

## #696 — the dead OpenRiskNet URLs

Both `aop-wiki` and `aop-db` advertised SPARQL access through OpenRiskNet service pages for services no longer hosted there.

**AOP-DB** — the endpoint moved to BiGCaT at Maastricht University. `connection_url` and `product_url` now both point at `https://aopdb.rdf.bigcat-bioinformatics.org/sparql/`, which I confirmed answers SPARQL queries and reports 12,707,791 triples. The description drops the OpenRiskNet hosting claim but keeps the provenance as a sentence. The propagated copy of this product on the AOP-Wiki page is updated to match.

**AOP-Wiki** — the `aop-wiki.sparql` product is **removed** rather than repointed. Its `connection_url` (`aopwiki-rdf.prod.openrisknet.org`) times out, and the live replacement is `aopwiki-rdf.sparql` on the AOP-Wiki RDF resource added in #698. That propagation has already happened on `main` — the AOP-Wiki page now carries all nine `aopwiki-rdf.*` products — so this only removes the dead entry and leaves the propagated ones untouched.

After this, neither file mentions `openrisknet` anywhere.

## Also included

The AOP-Wiki RDF overview linked to `/resource/aop-wiki`, which is wrong on two counts: the site sets `baseurl: /kg-registry`, and resource pages are served as `resource/<id>.html`. No other resource body cross-links internally, so it is plain text now rather than a corrected link.

## Notes

`make validate-file` passes on all three files. Only source-of-truth resource `.md` files are touched.

`resource/aop-wiki/aop-wiki.sparql.md` becomes stale once the product is gone. I confirmed by running the concat pipeline locally that `remove_stale_product_pages` reaps it (`Removing page for product aop-wiki.sparql - no longer listed by aop-wiki`), so the Update Registry Files action will delete it rather than leave it publishing a URL for a product the registry no longer describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)