### PR TITLE
Make tox -e lint able to fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ markers = [
 [tool.black]
 line-length = 100
 target-version = ["py310", "py311"]
+# gen-pydantic writes this file; reformatting it would be undone by the next
+# `make refresh-schema`. flake8 already excludes the same directory.
+extend-exclude = "^/src/kg_registry/kg_registry_schema/datamodel/"
 
 [tool.isort]
 profile = "black"
@@ -59,3 +62,4 @@ multi_line_output = 3
 line_length = 100
 include_trailing_comma = true
 reverse_relative = true
+extend_skip_glob = ["src/kg_registry/kg_registry_schema/datamodel/*"]

--- a/tests/fixtures/parquet_backend_fixtures.py
+++ b/tests/fixtures/parquet_backend_fixtures.py
@@ -24,9 +24,7 @@ def parquet_backend_sample_data():
                     {
                         "category": "Individual",
                         "label": "Test Person",
-                        "contact_details": [
-                            {"contact_type": "email", "value": "test@example.com"}
-                        ],
+                        "contact_details": [{"contact_type": "email", "value": "test@example.com"}],
                     }
                 ],
                 "products": [

--- a/tests/test_extract_metadata_product_pages.py
+++ b/tests/test_extract_metadata_product_pages.py
@@ -71,7 +71,9 @@ def test_concat_propagates_cross_resource_products(
                     "name": "Bioteque embeddings",
                     "category": "GraphEmbeddingProduct",
                     "description": "Embeddings built using BTO",
-                    "original_source": [{"source": "bto", "relation_type": "prov:hadPrimarySource"}],
+                    "original_source": [
+                        {"source": "bto", "relation_type": "prov:hadPrimarySource"}
+                    ],
                 }
             ],
         },
@@ -90,7 +92,9 @@ def test_concat_propagates_cross_resource_products(
                     "name": "ClinicalKG graph",
                     "category": "KnowledgeGraphProduct",
                     "description": "Graph with the BTO ontology product as a secondary source",
-                    "secondary_source": [{"source": "bto.owl", "relation_type": "prov:wasInfluencedBy"}],
+                    "secondary_source": [
+                        {"source": "bto.owl", "relation_type": "prov:wasInfluencedBy"}
+                    ],
                 }
             ],
         },
@@ -175,9 +179,7 @@ def test_product_pages_are_written_only_under_the_owning_resource(
                     "category": "Product",
                     "format": "gaf",
                     "description": "GOA annotation files",
-                    "original_source": [
-                        {"source": "go", "relation_type": "prov:hadPrimarySource"}
-                    ],
+                    "original_source": [{"source": "go", "relation_type": "prov:hadPrimarySource"}],
                 }
             ],
         },

--- a/tests/test_frink_sync.py
+++ b/tests/test_frink_sync.py
@@ -4,6 +4,7 @@ import copy
 
 from util.sync_frink import SHORTNAME_ALIASES
 
+
 def test_transform_frink_entry_to_resource(frink_syncer, frink_entry_example):
     resource = frink_syncer.transform_frink_to_kg_registry(frink_entry_example)
 
@@ -63,7 +64,10 @@ def test_merge_preserves_existing_graph_products_and_adds_frink_endpoints(
     merged_products = {product["id"]: product for product in merged["products"]}
     assert set(merged_products) == {"prokn.graph", "prokn.sparql", "prokn.tpf"}
     assert merged_products["prokn.graph"]["category"] == "GraphProduct"
-    assert merged_products["prokn.sparql"]["product_url"] == "https://frink.apps.renci.org/prokn/sparql"
+    assert (
+        merged_products["prokn.sparql"]["product_url"]
+        == "https://frink.apps.renci.org/prokn/sparql"
+    )
     assert merged_products["prokn.sparql"]["original_source"] == [
         {"source": "prokn", "relation_type": "prov:hadPrimarySource"}
     ]
@@ -141,7 +145,9 @@ def test_merge_preserve_identity_keeps_canonical_fields(
     # Products still merged (endpoint url updated in place, no duplicate).
     merged_products = {p["id"]: p for p in merged["products"]}
     assert set(merged_products) == {"prokn.graph", "prokn.sparql"}
-    assert merged_products["prokn.sparql"]["product_url"] == "https://apps.okn.us/biomarkerkg/sparql"
+    assert (
+        merged_products["prokn.sparql"]["product_url"] == "https://apps.okn.us/biomarkerkg/sparql"
+    )
 
 
 def test_merge_without_preserve_identity_still_overwrites(

--- a/tests/test_frontmatter_writing.py
+++ b/tests/test_frontmatter_writing.py
@@ -14,7 +14,6 @@ import pytest
 
 from util.common import CustomRuamelYAMLHandler, dump_frontmatter_text, save_frontmatter_file
 
-
 POST_TEXT = "---\nid: demo.product\nname: Demo\n---\n\nBody text.\n"
 
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse
 
 import frontmatter
 
-
 HERE = Path(__file__).parent.resolve()
 ROOT = HERE.parent
 RESOURCE_DIR = ROOT / "resource"
@@ -84,7 +83,9 @@ def test_root_resource_publications_have_at_most_one_preferred_entry():
     for path, metadata in _load_root_resource_posts():
         publications = metadata.get("publications", []) or []
         preferred_count = sum(
-            1 for publication in publications if isinstance(publication, dict) and publication.get("preferred")
+            1
+            for publication in publications
+            if isinstance(publication, dict) and publication.get("preferred")
         )
         if preferred_count > 1:
             violations.append(f"{path}: preferred_count={preferred_count}")
@@ -122,7 +123,9 @@ def test_root_resource_publication_identifiers_use_supported_formats():
 
         normalized_identifier = identifier.strip()
         if not _is_supported_publication_identifier(normalized_identifier):
-            violations.append(f"{path} publication[{index}] has unsupported identifier: {normalized_identifier}")
+            violations.append(
+                f"{path} publication[{index}] has unsupported identifier: {normalized_identifier}"
+            )
 
     assert not violations, "Unsupported publication identifiers found:\n" + "\n".join(violations)
 

--- a/tests/test_kg_bioportal_sync.py
+++ b/tests/test_kg_bioportal_sync.py
@@ -104,8 +104,12 @@ def test_name_similarity_accepts_reworded_names_and_rejects_collisions():
     # Genuine matches that read very differently.
     assert name_similarity("Uber Anatomy Ontology", "Uberon multi-species anatomy ontology") > 0.3
     assert name_similarity("Relations Ontology", "Relation Ontology") > 0.3
-    assert name_similarity("Microarray and Gene Expression Data Ontology",
-                           "Microarray experimental conditions") > 0.3
+    assert (
+        name_similarity(
+            "Microarray and Gene Expression Data Ontology", "Microarray experimental conditions"
+        )
+        > 0.3
+    )
     # Acronym collisions in the live manifest.
     assert name_similarity("Radiomics Ontology", "Relation Ontology") == 0.0
     assert name_similarity("Atlas Ontology Model", "ATOM") == 0.0
@@ -352,9 +356,7 @@ def test_sync_all_reports_entries_a_curator_could_resolve(syncer, agro_entry, mo
             "download_url": "https://example.org/UNRELATED.tar.gz",
         },
     ]
-    monkeypatch.setattr(
-        syncer, "fetch_manifest", lambda: {"ontologies": entries, "totals": {}}
-    )
+    monkeypatch.setattr(syncer, "fetch_manifest", lambda: {"ontologies": entries, "totals": {}})
 
     stats = syncer.sync_all()
 

--- a/tests/test_obo_sync_merge.py
+++ b/tests/test_obo_sync_merge.py
@@ -26,9 +26,7 @@ def test_merge_resource_metadata_preserves_curated_fields_products_and_publicati
             {
                 "category": "Organization",
                 "label": "Gene Ontology Consortium",
-                "contact_details": [
-                    {"contact_type": "url", "value": "https://geneontology.org/"}
-                ],
+                "contact_details": [{"contact_type": "url", "value": "https://geneontology.org/"}],
             }
         ],
         "products": [
@@ -61,9 +59,7 @@ def test_merge_resource_metadata_preserves_curated_fields_products_and_publicati
             {
                 "category": "Individual",
                 "label": "Suzi Aleksander",
-                "contact_details": [
-                    {"contact_type": "email", "value": "suzia@stanford.edu"}
-                ],
+                "contact_details": [{"contact_type": "email", "value": "suzia@stanford.edu"}],
             }
         ],
         "products": [
@@ -165,7 +161,10 @@ Keep this body.
 @pytest.mark.parametrize(
     ("raw_identifier", "expected"),
     [
-        ("https://www.ncbi.nlm.nih.gov/pubmed/10802651", "https://www.ncbi.nlm.nih.gov/pubmed/10802651"),
+        (
+            "https://www.ncbi.nlm.nih.gov/pubmed/10802651",
+            "https://www.ncbi.nlm.nih.gov/pubmed/10802651",
+        ),
         ("10.1093/nar/gkaf1271", "doi:10.1093/nar/gkaf1271"),
         ("10802651", "PMID:10802651"),
         (10802651, "PMID:10802651"),
@@ -213,9 +212,7 @@ def test_merge_products_excludes_configured_product_ids(tmp_path):
         {"id": "pcl-base.owl"},
     ]
 
-    merged = syncer.merge_products(
-        existing, synced, excluded_ids=syncer.product_exclusions["pcl"]
-    )
+    merged = syncer.merge_products(existing, synced, excluded_ids=syncer.product_exclusions["pcl"])
     merged_ids = {p["id"] for p in merged}
     assert merged_ids == {"pcl.owl", "pcl.obo"}
 

--- a/tests/test_parallel_loader.py
+++ b/tests/test_parallel_loader.py
@@ -10,11 +10,7 @@ def test_load_md_parallel_reads_frontmatter(tmp_path):
     resource_dir.mkdir()
     resource_file = resource_dir / "demo.md"
     resource_file.write_text(
-        "---\n"
-        "id: demo\n"
-        "name: Demo Resource\n"
-        "---\n"
-        "Demo body\n",
+        "---\n" "id: demo\n" "name: Demo Resource\n" "---\n" "Demo body\n",
         encoding="utf-8",
     )
 

--- a/tests/test_parquet_backend.py
+++ b/tests/test_parquet_backend.py
@@ -141,14 +141,12 @@ def test_duckdb_parquet_querier(parquet_backend_sample_data, parquet_yaml_writer
         assert len(results) == 1
         assert results[0]["id"] == "test-resource-1"
 
-        results = querier.execute_query(
-            """
+        results = querier.execute_query("""
             SELECT r.id, r.name, d.domain
             FROM resources r
             JOIN resource_domains d ON r.id = d.resource_id
             WHERE d.domain = 'example'
-            """
-        )
+            """)
         assert len(results) == 1
         assert results[0]["id"] == "test-resource-1"
         assert results[0]["domain"] == "example"

--- a/tests/test_quality_dashboard.py
+++ b/tests/test_quality_dashboard.py
@@ -70,8 +70,11 @@ def test_build_dashboard_data_counts_and_scoring(quality_dashboard_module):
 
     data = mod.build_dashboard_data(
         resources,
-        org_index={"ids": {"ncbi"}, "short_ids": set(), "labels": {
-            "nationalcenterforbiotechnologyinformation"}},
+        org_index={
+            "ids": {"ncbi"},
+            "short_ids": set(),
+            "labels": {"nationalcenterforbiotechnologyinformation"},
+        },
         url_results=url_results,
         citation_reports={
             "res2": {
@@ -143,9 +146,7 @@ def test_resources_are_scored_only_for_products_they_own(quality_dashboard_modul
         "category": "GraphProduct",
         "name": "Aggregated Download",
         "repository": "https://example.org/broken-repo",
-        "warnings": [
-            "File was not able to be retrieved when checked on 2026-02-10: timeout"
-        ],
+        "warnings": ["File was not able to be retrieved when checked on 2026-02-10: timeout"],
     }
     resources = [
         {"id": "agg", "name": "Aggregator", "products": [dict(broken_product)]},
@@ -171,8 +172,12 @@ def test_resources_are_scored_only_for_products_they_own(quality_dashboard_modul
     )
 
     by_id = {record["id"]: record for record in data["top_resources"]}
-    product_issues = {"product_missing_format", "product_missing_original_source",
-                      "product_missing_product_url", "broken_link"}
+    product_issues = {
+        "product_missing_format",
+        "product_missing_original_source",
+        "product_missing_product_url",
+        "broken_link",
+    }
 
     agg_issues = {issue["issue_key"] for issue in by_id["agg"]["issues"]}
     src_issues = {issue["issue_key"] for issue in by_id["src"]["issues"]}
@@ -205,9 +210,7 @@ def test_product_metrics_count_unique_products(quality_dashboard_module):
         "id": "agg.download",
         "category": "GraphProduct",
         "name": "Aggregated Download",
-        "warnings": [
-            "File was not able to be retrieved when checked on 2026-02-10: timeout"
-        ],
+        "warnings": ["File was not able to be retrieved when checked on 2026-02-10: timeout"],
     }
     resources = [
         {
@@ -415,9 +418,7 @@ def test_is_sparql_endpoint(quality_dashboard_module):
 def test_check_http_url_treats_406_and_412_as_live(quality_dashboard_module, monkeypatch):
     mod = quality_dashboard_module
     for code in (406, 412):
-        _install_fake_requests(
-            monkeypatch, mod, lambda method, url, code=code: _FakeResponse(code)
-        )
+        _install_fake_requests(monkeypatch, mod, lambda method, url, code=code: _FakeResponse(code))
         result = mod.check_http_url("https://example.org/page", timeout=5.0)
         assert result["ok"] is True, f"HTTP {code} should be treated as live"
         assert result.get("access_restricted") is True
@@ -433,9 +434,7 @@ def test_check_http_url_probes_sparql_endpoints(quality_dashboard_module, monkey
         return _FakeResponse(404)
 
     _install_fake_requests(monkeypatch, mod, responder)
-    result = mod.check_http_url(
-        "https://frink.apps.renci.org/wikidata/sparql", timeout=5.0
-    )
+    result = mod.check_http_url("https://frink.apps.renci.org/wikidata/sparql", timeout=5.0)
     assert result["ok"] is True
     assert result.get("sparql_probe") is True
 
@@ -443,8 +442,6 @@ def test_check_http_url_probes_sparql_endpoints(quality_dashboard_module, monkey
 def test_check_http_url_still_flags_dead_sparql_endpoint(quality_dashboard_module, monkeypatch):
     mod = quality_dashboard_module
     # Endpoint is genuinely gone: every request 404s, including the query probe.
-    _install_fake_requests(
-        monkeypatch, mod, lambda method, url: _FakeResponse(404)
-    )
+    _install_fake_requests(monkeypatch, mod, lambda method, url: _FakeResponse(404))
     result = mod.check_http_url("https://gone.example.org/sparql", timeout=5.0)
     assert result["ok"] is False

--- a/tests/test_reference_validation.py
+++ b/tests/test_reference_validation.py
@@ -94,9 +94,18 @@ doi: 10.1000/correct
         require_cache=True,
     )
 
-    assert any("title 'Wrong title' does not match cached title 'Correct title'" in e for e in report.errors)
-    assert any("doi '10.1000/wrong' does not match cached doi '10.1000/correct'" in e for e in report.errors)
-    assert any("first author 'Wrong A' does not match cached first author 'Correct A'" in e for e in report.errors)
+    assert any(
+        "title 'Wrong title' does not match cached title 'Correct title'" in e
+        for e in report.errors
+    )
+    assert any(
+        "doi '10.1000/wrong' does not match cached doi '10.1000/correct'" in e
+        for e in report.errors
+    )
+    assert any(
+        "first author 'Wrong A' does not match cached first author 'Correct A'" in e
+        for e in report.errors
+    )
     assert any("year '2023' does not match cached year '2024'" in w for w in report.warnings)
     assert report.invalid_publication_indexes == [0]
 
@@ -207,8 +216,7 @@ def test_validate_markdown_runs_publication_reference_validation(
     resource_dir = tmp_path / "tmpres"
     resource_dir.mkdir()
     md_path = resource_dir / "tmpres.md"
-    md_path.write_text(
-        """---
+    md_path.write_text("""---
 id: tmpres
 layout: resource_detail
 category: DataSource
@@ -224,8 +232,7 @@ products:
 ---
 
 Content
-"""
-    )
+""")
 
     monkeypatch.setattr(
         mod,
@@ -255,8 +262,7 @@ def test_validate_markdown_can_warn_on_publication_reference_errors(
     resource_dir = tmp_path / "tmpres"
     resource_dir.mkdir()
     md_path = resource_dir / "tmpres.md"
-    md_path.write_text(
-        """---
+    md_path.write_text("""---
 id: tmpres
 layout: resource_detail
 category: DataSource
@@ -272,8 +278,7 @@ products:
 ---
 
 Content
-"""
-    )
+""")
 
     monkeypatch.setattr(
         mod,
@@ -309,8 +314,7 @@ def test_validate_markdown_can_remove_invalid_publications(
     resource_dir = tmp_path / "tmpres"
     resource_dir.mkdir()
     md_path = resource_dir / "tmpres.md"
-    md_path.write_text(
-        """---
+    md_path.write_text("""---
 id: tmpres
 layout: resource_detail
 category: DataSource
@@ -327,8 +331,7 @@ products:
 ---
 
 Content
-"""
-    )
+""")
 
     monkeypatch.setattr(
         mod,

--- a/tests/test_retrieve_file_sizes_parallel.py
+++ b/tests/test_retrieve_file_sizes_parallel.py
@@ -15,7 +15,9 @@ def test_update_product_file_sizes_deduplicates_shared_urls(
 ):
     calls = []
 
-    def _fake_process_single_url(url, product_id, resource_id, cache, ignore_cache, clean_warnings_only, product):
+    def _fake_process_single_url(
+        url, product_id, resource_id, cache, ignore_cache, clean_warnings_only, product
+    ):
         calls.append((url, product_id, resource_id))
         return {
             "url": url,

--- a/tests/test_source_associations.py
+++ b/tests/test_source_associations.py
@@ -3,8 +3,8 @@
 from util.source_associations import (
     ORIGINAL_SOURCE_RELATION,
     SECONDARY_SOURCE_RELATION,
-    iter_source_ids,
     ensure_direct_product_primary_source,
+    iter_source_ids,
     make_original_source_associations,
     make_secondary_source_associations,
     merge_source_associations,
@@ -21,9 +21,7 @@ def test_source_association_defaults_and_legacy_iteration():
         {"source": "go", "relation_type": ORIGINAL_SOURCE_RELATION},
         {"source": "hp", "relation_type": ORIGINAL_SOURCE_RELATION},
     ]
-    assert secondary == [
-        {"source": "translator", "relation_type": SECONDARY_SOURCE_RELATION}
-    ]
+    assert secondary == [{"source": "translator", "relation_type": SECONDARY_SOURCE_RELATION}]
     assert list(iter_source_ids(["go", {"source": "hp", "relation_type": "prov:used"}])) == [
         "go",
         "hp",
@@ -78,8 +76,8 @@ def test_resource_owns_product_rejects_string_prefix_matches():
 
 
 def test_resource_owns_product_handles_missing_and_malformed_ids():
-    assert not resource_owns_product("go", "go")       # undotted: no owner segment
+    assert not resource_owns_product("go", "go")  # undotted: no owner segment
     assert not resource_owns_product("", "go.owl")
     assert not resource_owns_product("go", None)
     assert not resource_owns_product(None, "go.owl")
-    assert resource_owns_product(" go ", " go.owl ")   # surrounding whitespace tolerated
+    assert resource_owns_product(" go ", " go.owl ")  # surrounding whitespace tolerated

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,19 @@ deps =
     isort
 skip_install = true
 commands =
-    black src/ tests/
+    black --check --diff src/ tests/
+    isort --check-only --diff src/ tests/
+description = Check formatting. Run `tox -e format` to apply the fixes.
+
+[testenv:format]
+deps =
+    black
+    isort
+skip_install = true
+commands =
     isort src/ tests/
-description = Run linters.
+    black src/ tests/
+description = Apply the formatting that `tox -e lint` checks.
 
 [testenv:doclint]
 deps =


### PR DESCRIPTION
Third in the stack — on top of #704, which is on #703. Review in that order; GitHub retargets each as its parent merges.

This is the "Related" note from #677: the lint env ran `black src/ tests/` and `isort src/ tests/` in **write mode**. On CI that reformatted the checkout, exited 0, and threw the changes away with the runner. The job could not fail, so nothing it checked was ever enforced — it has been reporting success over a backlog of 13 unformatted test files.

### The fix

`--check --diff` and `--check-only --diff` make it an actual check, and print what would change so a failure explains itself. The write-mode behavior moves to a new `tox -e format`, which the lint env's description now points at.

### The backlog is cleared in the same commit

A check that fails the moment it lands is not useful. The reformat is 12 test files, entirely blank lines and line wrapping — 84 insertions, 79 deletions, no logic touched. 139 tests pass on both 3.10 and 3.11 after it.

### One file deliberately not reformatted

`src/kg_registry/kg_registry_schema/datamodel/kg_registry_schema.py` was the 13th. It is written by `gen-pydantic`, so formatting it would be undone by the next `make refresh-schema` — which would then fail lint. It is now excluded from black and isort, matching the exclusion flake8 already carries for that directory.

### Verified it can fail

An unformatted file dropped into `tests/`:

```
lint: commands[0]> black --check --diff src/ tests/
-x = {  "a":1 }
+x = {"a": 1}
1 file would be reformatted, 39 files would be left unchanged.
  lint: FAIL code 1
```

And on the branch as it stands, `tox -e lint`, `tox -e flake8` and `tox -e mypy` all pass.

### Worth knowing

black, isort and flake8 all still cover only `src/` and `tests/`. Most of this repo's actual code lives in `util/`, which none of them touch — `sync_obo_foundry.py`, `extract-metadata.py`, `generate-quality-dashboard.py` and the rest are entirely unlinted. That is a much larger reformat and a separate decision, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcjCL63qkoxU5PVt33Szwu