### PR TITLE
Run the whole test suite in CI, not the 18 tests unittest can see

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -33,5 +33,9 @@ jobs:
       - name: Check static typing with MyPy
         run: uv run tox -e mypy
 
+      # pytest, not `unittest discover`: most of this suite is pytest-style
+      # functions, which unittest walks past silently (18 of 139 collected).
+      # Tests marked `network` reach live external services and are excluded
+      # here to keep CI deterministic; run them locally with `pytest -m network`.
       - name: Run tests
-        run: uv run python -m unittest discover tests
+        run: uv run pytest tests/ -m "not network"

--- a/cache/publication_reference_validation.yml
+++ b/cache/publication_reference_validation.yml
@@ -126,19 +126,10 @@ entries:
     status: valid
     warnings: []
   resource/agro/agro.md#publication[0]#url:http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf:
-    checked_at: '2026-06-12T20:32:32Z'
-    errors: []
-    fingerprint: aa53efb180f186ceeb09eb76a6156f189d2f9e6502b8d62599cc17318d5694df
-    publication_index: 0
-    reference_id: url:http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf
-    source_path: resource/agro/agro.md
-    status: valid
-    warnings: []
-  resource/agro/agro.md#publication[1]#url:http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf:
-    checked_at: '2026-08-06T18:16:30Z'
+    checked_at: '2026-08-31T17:59:34Z'
     errors: []
     fingerprint: 1cd470a4f6dff1f52c5673a55c4fc8b55964c5f6bb860277c2bfdd2b4f8e0712
-    publication_index: 1
+    publication_index: 0
     reference_id: url:http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf
     source_path: resource/agro/agro.md
     status: valid
@@ -7168,9 +7159,9 @@ entries:
     status: valid
     warnings: []
   resource/sepio/sepio.md#publication[0]#url:http://ceur-ws.org/Vol-1747/IT605_ICBO2016.pdf:
-    checked_at: '2026-08-06T18:18:57Z'
+    checked_at: '2026-08-31T17:59:38Z'
     errors: []
-    fingerprint: c4680f10c2347e80fea3ca94c402f7f5590d262fe21be6375ba93b69615ac61a
+    fingerprint: d6b21b551f385160e159910549f3311fed965f9c59676d7608d566e031715c88
     publication_index: 0
     reference_id: url:http://ceur-ws.org/Vol-1747/IT605_ICBO2016.pdf
     source_path: resource/sepio/sepio.md
@@ -8039,9 +8030,9 @@ entries:
     status: valid
     warnings: []
   ? resource/unii/unii.md#publication[0]#url:https://www.fda.gov/science-research/fda-grand-rounds/fdas-global-substance-registration-system-gsrs-unique-ingredient-identifiers-uniis-uniquely-define
-  : checked_at: '2026-06-12T20:32:32Z'
+  : checked_at: '2026-08-31T17:59:41Z'
     errors: []
-    fingerprint: 0fd2a1c9aa5d90b789381554958dc4035dff0c3c41bf53bfcf08f4bb68bd0801
+    fingerprint: 2904d3ab7f87f14ca251b763d7173c3e4be405cd9ee3e81305d5e1fccff1b70f
     publication_index: 0
     reference_id: url:https://www.fda.gov/science-research/fda-grand-rounds/fdas-global-substance-registration-system-gsrs-unique-ingredient-identifiers-uniis-uniquely-define
     source_path: resource/unii/unii.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,16 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = ["pytest>=7.1.2", "setuptools>=65.5.0", "tox>=3.25.1"]
 
+[tool.pytest.ini_options]
+# Collect from tests/ only. A Jekyll build leaves a copy of the test tree in
+# _site/, which is gitignored but present in working trees; collecting it fails
+# because its conftest.py defines pytest_plugins outside the rootdir.
+testpaths = ["tests"]
+norecursedirs = ["_site", ".git", ".tox", ".venv", "build", "dist", "node_modules"]
+markers = [
+    "network: test contacts a live external service (deselect with -m 'not network')",
+]
+
 [tool.black]
 line-length = 100
 target-version = ["py39", "py310"]

--- a/resource/agro/agro.md
+++ b/resource/agro/agro.md
@@ -60,18 +60,6 @@ publications:
   - Léo Valette
   - Elizabeth Arnaud
   - Pier Luigi Buttigieg
-  id: url:http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf
-  journal: CEUR Workshop Proceedings
-  title: 'Data-driven Agricultural Research for Development: A Need for Data Harmonization
-    Via Semantics'
-  year: '2016'
-- authors:
-  - Medha Devare
-  - Céline Aubert
-  - Marie-Angélique Laporte
-  - Léo Valette
-  - Elizabeth Arnaud
-  - Pier Luigi Buttigieg
   id: http://ceur-ws.org/Vol-1747/IT205_ICBO2016.pdf
   journal: CEUR Workshop Proceedings
   title: 'Data-driven Agricultural Research for Development: A Need for Data Harmonization

--- a/resource/sepio/sepio.md
+++ b/resource/sepio/sepio.md
@@ -59,7 +59,7 @@ publications:
   - Brush MH
   - Shefchek K
   - Haendel M
-  id: url:http://ceur-ws.org/Vol-1747/IT605_ICBO2016.pdf
+  id: http://ceur-ws.org/Vol-1747/IT605_ICBO2016.pdf
   journal: CEUR Workshop Proceedings
   preferred: true
   title: 'SEPIO: A Semantic Model for the Integration and Analysis of Scientific Evidence'

--- a/resource/unii/unii.md
+++ b/resource/unii/unii.md
@@ -134,7 +134,7 @@ products:
   - relation_type: prov:wasInformedBy
     source: ndcd
 publications:
-- id: url:https://www.fda.gov/science-research/fda-grand-rounds/fdas-global-substance-registration-system-gsrs-unique-ingredient-identifiers-uniis-uniquely-define
+- id: https://www.fda.gov/science-research/fda-grand-rounds/fdas-global-substance-registration-system-gsrs-unique-ingredient-identifiers-uniis-uniquely-define
   title: "FDA\u2019s Global Substance Registration System (GSRS) Unique Ingredient\
     \ Identifiers (UNIIs) uniquely define substances in FDA-regulated products - 06/08/2023\
     \ | FDA"

--- a/tests/test_ftp_url_checker.py
+++ b/tests/test_ftp_url_checker.py
@@ -1,5 +1,9 @@
 """Tests for FTP URL checking functionality.
 
+Tests marked ``network`` contact ftp.ncbi.nlm.nih.gov directly and are
+therefore subject to that server's availability. CI deselects them with
+``-m 'not network'``; run them locally with ``pytest -m network``.
+
 Test fixtures are available in tests/fixtures/:
 - test_ftp_parallel.yml: Test data for retrieve-file-sizes-parallel.py (uses product_url field)
 
@@ -13,6 +17,8 @@ import importlib.util
 import sys
 from pathlib import Path
 from unittest import TestCase
+
+import pytest
 
 # Add util directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "util"))
@@ -32,6 +38,7 @@ retrieve_spec.loader.exec_module(retrieve_file_sizes)
 class TestFTPURLChecker(TestCase):
     """Test FTP URL checking functionality in retrieve-file-sizes.py."""
 
+    @pytest.mark.network
     def test_ftp_file_size_retrieval(self):
         """Test that FTP file size can be retrieved successfully."""
         # Test with a known public FTP file
@@ -47,6 +54,7 @@ class TestFTPURLChecker(TestCase):
         self.assertIn("checked_at", info)
         self.assertGreater(size, 0)
 
+    @pytest.mark.network
     def test_ftp_directory_detection(self):
         """Test that FTP directories are correctly identified."""
         # Test with a known public FTP directory
@@ -61,6 +69,7 @@ class TestFTPURLChecker(TestCase):
         self.assertEqual(info["protocol"], "ftp")
         self.assertIn("checked_at", info)
 
+    @pytest.mark.network
     def test_ftp_nonexistent_path(self):
         """Test that nonexistent FTP paths return appropriate errors."""
         # Test with a path that doesn't exist
@@ -103,6 +112,7 @@ class TestFTPURLChecker(TestCase):
         self.assertIsNotNone(entry)
         self.assertEqual(entry["skip_reason"], "directory")
 
+    @pytest.mark.network
     def test_get_file_size_from_header_routes_ftp(self):
         """Test that get_file_size_from_header correctly routes FTP URLs to get_ftp_info."""
         url = "ftp://ftp.ncbi.nlm.nih.gov/README.ftp"

--- a/tests/test_obo_cache.py
+++ b/tests/test_obo_cache.py
@@ -1,169 +1,121 @@
-#!/usr/bin/env python3
-"""Test OBO Foundry cache creation, reuse, expiration, and validation behavior."""
+"""Tests for OBO Foundry cache creation, reuse, expiration, and fallback behavior."""
 
 import os
 import time
 
+import pytest
+import yaml
+
 from util.sync_obo_foundry import OBOFoundrySync
 
+SAMPLE_ONTOLOGIES = [
+    {"id": "go", "title": "Gene Ontology"},
+    {"id": "chebi", "title": "Chemical Entities of Biological Interest"},
+]
 
-def test_cache_creation():
-    """Test that cache is created on first fetch"""
-    print("Test 1: Cache Creation")
-    print("-" * 50)
 
-    # Create syncer with short TTL for testing
-    syncer = OBOFoundrySync(cache_ttl_hours=1)
+class FakeResponse:
+    """Minimal stand-in for the ``requests.Response`` used by the syncer."""
 
-    # Remove cache if it exists
-    if syncer.cache_file.exists():
-        syncer.cache_file.unlink()
-        print(f"✅ Removed existing cache: {syncer.cache_file}")
+    def __init__(self, payload):
+        self.content = yaml.dump(payload).encode("utf-8")
 
-    # First fetch should create cache
-    print("Fetching OBO Foundry data (should create cache)...")
-    start_time = time.time()
+    def raise_for_status(self):
+        return None
+
+
+@pytest.fixture
+def fetches(monkeypatch):
+    """Replace the live OBO Foundry request with a call-counting fake."""
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        return FakeResponse(SAMPLE_ONTOLOGIES)
+
+    monkeypatch.setattr("util.sync_obo_foundry.requests.get", fake_get)
+    return calls
+
+
+@pytest.fixture
+def syncer(tmp_path, fetches):
+    """An ``OBOFoundrySync`` whose registry and cache both live under tmp_path."""
+    instance = OBOFoundrySync(registry_root=str(tmp_path / "resource"), cache_ttl_hours=24)
+    instance.cache_dir = tmp_path / "cache"
+    instance.cache_dir.mkdir(parents=True, exist_ok=True)
+    instance.cache_file = instance.cache_dir / "obo_foundry_cache.yml"
+    return instance
+
+
+def age_cache(syncer, hours):
+    """Backdate the cache file so it reads as ``hours`` old."""
+    stale = time.time() - hours * 3600
+    os.utime(syncer.cache_file, (stale, stale))
+
+
+def test_cache_created_on_first_fetch(syncer, fetches):
+    """The first fetch hits the network and writes the cache file."""
+    assert not syncer.cache_file.exists()
+
     data = syncer.fetch_obo_foundry_data()
-    elapsed = time.time() - start_time
 
-    print(f"✅ Fetched {len(data)} ontologies in {elapsed:.2f} seconds")
-
-    # Check that cache was created
-    if syncer.cache_file.exists():
-        print(f"✅ Cache file created: {syncer.cache_file}")
-        cache_size = syncer.cache_file.stat().st_size / 1024
-        print(f"   Cache size: {cache_size:.2f} KB")
-    else:
-        print("❌ Cache file was not created!")
-        return False
-
-    return True
+    assert data == SAMPLE_ONTOLOGIES
+    assert len(fetches) == 1
+    assert syncer.cache_file.exists()
+    assert yaml.safe_load(syncer.cache_file.read_text()) == SAMPLE_ONTOLOGIES
 
 
-def test_cache_usage():
-    """Test that cache is used on subsequent fetches"""
-    print("\nTest 2: Cache Usage")
-    print("-" * 50)
-
-    syncer = OBOFoundrySync(cache_ttl_hours=1)
-
-    # This should use cache
-    print("Fetching OBO Foundry data (should use cache)...")
-    start_time = time.time()
+def test_cache_reused_within_ttl(syncer, fetches):
+    """A second fetch inside the TTL is served from cache without a request."""
+    syncer.fetch_obo_foundry_data()
     data = syncer.fetch_obo_foundry_data()
-    elapsed = time.time() - start_time
 
-    print(f"✅ Fetched {len(data)} ontologies in {elapsed:.2f} seconds")
-
-    # Should be very fast (< 1 second) if using cache
-    if elapsed < 1.0:
-        print(f"✅ Fast fetch indicates cache was used ({elapsed:.3f}s)")
-    else:
-        print(f"⚠️  Slow fetch - cache may not have been used ({elapsed:.3f}s)")
-
-    return True
+    assert data == SAMPLE_ONTOLOGIES
+    assert len(fetches) == 1
 
 
-def test_cache_expiration():
-    """Test that expired cache triggers fresh fetch"""
-    print("\nTest 3: Cache Expiration")
-    print("-" * 50)
+def test_expired_cache_triggers_refetch(syncer, fetches):
+    """A cache older than the TTL is refreshed from the network."""
+    syncer.fetch_obo_foundry_data()
+    age_cache(syncer, hours=25)
 
-    # Create syncer with 0 hour TTL (immediate expiration)
-    syncer = OBOFoundrySync(cache_ttl_hours=0)
-
-    print("Fetching with TTL=0 (should fetch fresh data)...")
-    start_time = time.time()
     data = syncer.fetch_obo_foundry_data()
-    elapsed = time.time() - start_time
 
-    print(f"✅ Fetched {len(data)} ontologies in {elapsed:.2f} seconds")
-
-    # Should be slower (> 1 second) as it's fetching fresh
-    if elapsed > 1.0:
-        print(f"✅ Slow fetch indicates fresh data was fetched ({elapsed:.3f}s)")
-    else:
-        print(f"⚠️  Fast fetch - may have used cache incorrectly ({elapsed:.3f}s)")
-
-    return True
+    assert data == SAMPLE_ONTOLOGIES
+    assert len(fetches) == 2
 
 
-def test_cache_validation():
-    """Test that cache validation works correctly"""
-    print("\nTest 4: Cache Validation")
-    print("-" * 50)
+def test_is_cache_valid_respects_ttl(syncer):
+    """`_is_cache_valid` is false with no cache, and tracks the file's age."""
+    assert syncer._is_cache_valid() is False
 
-    syncer = OBOFoundrySync(cache_ttl_hours=24)
+    syncer.fetch_obo_foundry_data()
+    assert syncer._is_cache_valid() is True
 
-    # Check if cache is valid
-    is_valid = syncer._is_cache_valid()
-    print(f"Cache valid (TTL=24h): {is_valid}")
-
-    if is_valid:
-        cache_age = (time.time() - os.path.getmtime(syncer.cache_file)) / 3600
-        print(f"✅ Cache age: {cache_age:.2f} hours")
-
-    # Test with short TTL
-    syncer_short = OBOFoundrySync(cache_ttl_hours=0.001)  # ~3.6 seconds
-    time.sleep(4)  # Wait for cache to expire
-
-    is_valid_short = syncer_short._is_cache_valid()
-    print(f"Cache valid (TTL=0.001h, after 4s wait): {is_valid_short}")
-
-    if not is_valid_short:
-        print("✅ Cache correctly identified as expired")
-    else:
-        print("⚠️  Cache should have expired but didn't")
-
-    return True
+    age_cache(syncer, hours=25)
+    assert syncer._is_cache_valid() is False
 
 
-def main():
-    print("=" * 50)
-    print("OBO Foundry Cache Testing")
-    print("=" * 50)
-    print()
+def test_expired_cache_is_fallback_when_fetch_fails(syncer, monkeypatch, fetches):
+    """When a refresh fails, the stale cache is returned rather than raising."""
+    syncer.fetch_obo_foundry_data()
+    age_cache(syncer, hours=25)
 
-    try:
-        # Run all tests
-        tests = [
-            test_cache_creation,
-            test_cache_usage,
-            test_cache_expiration,
-            test_cache_validation,
-        ]
+    def boom(url, **kwargs):
+        raise RuntimeError("network down")
 
-        results = []
-        for test in tests:
-            try:
-                result = test()
-                results.append(result)
-            except Exception as e:
-                print(f"❌ Test failed with error: {e}")
-                results.append(False)
+    monkeypatch.setattr("util.sync_obo_foundry.requests.get", boom)
 
-        # Summary
-        print("\n" + "=" * 50)
-        print("Test Summary")
-        print("=" * 50)
-        passed = sum(results)
-        total = len(results)
-        print(f"Passed: {passed}/{total}")
-
-        if passed == total:
-            print("✅ All tests passed!")
-            return 0
-        else:
-            print(f"❌ {total - passed} test(s) failed")
-            return 1
-
-    except Exception as e:
-        print(f"❌ Testing failed: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return 1
+    assert syncer.fetch_obo_foundry_data() == SAMPLE_ONTOLOGIES
 
 
-if __name__ == "__main__":
-    sys.exit(main())
+def test_fetch_failure_without_cache_raises(syncer, monkeypatch):
+    """With no cache to fall back on, a failed fetch propagates."""
+
+    def boom(url, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("util.sync_obo_foundry.requests.get", boom)
+
+    with pytest.raises(RuntimeError):
+        syncer.fetch_obo_foundry_data()


### PR DESCRIPTION
Closes #677.

`python -m unittest discover tests` collects only `unittest.TestCase` subclasses. Most of this suite is pytest-style functions taking fixtures, so unittest walked past them — **18 of 139 tests ran**, with no error and no skip message, just `OK` over a seventh of the suite. The test step now runs pytest, matching the pytest environment tox has had all along.

Turning on the other 121 tests surfaced two real problems, both fixed here.

### Three publication identifiers were malformed

`agro`, `sepio` and `unii` each had a publication `id` prefixed with `url:`. That prefix is an internal normalization `reference_validation.normalize_reference_id` applies when talking to the reference validator — not a form the registry stores. `_layouts/resource_detail.html` renders publication ids straight into an `href`, so `url:http://ceur-ws.org/...` was emitted as a dead link.

`sepio` and `unii` keep the bare URL. `agro`'s turned out to be a duplicate of the entry immediately below it — same paper, same URL, and the same cache fingerprint once revalidated — so the stray goes and the OBO-sourced entry stays.

### `tests/test_obo_cache.py` was a script wearing a test file's name

It deleted and rewrote the real `cache/obo_foundry_cache.yml`, fetched the live OBO Foundry registry three times, `time.sleep(4)`, asserted nothing, and returned `True`/`False` that pytest could only warn about. It could not fail, and running it dirtied the working tree. (Its `main()` also called `sys.exit` without importing `sys`.)

Rewritten as six hermetic tests over the same caching contract — create, reuse within TTL, refetch when expired, stale-cache fallback, propagate when there is nothing to fall back on — against a `tmp_path` cache and a call-counting fake. 0.16s, no network, no side effects.

### Supporting changes

- **`[tool.pytest.ini_options]`** sets `testpaths` and `norecursedirs`, so a bare `pytest` at the repo root works. A Jekyll build leaves a copy of the test tree at `_site/tests`; it is gitignored but present in working trees, and its `conftest.py` defines `pytest_plugins` outside the rootdir, which is a hard collection error.
- **The four FTP tests that reach `ftp.ncbi.nlm.nih.gov`** are marked `network` and deselected in CI, so the run does not depend on NCBI being reachable. These already ran under unittest and were the known flake; `pytest -m network` runs them locally.

### Result

```
$ uv run pytest tests/ -m "not network"
135 passed, 4 deselected in 32.36s

$ uv run pytest tests/          # including network
139 passed in 29.42s
```

The working tree is clean after both.

### Noted, not fixed here

The `python-version: [3.9, 3.10]` matrix is not doing anything. `uv sync` ignores it and picks `/usr/bin/python3` — CPython 3.12.3 on the runner — so both legs test the same interpreter. Making uv honor the matrix would immediately break the 3.9 leg, because `python-frontmatter` 1.2.0 (the version the lock pins for `<3.10`) imports `typing.TypeGuard`, which is 3.10+. That is a call about whether the project still supports 3.9, so it is left for its own issue rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcjCL63qkoxU5PVt33Szwu