### PR TITLE
Stop treating HEAD as authoritative for link failure

### DIFF
--- a/tests/test_quality_dashboard.py
+++ b/tests/test_quality_dashboard.py
@@ -445,3 +445,122 @@ def test_check_http_url_still_flags_dead_sparql_endpoint(quality_dashboard_modul
     _install_fake_requests(monkeypatch, mod, lambda method, url: _FakeResponse(404))
     result = mod.check_http_url("https://gone.example.org/sparql", timeout=5.0)
     assert result["ok"] is False
+
+
+class _FlakyResponder:
+    """Responder that fails a set number of times before succeeding."""
+
+    def __init__(self, mod, failures, exc_factory, then_code=200):
+        self.mod = mod
+        self.remaining = failures
+        self.exc_factory = exc_factory
+        self.then_code = then_code
+        self.calls = []
+
+    def __call__(self, method, url):
+        self.calls.append(method)
+        if self.remaining > 0:
+            self.remaining -= 1
+            raise self.exc_factory()
+        return _FakeResponse(self.then_code)
+
+
+def test_check_http_url_falls_back_to_get_on_head_404(quality_dashboard_module, monkeypatch):
+    """A host answering HEAD 404 but GET 200 is reachable, not broken.
+
+    Real cases: dsstox's clowder.edap-cluster.com URL and ssurgo's box.com URL.
+    """
+    mod = quality_dashboard_module
+    calls = []
+
+    def responder(method, url):
+        calls.append(method)
+        return _FakeResponse(404 if method == "head" else 200)
+
+    _install_fake_requests(monkeypatch, mod, responder)
+    result = mod.check_http_url("https://example.org/file.zip", timeout=5.0)
+    assert result["ok"] is True
+    assert result["status_code"] == 200
+    assert calls == ["head", "get"], "GET must be attempted after a HEAD 404"
+
+
+def test_check_http_url_falls_back_to_get_when_head_connection_fails(
+    quality_dashboard_module, monkeypatch
+):
+    """Some hosts drop HEAD connections but serve GET fine (noaa-ncei.ibtracs)."""
+    mod = quality_dashboard_module
+
+    def responder(method, url):
+        if method == "head":
+            raise mod.requests.exceptions.ConnectionError("RemoteDisconnected")
+        return _FakeResponse(200)
+
+    _install_fake_requests(monkeypatch, mod, responder)
+    result = mod.check_http_url("https://example.org/page", timeout=5.0)
+    assert result["ok"] is True
+    assert result["status_code"] == 200
+
+
+def test_check_http_url_retries_once_on_connection_error(quality_dashboard_module, monkeypatch):
+    """A single transient reset must not write a durable broken-link warning."""
+    mod = quality_dashboard_module
+    responder = _FlakyResponder(
+        mod, failures=1, exc_factory=lambda: mod.requests.exceptions.ConnectionError("reset")
+    )
+    _install_fake_requests(monkeypatch, mod, responder)
+    monkeypatch.setattr(mod, "_RETRY_DELAY_SECONDS", 0)
+    result = mod.check_http_url("https://example.org/page", timeout=5.0)
+    assert result["ok"] is True
+    assert responder.calls == ["head", "head"], "HEAD should be retried once, then succeed"
+
+
+def test_check_http_url_does_not_retry_timeouts(quality_dashboard_module, monkeypatch):
+    """Timeouts dominate genuinely dead hosts; retrying them only doubles runtime."""
+    mod = quality_dashboard_module
+    calls = []
+
+    def responder(method, url):
+        calls.append(method)
+        raise mod.requests.exceptions.Timeout("timed out")
+
+    _install_fake_requests(monkeypatch, mod, responder)
+    monkeypatch.setattr(mod, "_RETRY_DELAY_SECONDS", 0)
+    result = mod.check_http_url("https://dead.example.org/page", timeout=5.0)
+    assert result["ok"] is False
+    assert calls == ["head", "get"], "one HEAD and one GET, no timeout retries"
+
+
+def test_check_http_url_still_reports_genuinely_dead_urls(quality_dashboard_module, monkeypatch):
+    """The GET fallback must not turn real 404s into false positives."""
+    mod = quality_dashboard_module
+    _install_fake_requests(monkeypatch, mod, lambda method, url: _FakeResponse(404))
+    result = mod.check_http_url("https://example.org/gone.zip", timeout=5.0)
+    assert result["ok"] is False
+    assert result["status_code"] == 404
+    assert "GET returned HTTP 404" in result["error"]
+
+
+def test_check_http_url_reports_both_failures_when_neither_verb_responds(
+    quality_dashboard_module, monkeypatch
+):
+    mod = quality_dashboard_module
+
+    def responder(method, url):
+        raise mod.requests.exceptions.Timeout("timed out")
+
+    _install_fake_requests(monkeypatch, mod, responder)
+    monkeypatch.setattr(mod, "_RETRY_DELAY_SECONDS", 0)
+    result = mod.check_http_url("https://dead.example.org/page", timeout=5.0)
+    assert result["ok"] is False
+    assert result["status_code"] is None
+    assert "HEAD request failed" in result["error"]
+    assert "GET request failed" in result["error"]
+
+
+def test_check_http_url_keeps_access_restricted_semantics(quality_dashboard_module, monkeypatch):
+    """403 on both verbs stays reachable-but-restricted, not broken."""
+    mod = quality_dashboard_module
+    _install_fake_requests(monkeypatch, mod, lambda method, url: _FakeResponse(403))
+    result = mod.check_http_url("https://example.org/page", timeout=5.0)
+    assert result["ok"] is True
+    assert result.get("access_restricted") is True

--- a/tests/test_retrieve_file_sizes_parallel.py
+++ b/tests/test_retrieve_file_sizes_parallel.py
@@ -74,3 +74,91 @@ def test_update_product_file_sizes_deduplicates_shared_urls(
     assert updated_data["resources"][1]["products"][0]["product_file_size"] == 123
     assert updated_products["res1"][0]["product_file_size"] == 123
     assert updated_products["res2"][0]["product_file_size"] == 123
+
+
+class _HeaderOnlyResponse:
+    """Minimal response stub: a successful reply with controllable headers."""
+
+    def __init__(self, headers, status_code=200):
+        self.headers = headers
+        self.status_code = status_code
+        self.url = "https://example.org/file.bin"
+
+    def close(self):
+        pass
+
+
+def _fake_head(module, monkeypatch, response):
+    class _FakeRequests:
+        exceptions = module.requests.exceptions
+
+        @staticmethod
+        def head(url, **kwargs):
+            return response
+
+        @staticmethod
+        def get(url, **kwargs):
+            return response
+
+    monkeypatch.setattr(module, "requests", _FakeRequests)
+
+
+def test_missing_content_length_is_not_a_retrieval_error(
+    retrieve_file_sizes_parallel_module, monkeypatch
+):
+    """A reachable URL with no Content-Length must not produce a warning.
+
+    Chunked or dynamically generated responses omit the header. Recording that
+    as an error is what put "File was not able to be retrieved" warnings on
+    products whose URLs were fine (e.g. edrr-invasive-catalog.dataset).
+    """
+    mod = retrieve_file_sizes_parallel_module
+    _fake_head(mod, monkeypatch, _HeaderOnlyResponse({"Content-Type": "application/octet-stream"}))
+
+    size, error, info = mod.get_file_size_from_header("https://example.org/file.bin")
+
+    assert size is None
+    assert error is None, "reachable-but-unmeasurable must not be reported as an error"
+    assert info.get("error") is None
+    assert info.get("skip_reason") == "no_content_length"
+
+
+def test_unparseable_content_length_is_not_a_retrieval_error(
+    retrieve_file_sizes_parallel_module, monkeypatch
+):
+    mod = retrieve_file_sizes_parallel_module
+    _fake_head(
+        mod,
+        monkeypatch,
+        _HeaderOnlyResponse({"Content-Type": "application/octet-stream", "Content-Length": "many"}),
+    )
+
+    size, error, info = mod.get_file_size_from_header("https://example.org/file.bin")
+
+    assert size is None
+    assert error is None
+    assert info.get("skip_reason") == "no_content_length"
+
+
+def test_valid_content_length_still_returns_size(retrieve_file_sizes_parallel_module, monkeypatch):
+    mod = retrieve_file_sizes_parallel_module
+    _fake_head(
+        mod,
+        monkeypatch,
+        _HeaderOnlyResponse({"Content-Type": "application/octet-stream", "Content-Length": "4096"}),
+    )
+
+    size, error, info = mod.get_file_size_from_header("https://example.org/file.bin")
+
+    assert size == 4096
+    assert error is None
+
+
+def test_no_content_length_skip_reason_is_honoured_by_cache(
+    retrieve_file_sizes_parallel_module,
+):
+    """The new skip reason must suppress re-checking on later runs."""
+    mod = retrieve_file_sizes_parallel_module
+    cache = {"https://example.org/file.bin": {"skip_reason": "no_content_length"}}
+    should_skip, _ = mod.cache_should_skip("https://example.org/file.bin", cache)
+    assert should_skip is True

--- a/util/generate-quality-dashboard.py
+++ b/util/generate-quality-dashboard.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
@@ -477,6 +478,20 @@ def check_ftp_url(url: str, timeout: float) -> Dict[str, Any]:
             pass
 
 
+# A single transient connection reset would otherwise write a durable
+# "File was not able to be retrieved" warning onto a product page, so
+# connection-level failures get one retry. Timeouts are not retried: they are
+# the dominant failure mode for genuinely dead hosts and retrying them doubles
+# the runtime of the slowest part of the check for no benefit.
+_CONNECTION_RETRIES = 1
+_RETRY_DELAY_SECONDS = 2.0
+
+# Statuses that mean "the server is up but will not serve this to an automated
+# client": auth walls, throttling, bot walls, content-negotiation refusals.
+# (Trade-off: a host that returns 403 for genuinely-missing objects -- e.g.
+# some CloudFront/S3 setups -- will not be flagged.)
+_ACCESS_RESTRICTED_CODES = frozenset({401, 403, 405, 406, 412, 429})
+
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
@@ -571,75 +586,75 @@ def check_http_url(url: str, timeout: float) -> Dict[str, Any]:
             warnings.simplefilter("ignore", InsecureRequestWarning)
             return requests.get(url, timeout=timeout, allow_redirects=True, headers=headers, verify=verify)
 
-    tls_fallback_used = False
+    def _perform(request_fn, verify: bool) -> Tuple[Optional[int], Optional[str], bool]:
+        """Issue one request, returning ``(status_code, error, tls_fallback_used)``.
 
-    try:
-        head_resp = _head_request(verify=True)
-        head_code = head_resp.status_code
-        head_resp.close()
-    except requests.exceptions.SSLError:
-        tls_fallback_used = True
-        try:
-            head_resp = _head_request(verify=False)
-            head_code = head_resp.status_code
-            head_resp.close()
-        except requests.RequestException as error:
-            return {
-                "ok": False,
-                "status_code": None,
-                "error": f"HEAD request failed after TLS fallback: {error}",
-            }
-    except requests.RequestException as error:
-        return {"ok": False, "status_code": None, "error": f"HEAD request failed: {error}"}
+        Falls back to an unverified connection once on a TLS error, and retries
+        once on a connection-level failure. ``status_code`` is ``None`` only
+        when no response was obtained at all.
+        """
+        tls_fallback = False
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                resp = request_fn(verify)
+                code = resp.status_code
+                resp.close()
+                return code, None, tls_fallback
+            except requests.exceptions.SSLError as error:
+                if verify:
+                    verify = False
+                    tls_fallback = True
+                    continue
+                return None, f"TLS verification failed: {error}", tls_fallback
+            except requests.exceptions.Timeout as error:
+                return None, str(error), tls_fallback
+            except requests.RequestException as error:
+                if attempts <= _CONNECTION_RETRIES:
+                    time.sleep(_RETRY_DELAY_SECONDS)
+                    continue
+                return None, str(error), tls_fallback
 
-    if 200 <= head_code < 400:
-        result = {"ok": True, "status_code": head_code, "error": None}
-        if tls_fallback_used:
+    def _reachable(code: int, tls_fallback: bool) -> Dict[str, Any]:
+        result: Dict[str, Any] = {"ok": True, "status_code": code, "error": None}
+        if tls_fallback:
             result["tls_verification_failed"] = True
+        if code in _ACCESS_RESTRICTED_CODES:
+            result["access_restricted"] = True
         return result
 
-    # Some endpoints disallow HEAD, throttle, block automated/bot clients, or
-    # reject the request's content negotiation with a status (401/403/405/406/
-    # 412/429) even though the resource is publicly reachable in a browser.
-    # Treat these as reachable rather than broken: the server is up and
-    # responding, we simply cannot fully verify the resource via an automated
-    # request. 406 (Not Acceptable) and 412 (Precondition Failed, used by some
-    # JavaScript anti-bot walls) are included here for that reason. (Trade-off:
-    # a host that returns 403 for genuinely-missing objects -- e.g. some
-    # CloudFront/S3 setups -- will not be flagged here.)
-    fallback_codes = {401, 403, 405, 406, 412, 429}
-    if head_code in fallback_codes:
-        try:
-            get_resp = _get_request(verify=not tls_fallback_used)
-            get_code = get_resp.status_code
-            get_resp.close()
-            if 200 <= get_code < 400:
-                result = {"ok": True, "status_code": get_code, "error": None}
-                if tls_fallback_used:
-                    result["tls_verification_failed"] = True
-                return result
-            if get_code in fallback_codes:
-                result = {
-                    "ok": True,
-                    "status_code": get_code,
-                    "error": None,
-                    "access_restricted": True,
-                }
-                if tls_fallback_used:
-                    result["tls_verification_failed"] = True
-                return result
-            return {
-                "ok": False,
-                "status_code": get_code,
-                "error": f"GET returned HTTP {get_code}",
-            }
-        except requests.RequestException as error:
-            return {"ok": False, "status_code": head_code, "error": f"GET request failed: {error}"}
+    head_code, head_error, tls_fallback_used = _perform(_head_request, True)
 
+    if head_code is not None and 200 <= head_code < 400:
+        return _reachable(head_code, tls_fallback_used)
+
+    # HEAD is never authoritative for *failure*. Hosts answer HEAD with 404 or
+    # 405, or drop the connection outright, while serving the same URL fine
+    # over GET, so always confirm with GET before reporting a broken link.
+    get_code, get_error, get_tls_fallback = _perform(_get_request, not tls_fallback_used)
+    tls_fallback_used = tls_fallback_used or get_tls_fallback
+
+    if get_code is not None:
+        if 200 <= get_code < 400 or get_code in _ACCESS_RESTRICTED_CODES:
+            return _reachable(get_code, tls_fallback_used)
+        return {
+            "ok": False,
+            "status_code": get_code,
+            "error": f"GET returned HTTP {get_code}",
+        }
+
+    # No response from either verb.
+    if head_code is not None:
+        return {
+            "ok": False,
+            "status_code": head_code,
+            "error": f"HEAD returned HTTP {head_code}; GET request failed: {get_error}",
+        }
     return {
         "ok": False,
-        "status_code": head_code,
-        "error": f"HEAD returned HTTP {head_code}",
+        "status_code": None,
+        "error": f"HEAD request failed: {head_error}; GET request failed: {get_error}",
     }
 
 

--- a/util/retrieve-file-sizes-parallel.py
+++ b/util/retrieve-file-sizes-parallel.py
@@ -99,7 +99,8 @@ def cache_should_skip(url: str, cache: Dict[str, Any], ignore_cache: bool = Fals
     if not entry:
         return False, None
     # Skip if prior run recorded skip_reason we want to honor
-    if entry.get('skip_reason') in {'html_page', 'no_content_type', 'directory', 'tls_cert_accessible', 'access_restricted'}:
+    if entry.get('skip_reason') in {'html_page', 'no_content_type', 'directory', 'tls_cert_accessible',
+                                   'access_restricted', 'no_content_length'}:
         return True, entry
     return False, entry
 
@@ -311,14 +312,18 @@ def get_file_size_from_header(url: str) -> Tuple[Optional[int], Optional[str], D
         content_length = response.headers.get('Content-Length')
 
         if content_length is None:
+            # The request succeeded; the server just did not declare a size
+            # (chunked transfer encoding, or a dynamically generated response).
+            # The URL is reachable, so this must not raise a "file was not able
+            # to be retrieved" warning -- that reads as a broken link and is
+            # what put stale warnings on products whose URLs were fine.
             if tls_fallback_used:
-                safe_print("  ⚠️  TLS verification failed; endpoint is reachable but no Content-Length header was found")
+                safe_print("  ⏭️  TLS verification failed; endpoint is reachable but no Content-Length header was found")
                 info['skip_reason'] = 'tls_cert_accessible'
-                return None, None, info
-            error_msg = "No Content-Length header found"
-            safe_print(f"  ⚠️  {error_msg}")
-            info['error'] = error_msg
-            return None, error_msg, info
+            else:
+                safe_print("  ⏭️  Reachable, but no Content-Length header; size unknown")
+                info['skip_reason'] = 'no_content_length'
+            return None, None, info
 
         try:
             file_size = int(content_length)
@@ -326,14 +331,14 @@ def get_file_size_from_header(url: str) -> Tuple[Optional[int], Optional[str], D
             info['content_length'] = file_size
             return file_size, None, info
         except ValueError:
+            # Reachable but unmeasurable, same as a missing header above.
             if tls_fallback_used:
-                safe_print("  ⚠️  TLS verification failed; endpoint is reachable but Content-Length is not parseable")
+                safe_print("  ⏭️  TLS verification failed; endpoint is reachable but Content-Length is not parseable")
                 info['skip_reason'] = 'tls_cert_accessible'
-                return None, None, info
-            error_msg = f"Invalid Content-Length value: {content_length}"
-            safe_print(f"  ⚠️  {error_msg}")
-            info['error'] = error_msg
-            return None, error_msg, info
+            else:
+                safe_print(f"  ⏭️  Reachable, but Content-Length is not parseable: {content_length}")
+                info['skip_reason'] = 'no_content_length'
+            return None, None, info
 
     except requests.exceptions.Timeout:
         error_msg = "Timeout connecting to URL"

--- a/util/retrieve-file-sizes.py
+++ b/util/retrieve-file-sizes.py
@@ -80,7 +80,8 @@ def cache_should_skip(url: str, cache: Dict[str, Any], ignore_cache: bool = Fals
     if not entry:
         return False, None
     # Skip if prior run recorded skip_reason we want to honor
-    if entry.get('skip_reason') in {'html_page', 'no_content_type', 'directory', 'tls_cert_accessible', 'access_restricted'}:
+    if entry.get('skip_reason') in {'html_page', 'no_content_type', 'directory', 'tls_cert_accessible',
+                                   'access_restricted', 'no_content_length'}:
         return True, entry
     return False, entry
 
@@ -283,14 +284,17 @@ def get_file_size_from_header(url: str) -> Tuple[Optional[int], Optional[str], D
         content_length = response.headers.get('Content-Length')
 
         if content_length is None:
+            # The request succeeded; the server just did not declare a size
+            # (chunked transfer encoding, or a dynamically generated response).
+            # The URL is reachable, so this must not raise a "file was not able
+            # to be retrieved" warning -- that reads as a broken link.
             if tls_fallback_used:
-                print("  ⚠️  TLS verification failed; endpoint is reachable but no Content-Length header was found")
+                print("  ⏭️  TLS verification failed; endpoint is reachable but no Content-Length header was found")
                 info['skip_reason'] = 'tls_cert_accessible'
-                return None, None, info
-            error_msg = "No Content-Length header found"
-            print(f"  ⚠️  {error_msg}")
-            info['error'] = error_msg
-            return None, error_msg, info
+            else:
+                print("  ⏭️  Reachable, but no Content-Length header; size unknown")
+                info['skip_reason'] = 'no_content_length'
+            return None, None, info
 
         try:
             file_size = int(content_length)
@@ -298,14 +302,14 @@ def get_file_size_from_header(url: str) -> Tuple[Optional[int], Optional[str], D
             info['content_length'] = file_size
             return file_size, None, info
         except ValueError:
+            # Reachable but unmeasurable, same as a missing header above.
             if tls_fallback_used:
-                print("  ⚠️  TLS verification failed; endpoint is reachable but Content-Length is not parseable")
+                print("  ⏭️  TLS verification failed; endpoint is reachable but Content-Length is not parseable")
                 info['skip_reason'] = 'tls_cert_accessible'
-                return None, None, info
-            error_msg = f"Invalid Content-Length value: {content_length}"
-            print(f"  ⚠️  {error_msg}")
-            info['error'] = error_msg
-            return None, error_msg, info
+            else:
+                print(f"  ⏭️  Reachable, but Content-Length is not parseable: {content_length}")
+                info['skip_reason'] = 'no_content_length'
+            return None, None, info
 
     except requests.exceptions.Timeout:
         error_msg = "Timeout connecting to URL"


### PR DESCRIPTION
Fixes #711.

## Measured impact

I re-ran the patched checker over the same 326 URLs the Aug-31 dashboard calls broken:

| | |
|---|---|
| URLs flagged | 326 |
| **Now correctly reachable** | **73 (22%)** |
| Still broken | 253 |
| **Resources fully cleared** | **49** |
| Product reference sites cleared | 114 |

That 22% matches the false-positive rate measured independently during the link-backlog triage. Every genuinely dead URL — `apps.okn.us`, `kgx-storage.rtx.ai`, the retired OBO PURLs — stays flagged.

## `check_http_url`

The checker was already careful: browser User-Agent, real SPARQL `?query=` probing, GET fallback on `{401, 403, 405, 406, 412, 429}`. But the fallback was keyed to a **specific set of status codes**, so two common cases slipped through:

- **HEAD 404 / GET 200.** `dsstox`'s clowder URL and `ssurgo`'s box.com URL both behave this way.
- **HEAD connection dropped / GET 200.** This is the `RemoteDisconnected` error appearing in product `warnings:` blocks, e.g. `noaa-ncei.ibtracs`.

Rather than adding `404` to the fallback set and leaving the second case unhandled, **HEAD is no longer authoritative for failure at all.** It remains the fast path for success — a 2xx/3xx HEAD still returns immediately, so the common case costs exactly what it did before — but any non-success outcome is confirmed with GET before the URL is reported broken.

Connection-level errors get **one** retry, because a single transient reset otherwise writes a durable "File was not able to be retrieved" warning onto a product page. `purl.obolibrary.org/obo/pr.obo` did exactly that during triage: it failed once at connection level and returned HEAD 200 minutes later.

**Timeouts are deliberately not retried.** They are the dominant failure mode for genuinely dead hosts, and retrying them would double the runtime of the slowest part of the run for no benefit.

## `Content-Length` handling

`retrieve-file-sizes.py` and its parallel twin recorded a missing or unparseable `Content-Length` as a *retrieval error*. A chunked or dynamically generated response is reachable, just unmeasurable, and reporting it as "File was not able to be retrieved" reads as a broken link — this is what put a stale warning on `edrr-invasive-catalog.dataset`.

Both scripts now record a `no_content_length` skip reason instead, alongside the existing `html_page` / `no_content_type` skips, and honour it on later runs. Fixed in both scripts because the Makefile has targets for each and they had drifted identically.

## Tests

11 new tests, covering each defect **and the inverse** — the risk with a change like this is turning real breakage into silent false negatives:

- GET fallback on HEAD 404, and on HEAD connection error
- one retry on connection error; **no** retry on timeout
- a URL 404ing on **both** verbs is still reported broken
- `access_restricted` semantics for 401/403/etc unchanged
- missing / unparseable / valid `Content-Length` paths
- the new skip reason suppresses re-checking

Full suite passes (150 tests, 6 subtests). `black` and `isort` clean.

## Known gap, not addressed here

Two endpoints in the backlog are alive but only answer a POST or a query-bearing GET: a GraphQL endpoint, and a SPARQL endpoint whose path doesn't end in `/sparql` so `is_sparql_endpoint()` misses it. Both are single instances today, so I left them rather than widening the heuristic speculatively. Worth revisiting if the pattern grows.

## Follow-on effect worth noting

This also stops the build re-adding warnings that curation has just cleared. #709 needed a merge-conflict resolution for exactly that reason — the build re-ran and re-added the six warnings that PR had removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcjCL63qkoxU5PVt33Szwu
