### PR TITLE
Add verified homepage_url to the 22 resources missing one

### DIFF
--- a/resource/cancer-genome-interpreter/cancer-genome-interpreter.md
+++ b/resource/cancer-genome-interpreter/cancer-genome-interpreter.md
@@ -11,8 +11,9 @@ domains:
 - clinical
 - precision medicine
 - drug discovery
+homepage_url: https://www.cancergenomeinterpreter.org/
 id: cancer-genome-interpreter
-last_modified_date: '2025-09-16T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.cancergenomeinterpreter.org/conditions#license

--- a/resource/cmaup/cmaup.md
+++ b/resource/cmaup/cmaup.md
@@ -10,8 +10,9 @@ domains:
 - drug discovery
 - pharmacology
 - chemistry and biochemistry
+homepage_url: https://bidd.group/CMAUP/
 id: cmaup
-last_modified_date: '2026-05-30T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: CMAUP
 products:

--- a/resource/compartments/compartments.md
+++ b/resource/compartments/compartments.md
@@ -10,8 +10,9 @@ domains:
 - proteomics
 - systems biology
 - biological systems
+homepage_url: https://compartments.jensenlab.org/
 id: compartments
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/

--- a/resource/crd/crd.md
+++ b/resource/crd/crd.md
@@ -1,13 +1,14 @@
 ---
-activity_status: unresponsive
+activity_status: active
 category: Aggregator
 creation_date: '2025-09-09T00:00:00Z'
-description: The Comparative RNA Database (CRD) was an aggregator of RNA sequence and structure data, but is no longer available. This resource is considered unresponsive; only its metadata and publication are retained for reference.
+description: The Comparative RNA Database (CRD) is an aggregator of comparative RNA sequence and secondary structure data, covering ribosomal, intron, and other RNAs. It is published through the Comparative RNA Web (CRW) Site, which relocated from its original University of Texas host to CRW2 (Comparative RNA Web-2).
 domains:
   - biological systems
   - genomics
+homepage_url: https://crw2-comparative-rna-web.org/
 id: crd
-last_modified_date: '2025-10-10T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: Comparative RNA Database (CRD)
 products:
@@ -408,12 +409,10 @@ publications:
   journal: Journal of Interferon & Cytokine Research
   title: 'Collaborative Bioinformatics: Data Warehouses for Targeted Experimental Results'
   year: '1998'
-warnings:
-  - This resource is unresponsive. The database is no longer available; only metadata and publication are retained.
 ---
 
 # Comparative RNA Database (CRD)
 
-The Comparative RNA Database (CRD) was an aggregator of RNA sequence and structure data, including ribosomal and intron RNAs. The database is no longer available, but its metadata and publication are retained for reference. For more information, see the original publication:
+The Comparative RNA Database (CRD) is an aggregator of comparative RNA sequence and secondary structure data, including ribosomal, intron, and other RNAs. Its data is published through the Comparative RNA Web (CRW) Site, which has moved from its original University of Texas host to CRW2 (Comparative RNA Web-2) at https://crw2-comparative-rna-web.org/. For more information, see the original publication:
 
 - Gutell RR, Cannone JJ, Konings BF, Yang Z. The Comparative RNA Web (CRW) Site: An Online Database of Comparative Sequence and Structure Information for Ribosomal, Intron, and Other RNAs. Journal of Interferon & Cytokine Research. 1998;18(10):799-803. doi:10.1089/jir.1998.18.799

--- a/resource/creeds/creeds.md
+++ b/resource/creeds/creeds.md
@@ -16,8 +16,9 @@ description: CREEDS (CRowd Extracted Expression of Differential Signatures) is a
 domains:
 - pharmacology
 - genomics
+homepage_url: https://maayanlab.cloud/CREEDS/
 id: creeds
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/

--- a/resource/drug-approvals-kp/drug-approvals-kp.md
+++ b/resource/drug-approvals-kp/drug-approvals-kp.md
@@ -18,8 +18,9 @@ domains:
 - biomedical
 - pharmacology
 - drug discovery
+homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/Drug-Approvals-KP
 id: drug-approvals-kp
-last_modified_date: '2026-05-28T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: Drug Approvals KP
 products:

--- a/resource/ena/ena.md
+++ b/resource/ena/ena.md
@@ -9,8 +9,9 @@ description: The European Nucleotide Archive (ENA) is a comprehensive database p
 domains:
 - genomics
 - biological systems
+homepage_url: https://www.ebi.ac.uk/ena/browser/home
 id: ena
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: European Nucleotide Archive (ENA)
 products:

--- a/resource/eupathdb/eupathdb.md
+++ b/resource/eupathdb/eupathdb.md
@@ -10,8 +10,9 @@ domains:
 - genomics
 - biological systems
 - organisms
+homepage_url: https://veupathdb.org/
 id: eupathdb
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: Eukaryotic Pathogen Database (EuPathDB)
 products:

--- a/resource/genetics-kp/genetics-kp.md
+++ b/resource/genetics-kp/genetics-kp.md
@@ -10,9 +10,10 @@ creation_date: '2025-03-09T00:00:00Z'
 description: A Translator Knowledge Provider focusing on genetic data.
 domains:
 - biomedical
+homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/Genetics-Knowledge-Provider
 id: genetics-kp
 infores_id: genetics-data-provider
-last_modified_date: '2026-07-03T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: Genetics KP
 products:

--- a/resource/malacards/malacards.md
+++ b/resource/malacards/malacards.md
@@ -10,8 +10,9 @@ domains:
 - biomedical
 - clinical
 - genomics
+homepage_url: https://www.malacards.org/
 id: malacards
-last_modified_date: '2025-10-10T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: MalaCards
 products:

--- a/resource/mat/mat.md
+++ b/resource/mat/mat.md
@@ -13,8 +13,9 @@ creation_date: '2025-09-29T00:00:00Z'
 description: Description unavailable.
 domains:
 - anatomy and development
+homepage_url: https://obofoundry.org/ontology/mat.html
 id: mat
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: ''

--- a/resource/mfo/mfo.md
+++ b/resource/mfo/mfo.md
@@ -17,8 +17,9 @@ description: A structured controlled vocabulary of the anatomy and development o
   the Japanese medaka fish, <i>Oryzias latipes</i>.
 domains:
 - anatomy and development
+homepage_url: https://obofoundry.org/ontology/mfo.html
 id: mfo
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: ''

--- a/resource/mgmlink/mgmlink.md
+++ b/resource/mgmlink/mgmlink.md
@@ -13,6 +13,7 @@ description: A knowledge graph of linked microbes, genes and metabolites.
 domains:
   - biological systems
   - microbiology
+homepage_url: https://github.com/bsantan/MGMLink
 id: mgmlink
 layout: resource_detail
 name: MGMLink
@@ -43,7 +44,7 @@ publications:
 taxon:
   - NCBITaxon:2759
 creation_date: '2025-04-13T00:00:00Z'
-last_modified_date: '2026-01-06T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 ---
 
 MGMLink

--- a/resource/mgnify/mgnify.md
+++ b/resource/mgnify/mgnify.md
@@ -10,8 +10,9 @@ domains:
   - genomics
   - environment
   - clinical
+homepage_url: https://www.ebi.ac.uk/metagenomics
 id: mgnify
-last_modified_date: '2025-10-10T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: MGnify
 products:

--- a/resource/mirgenedb/mirgenedb.md
+++ b/resource/mirgenedb/mirgenedb.md
@@ -9,8 +9,9 @@ description: MirGeneDB is a manually curated database of microRNA genes, providi
 domains:
 - genomics
 - biological systems
+homepage_url: https://mirgenedb.org/
 id: mirgenedb
-last_modified_date: '2025-10-15T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: MirGeneDB
 products:

--- a/resource/modomics/modomics.md
+++ b/resource/modomics/modomics.md
@@ -10,8 +10,9 @@ domains:
 - genomics
 - biological systems
 - chemistry and biochemistry
+homepage_url: https://genesilico.pl/modomics/
 id: modomics
-last_modified_date: '2025-10-15T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: MODOMICS
 products:

--- a/resource/multiomics-kp/multiomics-kp.md
+++ b/resource/multiomics-kp/multiomics-kp.md
@@ -11,8 +11,9 @@ contacts:
 description: A Translator Knowledge Provider incorporating multiomics data.
 domains:
   - biomedical
+homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/Multiomics-Provider
 id: multiomics-kp
-last_modified_date: '2026-07-03T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: Multiomics KP
 products:

--- a/resource/oio/oio.md
+++ b/resource/oio/oio.md
@@ -19,8 +19,9 @@ description: The OBO Interoperability Ontology (OIO) was a set of annotation pro
 domains:
 - biological systems
 - general
+homepage_url: https://www.ebi.ac.uk/ols4/ontologies/oio
 id: oio
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/

--- a/resource/ontology-kp/ontology-kp.md
+++ b/resource/ontology-kp/ontology-kp.md
@@ -10,8 +10,9 @@ creation_date: '2025-03-09T00:00:00Z'
 description: A Translator Knowledge Provider dedicated to ontology-based services.
 domains:
 - other
+homepage_url: https://github.com/NCATSTranslator/Translator-All/wiki/SRI-Ontology-Service
 id: ontology-kp
-last_modified_date: '2026-07-01T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: Ontology KP
 products:

--- a/resource/sckan/sckan.md
+++ b/resource/sckan/sckan.md
@@ -11,8 +11,9 @@ description: SCKAN (SPARC Connectivity Knowledge base of the Autonomic Nervous s
 domains:
 - biological systems
 - anatomy and development
+homepage_url: https://docs.sparc.science/docs/sckan
 id: sckan
-last_modified_date: '2025-10-15T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: SCKAN
 products:

--- a/resource/toxcast/toxcast.md
+++ b/resource/toxcast/toxcast.md
@@ -13,8 +13,9 @@ domains:
 - environment
 - public health
 - biomedical
+homepage_url: https://www.epa.gov/comptox-tools/toxicity-forecasting-toxcast
 id: toxcast
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.epa.gov/privacy/privacy-and-security-notice

--- a/resource/vhog/vhog.md
+++ b/resource/vhog/vhog.md
@@ -8,8 +8,9 @@ creation_date: '2025-09-29T00:00:00Z'
 description: Description unavailable.
 domains:
 - anatomy and development
+homepage_url: https://obofoundry.org/ontology/vhog.html
 id: vhog
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: ''


### PR DESCRIPTION
The data quality dashboard (`reports/quality-dashboard.json`, generated 2026-08-31) listed 22 resources with no `homepage_url`. All 22 are cleared here.

Every URL was checked live with `curl -L` before it was written to a file. None were inferred from the resource ID, the ontology prefix, or a naming pattern.

| Resource | homepage_url |
|---|---|
| cancer-genome-interpreter | https://www.cancergenomeinterpreter.org/ |
| cmaup | https://bidd.group/CMAUP/ |
| compartments | https://compartments.jensenlab.org/ |
| crd | https://crw2-comparative-rna-web.org/ |
| creeds | https://maayanlab.cloud/CREEDS/ |
| drug-approvals-kp | https://github.com/NCATSTranslator/Translator-All/wiki/Drug-Approvals-KP |
| ena | https://www.ebi.ac.uk/ena/browser/home |
| eupathdb | https://veupathdb.org/ |
| genetics-kp | https://github.com/NCATSTranslator/Translator-All/wiki/Genetics-Knowledge-Provider |
| malacards | https://www.malacards.org/ |
| mat | https://obofoundry.org/ontology/mat.html |
| mfo | https://obofoundry.org/ontology/mfo.html |
| mgmlink | https://github.com/bsantan/MGMLink |
| mgnify | https://www.ebi.ac.uk/metagenomics |
| mirgenedb | https://mirgenedb.org/ |
| modomics | https://genesilico.pl/modomics/ |
| multiomics-kp | https://github.com/NCATSTranslator/Translator-All/wiki/Multiomics-Provider |
| oio | https://www.ebi.ac.uk/ols4/ontologies/oio |
| ontology-kp | https://github.com/NCATSTranslator/Translator-All/wiki/SRI-Ontology-Service |
| sckan | https://docs.sparc.science/docs/sckan |
| toxcast | https://www.epa.gov/comptox-tools/toxicity-forecasting-toxcast |
| vhog | https://obofoundry.org/ontology/vhog.html |

`last_modified_date` is bumped to today on each page.

## Three things worth a reviewer's attention

**1. `crd` was wrong, not merely incomplete — this PR changes more than one field there.**

It carried `activity_status: unresponsive`, a description saying the database "is no longer available," and a matching `warnings:` entry. It did not die, it relocated: the original University of Texas host (`rna.ccbb.utexas.edu`) now serves a *"We have moved"* notice pointing at CRW2, which returns 200 and titles itself *CRW2: Comparative RNA Web-2*. Flipped to `active`, rewrote the description and body prose, and removed the now-false warning.

If you would rather land the plain homepage additions first and review the status change on its own, that file is the one to pull out.

**2. `malacards` never returns 200 to an automated client.**

Every request — varied UA, HTTP/1.1, subpaths, apex domain — gets `403` with `cf-mitigated: challenge` and a Cloudflare JS challenge body. That is a bot block, not an outage. It is recorded because the page already used that identical URL as its own `GraphicalInterface` `product_url`, but it will keep tripping the link checker, so it is called out rather than quietly added.

**3. `make prettify-file` was deliberately not run.**

It reformats each page wholesale: flat `- item` sequences become `  - item`, folded `description:` blocks unwrap, and keys reorder inside every `products:` entry. That style is the minority in this repo (roughly 68 flat vs 17 indented in a 400-file sample), so running it turned this 47-line change into a ~6000-line diff. Reverted, and only the semantic edits re-applied.

Every file passes `uv run make validate-file FILE=resource/<id>/<id>.md` without it.

## Known follow-up, intentionally not in this PR

`mat` and `vhog` still read `description: Description unavailable.`, and the OBO Foundry pages linked here carry real descriptions. That is a different field than this PR's scope, so it is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcjCL63qkoxU5PVt33Szwu