### PR TITLE
Repoint Reactome sqlite product at the semantic-sql CDN

### DIFF
--- a/resource/reactome/reactome.data.human.md
+++ b/resource/reactome/reactome.data.human.md
@@ -7,7 +7,7 @@ name: Reactome Human from BioPAX, sqlite
 original_source:
 - relation_type: prov:hadPrimarySource
   source: reactome
-product_file_size: 178009249
-product_url: https://s3.amazonaws.com/bbop-sqlite/reactome-hs.db.gz
+product_file_size: 183956402
+product_url: https://semanticsql.berkeleybop.io/reactome-hs.db.gz
 layout: product_detail
 ---

--- a/resource/reactome/reactome.md
+++ b/resource/reactome/reactome.md
@@ -47,8 +47,8 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: reactome
-  product_file_size: 178009249
-  product_url: https://s3.amazonaws.com/bbop-sqlite/reactome-hs.db.gz
+  product_file_size: 183956402
+  product_url: https://semanticsql.berkeleybop.io/reactome-hs.db.gz
 - category: GraphProduct
   compression: zip
   description: Complete Reactome pathway data in BioPAX (Biological Pathway Exchange)


### PR DESCRIPTION
The raw `bbop-sqlite` S3 bucket serving semantic-sql ontology databases was retired on 2026-08-28. `https://s3.amazonaws.com/bbop-sqlite/reactome-hs.db.gz` now returns `403 AccessDenied`, so the `reactome.data.human` product was pointing consumers at a dead link.

Swapped in the drop-in CDN replacement, `https://semanticsql.berkeleybop.io/reactome-hs.db.gz`, verified live:

```
old: 403
new: 200  content-type: application/gzip  content-length: 183956402
```

The CDN copy (last modified 2026-05-24) is a newer build than the one whose size was recorded here, so `product_file_size` goes from 178,009,249 to 183,956,402 to match what is actually served. Both the resource page and its propagated `reactome.data.human.md` product page are updated; both still validate with `extract-metadata.py validate`.

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcjCL63qkoxU5PVt33Szwu