### PR TITLE
Repoint 11 relocated URLs and point CardioKG at its Zenodo archive

### DIFF
--- a/resource/cardiokg/cardiokg.data.md
+++ b/resource/cardiokg/cardiokg.data.md
@@ -10,6 +10,6 @@ original_source:
   source: cardiokg
 - relation_type: prov:hadPrimarySource
   source: ukbiobank
-product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Data
+product_url: https://doi.org/10.5281/zenodo.16025953
 layout: product_detail
 ---

--- a/resource/cardiokg/cardiokg.embeddings.md
+++ b/resource/cardiokg/cardiokg.embeddings.md
@@ -7,6 +7,6 @@ name: CardioKG generated embeddings
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cardiokg
-product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Generated_embeddings
+product_url: https://doi.org/10.5281/zenodo.16025953
 layout: product_detail
 ---

--- a/resource/cardiokg/cardiokg.md
+++ b/resource/cardiokg/cardiokg.md
@@ -16,9 +16,9 @@ domains:
   - clinical
   - medical imaging
   - precision medicine
-homepage_url: https://github.com/ImperialCollegeLondon/cardioKG
+homepage_url: https://doi.org/10.5281/zenodo.16025953
 id: cardiokg
-last_modified_date: '2026-06-12T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://opensource.org/license/mit/
@@ -26,7 +26,7 @@ license:
 name: CardioKG
 products:
   - category: GraphProduct
-    description: Neo4j construction artifacts for CardioKG, including Cypher scripts to create graph nodes and add edges.
+    description: Neo4j construction artifacts for CardioKG, including Cypher scripts to create graph nodes and add edges. The GitHub repository is no longer available; these files are inside the archived Zenodo snapshot.
     dump_format: neo4j
     format: neo4j
     id: cardiokg.neo4j
@@ -54,9 +54,9 @@ products:
         source: string
       - relation_type: prov:used
         source: opentargets
-    product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+    product_url: https://doi.org/10.5281/zenodo.16025953
   - category: Product
-    description: CardioKG supporting data tables for anatomy and cardiac magnetic resonance anatomy mappings.
+    description: CardioKG supporting data tables for anatomy and cardiac magnetic resonance anatomy mappings. The GitHub repository is no longer available; these files are inside the archived Zenodo snapshot.
     format: csv
     id: cardiokg.data
     name: CardioKG supporting data tables
@@ -65,23 +65,23 @@ products:
         source: cardiokg
       - relation_type: prov:hadPrimarySource
         source: ukbiobank
-    product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Data
+    product_url: https://doi.org/10.5281/zenodo.16025953
   - category: Product
-    description: Generated CardioKG embeddings for gene-disease and medication-disease association prediction tasks.
+    description: Generated CardioKG embeddings for gene-disease and medication-disease association prediction tasks. The GitHub repository is no longer available; these files are inside the archived Zenodo snapshot.
     id: cardiokg.embeddings
     name: CardioKG generated embeddings
     original_source:
       - relation_type: prov:hadPrimarySource
         source: cardiokg
-    product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Generated_embeddings
+    product_url: https://doi.org/10.5281/zenodo.16025953
   - category: ProcessProduct
-    description: Analysis notebooks and scripts for CardioKG graph construction, PageRank importance analysis, gene-disease association prediction, and drug repurposing.
+    description: Analysis notebooks and scripts for CardioKG graph construction, PageRank importance analysis, gene-disease association prediction, and drug repurposing. The GitHub repository is no longer available; these files are inside the archived Zenodo snapshot.
     id: cardiokg.workflow
     name: CardioKG analysis workflow
     original_source:
       - relation_type: prov:hadPrimarySource
         source: cardiokg
-    product_url: https://github.com/ImperialCollegeLondon/cardioKG
+    product_url: https://doi.org/10.5281/zenodo.16025953
   - category: Product
     compression: zip
     description: Archived CardioKG repository release on Zenodo.
@@ -116,7 +116,6 @@ publications:
     journal: Nature Cardiovascular Research
     title: A multimodal vision knowledge graph of cardiovascular disease
     year: '2025'
-repository: https://github.com/ImperialCollegeLondon/cardioKG
 taxon:
   - NCBITaxon:9606
 ---
@@ -124,3 +123,8 @@ taxon:
 CardioKG combines cardiovascular imaging-derived phenotypes with biomedical knowledge
 sources to support graph-based prediction of disease genes, pathway enrichment, and
 drug repurposing opportunities for cardiovascular disease.
+
+The project's GitHub repository (`ImperialCollegeLondon/cardioKG`) is no longer
+available. The archived release deposited on Zenodo is the remaining source for the
+graph construction scripts, supporting data tables, generated embeddings and analysis
+notebooks, so the products above all resolve to that snapshot.

--- a/resource/cardiokg/cardiokg.neo4j.md
+++ b/resource/cardiokg/cardiokg.neo4j.md
@@ -29,6 +29,6 @@ original_source:
   source: string
 - relation_type: prov:used
   source: opentargets
-product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+product_url: https://doi.org/10.5281/zenodo.16025953
 layout: product_detail
 ---

--- a/resource/cardiokg/cardiokg.workflow.md
+++ b/resource/cardiokg/cardiokg.workflow.md
@@ -7,6 +7,6 @@ name: CardioKG analysis workflow
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cardiokg
-product_url: https://github.com/ImperialCollegeLondon/cardioKG
+product_url: https://doi.org/10.5281/zenodo.16025953
 layout: product_detail
 ---

--- a/resource/disgenet/disgenet.md
+++ b/resource/disgenet/disgenet.md
@@ -22,7 +22,7 @@ domains:
 homepage_url: https://www.disgenet.com/
 id: disgenet
 infores_id: disgenet
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.disgenet.com/Legal
@@ -2004,7 +2004,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: GraphProduct
   description: The full PrimeKG dataset containing disease relationships.
   format: csv

--- a/resource/drugbank/drugbank.md
+++ b/resource/drugbank/drugbank.md
@@ -23,7 +23,7 @@ domains:
 homepage_url: https://www.drugbank.com/
 id: drugbank
 infores_id: drugbank
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://go.drugbank.com/legal/terms_of_use
@@ -2867,7 +2867,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: GraphicalInterface
   description: Web-based interface for searching and browsing comprehensive gene-centric
     information integrating data from over 200 sources

--- a/resource/efip/efip.md
+++ b/resource/efip/efip.md
@@ -15,9 +15,9 @@ domains:
 - biomedical
 - literature
 - proteomics
-homepage_url: http://proteininformationresource.org/efip
+homepage_url: https://proteininformationresource.org/efip/
 id: efip
-last_modified_date: '2026-06-03T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: eFIP
 products:

--- a/resource/ensembl/ensembl.api.rest.md
+++ b/resource/ensembl/ensembl.api.rest.md
@@ -8,6 +8,6 @@ name: Ensembl REST API
 original_source:
 - relation_type: prov:hadPrimarySource
   source: ensembl
-product_url: https://rest.ensembl.org
+product_url: https://rest.ensembl.org/
 layout: product_detail
 ---

--- a/resource/ensembl/ensembl.md
+++ b/resource/ensembl/ensembl.md
@@ -16,7 +16,7 @@ domains:
 homepage_url: https://www.ensembl.org
 id: ensembl
 infores_id: ensembl-gene
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: http://www.apache.org/licenses/LICENSE-2.0
@@ -81,7 +81,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: ensembl
-  product_url: https://rest.ensembl.org
+  product_url: https://rest.ensembl.org/
 - category: GraphProduct
   description: Nodes for KGX distribution of the RTX-KG2 (RTX-KG2.10.1c)
   format: kgx-jsonl

--- a/resource/esgf/esgf.md
+++ b/resource/esgf/esgf.md
@@ -19,7 +19,7 @@ domains:
 - general
 homepage_url: https://esgf.llnl.gov/
 id: esgf
-last_modified_date: '2026-07-03T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: Earth System Grid Federation (ESGF)
 products:
@@ -33,7 +33,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: esgf
-  product_url: https://aims2.llnl.gov/search
+  product_url: https://metagrid.esgf-west.org/search
 - category: GraphProduct
   description: RDF/Turtle knowledge graph integrating climate model and dataset metadata
     (from ESGF, CMIP controlled vocabularies, and the NASA GCMD keyword taxonomy)
@@ -70,7 +70,7 @@ programmatic APIs.
 Federated search and download interface for climate dataset metadata across ESGF
 nodes.
 
-**URL**: [https://aims2.llnl.gov/search](https://aims2.llnl.gov/search)
+**URL**: [https://metagrid.esgf-west.org/search](https://metagrid.esgf-west.org/search)
 
 **Format**: http
 </content>

--- a/resource/esgf/esgf.search.md
+++ b/resource/esgf/esgf.search.md
@@ -9,6 +9,6 @@ name: ESGF Search
 original_source:
 - relation_type: prov:hadPrimarySource
   source: esgf
-product_url: https://aims2.llnl.gov/search
+product_url: https://metagrid.esgf-west.org/search
 layout: product_detail
 ---

--- a/resource/faers/faers.electronic_submissions.md
+++ b/resource/faers/faers.electronic_submissions.md
@@ -7,6 +7,6 @@ name: FAERS Electronic Submissions Portal
 original_source:
   - source: faers
     relation_type: prov:hadPrimarySource
-product_url: https://www.fda.gov/drugs/questions-and-answers-fdas-adverse-event-reporting-system-faers/fda-adverse-event-reporting-system-faers-electronic-submissions
+product_url: https://www.fda.gov/drugs/fda-adverse-event-monitoring-system-aems/fda-adverse-event-monitoring-system-aems-electronic-submissions
 layout: product_detail
 ---

--- a/resource/faers/faers.md
+++ b/resource/faers/faers.md
@@ -23,10 +23,10 @@ domains:
 - drug discovery
 - clinical
 - public health
-homepage_url: https://www.fda.gov/drugs/surveillance/fdas-adverse-event-reporting-system-faers
+homepage_url: https://www.fda.gov/drugs/surveillance-post-drug-approval-activities/fda-adverse-event-monitoring-system-aems
 id: faers
 infores_id: faers
-last_modified_date: '2026-06-02T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: FDA Adverse Event Reporting System
 products:
@@ -86,7 +86,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: faers
-  product_url: https://www.fda.gov/drugs/questions-and-answers-fdas-adverse-event-reporting-system-faers/fda-adverse-event-reporting-system-faers-electronic-submissions
+  product_url: https://www.fda.gov/drugs/fda-adverse-event-monitoring-system-aems/fda-adverse-event-monitoring-system-aems-electronic-submissions
 - category: Product
   description: Standardized and deduplicated version of FDA FAERS data with drug names
     mapped to RxNorm and adverse event outcomes mapped to SNOMED-CT, including pre-computed

--- a/resource/fda-orange-book/fda-orange-book.md
+++ b/resource/fda-orange-book/fda-orange-book.md
@@ -36,7 +36,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: fda-orange-book
-  product_url: https://www.fda.gov/cder/ob/default.htm
+  product_url: https://www.fda.gov/drugs/drug-approvals-and-databases/approved-drug-products-therapeutic-equivalence-evaluations-orange-book
 - category: Product
   description: FDA Orange Book data files and appendices for approved drug products,
     therapeutic equivalence evaluations, patents, exclusivity, and related regulatory

--- a/resource/fda-orange-book/fda-orange-book.search.md
+++ b/resource/fda-orange-book/fda-orange-book.search.md
@@ -9,6 +9,6 @@ name: FDA Orange Book Search
 original_source:
 - relation_type: prov:hadPrimarySource
   source: fda-orange-book
-product_url: https://www.fda.gov/cder/ob/default.htm
+product_url: https://www.fda.gov/drugs/drug-approvals-and-databases/approved-drug-products-therapeutic-equivalence-evaluations-orange-book
 layout: product_detail
 ---

--- a/resource/iproclass/iproclass.md
+++ b/resource/iproclass/iproclass.md
@@ -7,10 +7,10 @@ domains:
   - proteomics
 id: "iproclass"
 infores_id: "iproclass"
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 name: iProClass
-homepage_url: http://pir.georgetown.edu/iproclass/
+homepage_url: https://proteininformationresource.org/iproclass/
 contacts:
   - category: Organization
     contact_details:
@@ -29,7 +29,7 @@ products:
     original_source:
       - source: iproclass
         relation_type: prov:hadPrimarySource
-    product_url: http://pir.georgetown.edu/iproclass/
+    product_url: https://proteininformationresource.org/iproclass/
   - category: DocumentationProduct
     description: Protein Information Resource site with parent documentation and context for iProClass.
     format: http

--- a/resource/iproclass/iproclass.portal.md
+++ b/resource/iproclass/iproclass.portal.md
@@ -7,6 +7,6 @@ name: iProClass Portal
 original_source:
   - source: iproclass
     relation_type: prov:hadPrimarySource
-product_url: http://pir.georgetown.edu/iproclass/
+product_url: https://proteininformationresource.org/iproclass/
 layout: product_detail
 ---

--- a/resource/kegg/kegg.md
+++ b/resource/kegg/kegg.md
@@ -29,7 +29,7 @@ domains:
 homepage_url: https://www.genome.jp/kegg/
 id: kegg
 infores_id: kegg
-last_modified_date: '2026-07-01T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.kegg.jp/feedback/copyright.html
@@ -2523,7 +2523,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: GraphicalInterface
   description: Web interface that allows searching, browsing, and exploring food compounds
     and their properties.

--- a/resource/maude/maude.md
+++ b/resource/maude/maude.md
@@ -16,9 +16,9 @@ description: The U.S. FDA database of medical device adverse event reports. It h
 domains:
 - clinical
 - biomedical
-homepage_url: https://www.fda.gov/medical-devices/mandatory-reporting-requirements-manufacturers-importers-and-device-user-facilities/manufacturer-and-user-facility-device-experience-database-maude
+homepage_url: https://www.fda.gov/medical-devices/mandatory-reporting-requirements-manufacturers-importers-and-device-user-facilities/about-manufacturer-and-user-facility-device-experience-maude-database
 id: maude
-last_modified_date: '2026-07-01T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.usa.gov/government-works

--- a/resource/mesh/mesh.md
+++ b/resource/mesh/mesh.md
@@ -14,7 +14,7 @@ domains:
 homepage_url: https://www.nlm.nih.gov/mesh/meshhome.html
 id: mesh
 infores_id: mesh
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.nlm.nih.gov/databases/download/terms_and_conditions_mesh.html
@@ -1696,7 +1696,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: ProgrammingInterface
   description: REST API for searching identifiers and special keywords, mapping between
     data sources with a chain-query syntax, and retrieving entries across the integrated

--- a/resource/mirnao/mirnao.md
+++ b/resource/mirnao/mirnao.md
@@ -13,9 +13,9 @@ creation_date: '2025-09-29T00:00:00Z'
 description: An application ontology for use with miRNA databases.
 domains:
 - chemistry and biochemistry
-homepage_url: http://code.google.com/p/mirna-ontology/
+homepage_url: https://code.google.com/archive/p/mirna-ontology
 id: mirnao
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/

--- a/resource/mondo/mondo.md
+++ b/resource/mondo/mondo.md
@@ -20,7 +20,7 @@ domains:
 homepage_url: https://monarch-initiative.github.io/mondo
 id: mondo
 infores_id: mondo
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/
@@ -2095,7 +2095,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: ProgrammingInterface
   description: REST API for searching identifiers and special keywords, mapping between
     data sources with a chain-query syntax, and retrieving entries across the integrated

--- a/resource/mpath/mpath.md
+++ b/resource/mpath/mpath.md
@@ -17,10 +17,10 @@ description: A structured controlled vocabulary of mutant and transgenic mouse p
   phenotypes
 domains:
 - biomedical
-homepage_url: http://www.pathbase.net
+homepage_url: https://pathbase.net/
 id: mpath
 infores_id: mpath
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/3.0/

--- a/resource/pr/pr.md
+++ b/resource/pr/pr.md
@@ -16,10 +16,10 @@ creation_date: '2025-06-25T00:00:00Z'
 description: An ontological representation of protein-related entities
 domains:
 - chemistry and biochemistry
-homepage_url: http://proconsortium.org
+homepage_url: https://proconsortium.org/
 id: pr
 infores_id: pr
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: http://creativecommons.org/licenses/by/4.0/

--- a/resource/reactome/reactome.md
+++ b/resource/reactome/reactome.md
@@ -32,7 +32,7 @@ domains:
 homepage_url: https://reactome.org
 id: reactome
 infores_id: reactome
-last_modified_date: '2026-06-22T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -5611,7 +5611,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: ProgrammingInterface
   description: REST API for searching identifiers and special keywords, mapping between
     data sources with a chain-query syntax, and retrieving entries across the integrated

--- a/resource/string/string.md
+++ b/resource/string/string.md
@@ -21,7 +21,7 @@ domains:
 homepage_url: https://string-db.org/
 id: string
 infores_id: string
-last_modified_date: '2026-02-20T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -3436,7 +3436,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: ProgrammingInterface
   description: REST API for searching identifiers and special keywords, mapping between
     data sources with a chain-query syntax, and retrieving entries across the integrated

--- a/resource/ukbiobank/ukbiobank.md
+++ b/resource/ukbiobank/ukbiobank.md
@@ -13,7 +13,7 @@ domains:
 - phenotype
 homepage_url: https://www.ukbiobank.ac.uk/
 id: ukbiobank
-last_modified_date: '2025-12-13T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://www.ukbiobank.ac.uk/terms-and-conditions/
@@ -187,7 +187,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: Product
   description: CardioKG supporting data tables for anatomy and cardiac magnetic resonance
     anatomy mappings.
@@ -199,7 +199,7 @@ products:
     source: cardiokg
   - relation_type: prov:hadPrimarySource
     source: ukbiobank
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Data
+  product_url: https://doi.org/10.5281/zenodo.16025953
 publications:
 - authors:
   - Clare Bycroft

--- a/resource/uniprot/uniprot.md
+++ b/resource/uniprot/uniprot.md
@@ -17,7 +17,7 @@ domains:
 homepage_url: https://www.uniprot.org/
 id: uniprot
 infores_id: uniprot
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-01T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by/4.0/
@@ -4020,7 +4020,7 @@ products:
     source: string
   - relation_type: prov:used
     source: opentargets
-  product_url: https://github.com/ImperialCollegeLondon/cardioKG/tree/main/Building%20KG
+  product_url: https://doi.org/10.5281/zenodo.16025953
 - category: ProgrammingInterface
   description: REST API for searching identifiers and special keywords, mapping between
     data sources with a chain-query syntax, and retrieving entries across the integrated


### PR DESCRIPTION
Batch 2 of the broken-link backlog. **Deliberately smaller than 50.** After live triage, most of what remains in the backlog is either not actually broken or not fixable, and this PR contains only changes backed by a verified 200. The reasoning for what was left out is below — that's the more useful half of this PR.

## Relocated URLs (11)

Each old URL is genuinely deprecated; each replacement was fetched and confirmed live:

| Old | New | Why |
|---|---|---|
| `aims2.llnl.gov/search` | `metagrid.esgf-west.org/search` | AIMS2 retired; MetaGrid is the successor |
| `code.google.com/p/mirna-ontology` | `code.google.com/archive/p/…` | Google Code shut down |
| `pir.georgetown.edu/iproclass` | `proteininformationresource.org/iproclass/` | PIR left the georgetown.edu host |
| FDA FAERS × 2 | FDA **AEMS** pages | FAERS was renamed AEMS |
| FDA `/cder/ob/default.htm` | Orange Book page | legacy path retired |
| FDA MAUDE | `about-…-maude-database` | page renamed |
| `proconsortium`, `efip`, `pathbase`, `rest.ensembl` | https / canonical forms | http-only or www-only hosts |

## CardioKG (5 URLs + 9 foreign copies)

`github.com/ImperialCollegeLondon/cardioKG` is gone. GitHub search surfaces same-named repos under other owners, but the API confirms **neither is a fork** of the Imperial project, so they are not substitutes.

The Zenodo deposit for that repo is live and its record title (`ImperialCollegeLondon/cardioKG: cardioKG`) confirms provenance. So `homepage_url` and the four dead product URLs now resolve there, each description noting the files sit inside the archived snapshot. `repository:` is **dropped** rather than left pointing at a dead repo.

`cardiokg` owns those products, so the identical change is applied to the **9 foreign copies** on other pages to keep the dashboard accurate until `sync_product_references` runs. `opentargets` also carries a copy but is in `reports/curation_problems.tsv`, so it's left for the build to sync.

## Deliberately not changed — please sanity-check this reasoning

**1. PURLs are not broken links.** A number of flagged `purl.obolibrary.org` and `w3id.org` URLs are PURL services working exactly as designed. Repointing them at the raw GitHub files they redirect to would trade a stable identifier for a fragile one. I nearly did this before catching it; worth a checker exemption for known PURL hosts.

**2. `apps.okn.us` (36 SPARQL endpoints) — dead, and so is its successor.** The host root serves 200 but every endpoint TCP-connects then hangs, including for valid GET- and POST-form SPARQL queries. FRINK looks like the migration target and 36 of 38 graph names are *routed* there — but every one returns nginx **503**, persistently across retries. Two graphs (`ubergraph`, `nasa-gesdisc-kg`) aren't on FRINK at all. **No verified target exists, so nothing was repointed.** Worth someone with OKN contacts confirming whether FRINK is coming back.

**3. `kgx-storage.rtx.ai` (30 URLs, all owned by `translator`)** is unreachable with no announced replacement. `rtx.ai` itself is down, though `kg2webhost.rtx.ai` responds — so this is a real service loss, not my network. Automat hosts similarly-named graphs, but they're a different pipeline's artifacts; these products name exact build IDs (`ctd_February_2026_b588520f_2025sep1_4.3.6`), so repointing there would misrepresent provenance.

**4. Retired OBO PURLs (17).** Investigated; no live source found. `ogg`'s PURL config still resolves, but to a Bitbucket URL that 404s, and there's no GitHub replacement. Six of these pages have the dead PURL as their **only** product, so removal isn't available either without violating the keep-one-product rule.

## Four candidates dropped mid-batch

`snomedbrowser.org` (405), `drugs.ncats.io`, `microbialphenotypes.org` and `pathbank.org/pathwhiz` all returned 200 during the sweep and **failed on re-verification** immediately before editing. Not repointed. This is a reminder that a single probe isn't proof — the sweep's "healthy" bucket has its own false-positive rate.

## Validation

All 20 touched resource pages pass `uv run make validate-file`. Blocked resources untouched. `prettify-file` not run, per #707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcjCL63qkoxU5PVt33Szwu
