### PR TITLE
Model the PharmGKB/CPIC consolidation into ClinPGx

### DIFF
--- a/org/clinpgx/clinpgx.md
+++ b/org/clinpgx/clinpgx.md
@@ -1,0 +1,16 @@
+---
+category: Organization
+contact_details:
+- contact_type: email
+  value: feedback@clinpgx.org
+creation_date: '2026-09-02T00:00:00Z'
+description: ClinPGx is the clinical pharmacogenomics resource that succeeded PharmGKB
+  on 2025-07-30. It unifies PharmGKB, CPIC and PharmCAT under one site.
+id: clinpgx
+label: ClinPGx
+last_modified_date: '2026-09-02T00:00:00Z'
+layout: organization_detail
+---
+
+
+ClinPGx is an organization associated with resources in the KG-Registry.

--- a/resource/clinpgx/clinpgx.api.md
+++ b/resource/clinpgx/clinpgx.api.md
@@ -1,0 +1,14 @@
+---
+category: ProgrammingInterface
+connection_url: https://api.clinpgx.org/
+description: REST API for ClinPGx data and bulk file downloads, keeping the path structure
+  of the former PharmGKB API (for example /v1/download/file/data/)
+id: clinpgx.api
+is_public: true
+name: ClinPGx API
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: clinpgx
+product_url: https://api.clinpgx.org/swagger/
+layout: product_detail
+---

--- a/resource/clinpgx/clinpgx.downloads.md
+++ b/resource/clinpgx/clinpgx.downloads.md
@@ -1,0 +1,15 @@
+---
+category: DocumentationProduct
+description: Downloads page listing the bulk data files (formerly the PharmGKB downloads),
+  with data usage policy and file descriptions
+id: clinpgx.downloads
+is_public: true
+name: ClinPGx Downloads
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: clinpgx
+- relation_type: prov:wasDerivedFrom
+  source: pharmgkb
+product_url: https://www.clinpgx.org/downloads
+layout: product_detail
+---

--- a/resource/clinpgx/clinpgx.md
+++ b/resource/clinpgx/clinpgx.md
@@ -1,0 +1,119 @@
+---
+activity_status: active
+category: Resource
+contacts:
+- category: Organization
+  contact_details:
+  - contact_type: email
+    value: feedback@clinpgx.org
+  label: ClinPGx
+creation_date: '2026-09-02T00:00:00Z'
+description: ClinPGx is a clinical pharmacogenomics knowledge resource that unifies
+  the PharmGKB knowledge base, the CPIC prescribing guidelines and the PharmCAT
+  genotype-to-phenotype tool under one site. It launched on 2025-07-30 as the
+  successor to PharmGKB; pharmgkb.org and cpicpgx.org URLs redirect to their
+  clinpgx.org equivalents and the PharmGKB bulk downloads are served from
+  api.clinpgx.org. Content includes curated clinical and variant annotations,
+  drug labels, pathways, gene-drug pairs drawn from CPIC, DPWG and FDA sources,
+  and allele definition and frequency tables.
+domains:
+- biomedical
+- chemistry and biochemistry
+- clinical
+- pharmacology
+- genomics
+- precision medicine
+homepage_url: https://www.clinpgx.org/
+id: clinpgx
+last_modified_date: '2026-09-02T00:00:00Z'
+layout: resource_detail
+license:
+  id: https://creativecommons.org/licenses/by-sa/4.0/
+  label: CC-BY-SA-4.0
+name: ClinPGx
+products:
+- category: GraphicalInterface
+  description: ClinPGx web portal for browsing genes, variants, drugs, clinical annotations,
+    drug labels, pathways and CPIC guidelines, integrating PharmGKB and CPIC content
+  id: clinpgx.portal
+  is_public: true
+  name: ClinPGx Portal
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: clinpgx
+  - relation_type: prov:wasDerivedFrom
+    source: pharmgkb
+  - relation_type: prov:wasDerivedFrom
+    source: cpic
+  product_url: https://www.clinpgx.org/
+- category: DocumentationProduct
+  description: Downloads page listing the bulk data files (formerly the PharmGKB downloads),
+    with data usage policy and file descriptions
+  id: clinpgx.downloads
+  is_public: true
+  name: ClinPGx Downloads
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: clinpgx
+  - relation_type: prov:wasDerivedFrom
+    source: pharmgkb
+  product_url: https://www.clinpgx.org/downloads
+- category: ProgrammingInterface
+  connection_url: https://api.clinpgx.org/
+  description: REST API for ClinPGx data and bulk file downloads, keeping the path
+    structure of the former PharmGKB API (for example /v1/download/file/data/)
+  id: clinpgx.api
+  is_public: true
+  name: ClinPGx API
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: clinpgx
+  product_url: https://api.clinpgx.org/swagger/
+taxon:
+- NCBITaxon:9606
+---
+
+ClinPGx is the clinical pharmacogenomics resource that succeeded PharmGKB. It
+brings PharmGKB, CPIC and PharmCAT together on one site.
+
+## Transition from PharmGKB and CPIC
+
+ClinPGx launched on 2025-07-30. From that date every pharmgkb.org link redirects
+to its ClinPGx equivalent, and the standalone CPIC site (cpicpgx.org) redirects
+into the CPIC section of ClinPGx. The bulk download files that PharmGKB served
+from `api.pharmgkb.org` are served from `api.clinpgx.org` on the same paths.
+The old API host no longer resolves.
+
+In this registry the PharmGKB and CPIC pages are kept as separate resources.
+Many downstream resources cite `pharmgkb` as a provenance source and that
+identifier stays stable. The [PharmGKB](pharmgkb) page is marked inactive and
+points here with `use_instead`. The [CPIC](cpic) page remains active because the
+CPIC guidelines keep their own name and section within ClinPGx.
+
+## Content
+
+- Clinical annotations, variant annotations and drug label annotations curated
+  from the literature and regulatory sources
+- Gene-drug pairs annotated from CPIC, DPWG and FDA information
+- Pathways, haplotype and allele definition tables, and allele frequency data
+- CPIC prescribing guidelines and supporting tables
+- PharmCAT, a tool for calling pharmacogenomic genotypes and phenotypes from
+  sequence data
+
+## Access
+
+The portal is at https://www.clinpgx.org/. Bulk files are listed on the
+downloads page and are fetched through the API host, for example
+`https://api.clinpgx.org/v1/download/file/data/clinicalAnnotations.zip`. The
+individual download files are listed as products on the [PharmGKB](pharmgkb)
+page.
+
+## Licensing
+
+The download archives carry a `LICENSE.txt` stating the Creative Commons
+Attribution-ShareAlike 4.0 International License, checked on 2026-09-02 against
+`clinicalAnnotations_LOE1-2.zip`.
+
+## Contact
+
+Feedback address: feedback@clinpgx.org.

--- a/resource/clinpgx/clinpgx.portal.md
+++ b/resource/clinpgx/clinpgx.portal.md
@@ -1,0 +1,17 @@
+---
+category: GraphicalInterface
+description: ClinPGx web portal for browsing genes, variants, drugs, clinical annotations,
+  drug labels, pathways and CPIC guidelines, integrating PharmGKB and CPIC content
+id: clinpgx.portal
+is_public: true
+name: ClinPGx Portal
+original_source:
+- relation_type: prov:hadPrimarySource
+  source: clinpgx
+- relation_type: prov:wasDerivedFrom
+  source: pharmgkb
+- relation_type: prov:wasDerivedFrom
+  source: cpic
+product_url: https://www.clinpgx.org/
+layout: product_detail
+---

--- a/resource/cpic/cpic.alleles.md
+++ b/resource/cpic/cpic.alleles.md
@@ -9,6 +9,6 @@ name: CPIC Allele & Diplotype Function Tables
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cpic
-product_url: https://cpicpgx.org/alleles/
+product_url: https://www.clinpgx.org/page/cpicResources#guideline-alleles
 layout: product_detail
 ---

--- a/resource/cpic/cpic.api.md
+++ b/resource/cpic/cpic.api.md
@@ -10,6 +10,6 @@ name: CPIC Database & API
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cpic
-product_url: https://cpicpgx.org/api-and-database/
+product_url: https://www.clinpgx.org/page/cpicResources#database-and-api
 layout: product_detail
 ---

--- a/resource/cpic/cpic.cyp2d6_translation.md
+++ b/resource/cpic/cpic.cyp2d6_translation.md
@@ -7,6 +7,6 @@ name: CPIC CYP2D6 Genotype to Phenotype Project
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cpic
-product_url: https://cpicpgx.org/resources/cyp2d6-genotype-to-phenotype-standardization-project/
+product_url: https://www.clinpgx.org/page/cpicCyp2d6Standardization
 layout: product_detail
 ---

--- a/resource/cpic/cpic.genes_drugs.md
+++ b/resource/cpic/cpic.genes_drugs.md
@@ -9,6 +9,6 @@ name: CPIC Genes-Drugs Tables
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cpic
-product_url: https://cpicpgx.org/genes-drugs/
+product_url: https://www.clinpgx.org/cpic/pairs
 layout: product_detail
 ---

--- a/resource/cpic/cpic.guidelines.md
+++ b/resource/cpic/cpic.guidelines.md
@@ -9,6 +9,6 @@ name: CPIC Clinical Practice Guidelines
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cpic
-product_url: https://cpicpgx.org/guidelines/
+product_url: https://www.clinpgx.org/cpic/guidelines
 layout: product_detail
 ---

--- a/resource/cpic/cpic.md
+++ b/resource/cpic/cpic.md
@@ -5,31 +5,31 @@ contacts:
 - category: Organization
   contact_details:
   - contact_type: url
-    value: https://cpicpgx.org/contact/
+    value: https://www.clinpgx.org/cpic#contact
   - contact_type: email
     value: contact@cpicpgx.org
   label: Clinical Pharmacogenetics Implementation Consortium (CPIC)
 creation_date: '2025-09-03T00:00:00Z'
-description: "The Clinical Pharmacogenetics Implementation Consortium (CPIC) creates,\
-  \ curates, and disseminates freely available, peer-reviewed, evidence-based, and\
-  \ updatable clinical practice guidelines that translate patient pharmacogenetic\
-  \ test results into actionable prescribing decisions. CPIC also publishes structured\
-  \ gene\u2013drug annotations, allele function data, standardized terminology resources,\
-  \ and implementation tools (database, API, SOPs, educational materials) to accelerate\
-  \ pharmacogenomics in clinical care."
+description: The Clinical Pharmacogenetics Implementation Consortium (CPIC) creates,
+  curates, and disseminates freely available, peer-reviewed, evidence-based, and updatable
+  clinical practice guidelines that translate patient pharmacogenetic test results
+  into actionable prescribing decisions. CPIC also publishes structured gene-drug
+  annotations, allele function data, standardized terminology resources, and implementation
+  tools (database, API, SOPs, educational materials). Since 2025-07-30 CPIC content
+  is hosted within ClinPGx (registry id clinpgx) and cpicpgx.org pages redirect there;
+  the CPIC name and guidelines continue under ClinPGx.
 domains:
 - biomedical
 - clinical
 - drug discovery
-homepage_url: https://cpicpgx.org/
+homepage_url: https://www.clinpgx.org/cpic
 id: cpic
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-02T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/publicdomain/zero/1.0/
   label: CC0 1.0
 name: CPIC
-repository: https://github.com/cpicpgx/cpic-data
 products:
 - category: GraphicalInterface
   description: Main CPIC website portal providing access to guidelines, genes-drugs
@@ -40,7 +40,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cpic
-  product_url: https://cpicpgx.org/
+  product_url: https://www.clinpgx.org/cpic
 - category: DocumentationProduct
   description: Peer-reviewed, evidence-based, updatable pharmacogenetic clinical practice
     guidelines translating genotype into prescribing recommendations
@@ -51,7 +51,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cpic
-  product_url: https://cpicpgx.org/guidelines/
+  product_url: https://www.clinpgx.org/cpic/guidelines
 - category: Product
   description: "Curated gene\u2013drug pair tables linking pharmacogenes with affected\
     \ medications and guideline recommendations"
@@ -62,7 +62,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cpic
-  product_url: https://cpicpgx.org/genes-drugs/
+  product_url: https://www.clinpgx.org/cpic/pairs
 - category: Product
   description: Allele function and diplotype-to-phenotype tables standardized for
     clinical pharmacogenetic test result interpretation
@@ -73,11 +73,11 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cpic
-  product_url: https://cpicpgx.org/alleles/
+  product_url: https://www.clinpgx.org/page/cpicResources#guideline-alleles
 - category: ProgrammingInterface
+  connection_url: https://api.cpicpgx.org/
   description: "Structured data (database and API) for CPIC guideline-derived gene\u2013\
     drug relationships, allele function, and standardized terms"
-  connection_url: https://api.cpicpgx.org/
   format: json
   id: cpic.api
   is_public: true
@@ -85,7 +85,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cpic
-  product_url: https://cpicpgx.org/api-and-database/
+  product_url: https://www.clinpgx.org/page/cpicResources#database-and-api
 - category: DocumentationProduct
   description: Standard operating procedure PDF for assigning allele function and
     translating diplotypes to phenotypes
@@ -128,7 +128,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cpic
-  product_url: https://cpicpgx.org/resources/term-standardization
+  product_url: https://www.clinpgx.org/page/cpicTermStandardization
 - category: DocumentationProduct
   description: CYP2D6 genotype to phenotype translation project resources
   format: http
@@ -137,7 +137,7 @@ products:
   original_source:
   - relation_type: prov:hadPrimarySource
     source: cpic
-  product_url: https://cpicpgx.org/resources/cyp2d6-genotype-to-phenotype-standardization-project/
+  product_url: https://www.clinpgx.org/page/cpicCyp2d6Standardization
 - category: GraphProduct
   description: Integrated graph knowledge base combining Mendelian randomization causal
     estimates, pathway, QTL, drug, literature-derived, and ontology-backed relationships
@@ -181,10 +181,34 @@ products:
   - relation_type: prov:hadPrimarySource
     source: mrbase
   product_url: https://docs.epigraphdb.org/graph-database/
+- category: GraphicalInterface
+  description: ClinPGx web portal for browsing genes, variants, drugs, clinical annotations,
+    drug labels, pathways and CPIC guidelines, integrating PharmGKB and CPIC content
+  id: clinpgx.portal
+  is_public: true
+  name: ClinPGx Portal
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: clinpgx
+  - relation_type: prov:wasDerivedFrom
+    source: pharmgkb
+  - relation_type: prov:wasDerivedFrom
+    source: cpic
+  product_url: https://www.clinpgx.org/
+repository: https://github.com/cpicpgx/cpic-data
 taxon:
 - NCBITaxon:9606
 ---
 ## Overview
+
+Since 2025-07-30 CPIC is delivered through [ClinPGx](clinpgx), which unifies PharmGKB,
+CPIC and PharmCAT. The standalone cpicpgx.org site redirects into the CPIC section of
+ClinPGx and is stated to be retiring. Product URLs on this page were repointed to their
+ClinPGx targets on 2026-09-02, following the redirects the CPIC site issues. Three files
+remain on CPIC hosts with no redirect and no known ClinPGx copy: the API at
+api.cpicpgx.org, the overview slides on files.cpicpgx.org and the one-pager under
+cpicpgx.org/wp-content. They answered normally on 2026-09-02 and will need repointing
+when those hosts retire.
 
 The Clinical Pharmacogenetics Implementation Consortium (CPIC) facilitates the integration of pharmacogenetic test results into routine clinical care. CPIC develops and maintains evidence-based guidelines that translate patient genotype (or predicted phenotype) into prescribing recommendations, removing implementation barriers and standardizing clinical decision support for pharmacogenomics (PGx).
 
@@ -207,4 +231,4 @@ Caudle KE, Klein TE, Whirl-Carrillo M, et al. (CPIC® guideline citation – see
 
 ## Contact
 
-General inquiries: contact@cpicpgx.org. Additional forms and subscription options are available on the contact page for allele function questions, announcements, and discussion list enrollment.
+General inquiries: contact@cpicpgx.org (not re-verified since the ClinPGx move; feedback@clinpgx.org is the ClinPGx address). Additional forms and subscription options are available on the ClinPGx CPIC contact section for allele function questions, announcements, and discussion list enrollment.

--- a/resource/cpic/cpic.portal.md
+++ b/resource/cpic/cpic.portal.md
@@ -1,12 +1,13 @@
 ---
 category: GraphicalInterface
-description: Main CPIC website portal providing access to guidelines, genes-drugs tables, alleles, publications, resources, and implementation information
+description: Main CPIC website portal providing access to guidelines, genes-drugs
+  tables, alleles, publications, resources, and implementation information
 format: http
 id: cpic.portal
 name: CPIC Website Portal
 original_source:
-  - source: cpic
-    relation_type: prov:hadPrimarySource
-product_url: https://cpicpgx.org/
+- relation_type: prov:hadPrimarySource
+  source: cpic
+product_url: https://www.clinpgx.org/cpic
 layout: product_detail
 ---

--- a/resource/cpic/cpic.term_standardization.md
+++ b/resource/cpic/cpic.term_standardization.md
@@ -8,6 +8,6 @@ name: CPIC Term Standardization Project
 original_source:
 - relation_type: prov:hadPrimarySource
   source: cpic
-product_url: https://cpicpgx.org/resources/term-standardization
+product_url: https://www.clinpgx.org/page/cpicTermStandardization
 layout: product_detail
 ---

--- a/resource/pgxmine/pgxmine.md
+++ b/resource/pgxmine/pgxmine.md
@@ -1,5 +1,5 @@
 ---
-activity_status: active
+activity_status: inactive
 category: DataSource
 contacts:
   - category: Individual
@@ -8,16 +8,16 @@ contacts:
         value: jakelever
     label: Jake Lever
 creation_date: '2025-10-30T00:00:00Z'
-description: PGxMine uses text mining to identify pharmacogenomic associations between chemicals and genetic variants in the biomedical literature to assist curation of PharmGKB. The system uses the Kindred relation classifier along with PubTator annotations to extract chemical-variant associations from PubMed, PubMed Central Open Access, and PubMed Central Author Manuscript Collection.
+description: PGxMine used text mining to identify pharmacogenomic associations between chemicals and genetic variants in the biomedical literature to assist curation of PharmGKB. The system uses the Kindred relation classifier along with PubTator annotations to extract chemical-variant associations from PubMed, PubMed Central Open Access, and PubMed Central Author Manuscript Collection. The hosted viewer at pgxmine.pharmgkb.org stopped resolving after PharmGKB moved to ClinPGx (checked 2026-09-02) and the code was last updated in November 2022; the data remain on Zenodo and the code on GitHub.
 domains:
   - pharmacology
   - genomics
   - literature
   - precision medicine
-homepage_url: https://pgxmine.pharmgkb.org/
+homepage_url: https://github.com/jakelever/pgxmine
 id: pgxmine
 infores_id: pgxmine
-last_modified_date: '2025-10-31T00:00:00Z'
+last_modified_date: '2026-09-02T00:00:00Z'
 layout: resource_detail
 license:
   id: https://opensource.org/licenses/MIT
@@ -33,6 +33,10 @@ products:
       - source: pgxmine
         relation_type: prov:hadPrimarySource
     product_url: https://pgxmine.pharmgkb.org/
+    warnings:
+      - 'Host pgxmine.pharmgkb.org did not resolve when checked on 2026-09-02 (connection
+        failure). No ClinPGx equivalent is known. The Shiny viewer can be run locally from
+        the code repository.'
   - category: Product
     description: Collated chemical-variant associations with citation counts, normalized to PharmGKB, dbSNP, and Entrez identifiers
     format: tsv
@@ -70,6 +74,12 @@ synonyms:
 
 ## Overview
 
+**Status (2026-09-02):** the hosted viewer at pgxmine.pharmgkb.org no longer resolves.
+PharmGKB itself moved to [ClinPGx](clinpgx) on 2025-07-30 and no ClinPGx home for PGxMine
+is known. The code repository was last updated in November 2022. The Zenodo record and
+the GitHub repository remain available, so the resource is marked inactive rather than
+retired.
+
 PGxMine is a text mining system designed to extract pharmacogenomic associations from biomedical literature to assist in the curation of PharmGKB. The system processes millions of documents from PubMed, PubMed Central Open Access, and the PubMed Central Author Manuscript Collection to identify relationships between chemicals (drugs) and genetic variants.
 
 The project uses advanced natural language processing, including the Kindred relation classifier and scispacy, combined with PubTator for entity recognition. PGxMine specifically targets associations between chemical compounds and genetic variants, including rsIDs, star alleles (e.g., CYP2D6*4), and other variant nomenclature.
@@ -100,7 +110,7 @@ The system provides three main TSV files:
 
 ## Access Methods
 
-1. **Web Interface**: Browse associations through the interactive Shiny viewer at https://pgxmine.pharmgkb.org/
+1. **Web Interface**: The hosted Shiny viewer at https://pgxmine.pharmgkb.org/ is offline; the viewer can be run locally from the code repository
 2. **Direct Download**: Access TSV files via Zenodo (DOI: 10.5281/zenodo.3360930)
 3. **Local Installation**: Run the Shiny viewer locally using code from the GitHub repository
 4. **Custom Pipeline**: Execute the full text mining pipeline on custom corpora using provided code
@@ -146,35 +156,3 @@ Developed and maintained by Jake Lever. The system is designed to support PharmG
 ## Last Update
 
 Data files last updated: June 2022 (v10 on Zenodo)
-
-# Text Mined pharmacogenomic polymorphisms
-
-## Overview
-
-Text mined pharmacogenomic polymorphisms to assist curation of PharmGKB.
-
-**Note:** This is a stub entry that was automatically created from the [Translator Information Resource Registry](https://biolink.github.io/information-resource-registry/). It requires manual curation to add complete metadata, products, and additional information.
-
-## Information Resource ID
-
-This resource has the Information Resource identifier: `infores:pgxmine`
-
-## Curation Status
-
-- **Stub**: Yes - needs manual curation
-- **Creation Date**: 2025-10-30
-- **Original Source**: Translator Information Resource Registry
-
-## What Needs to be Curated
-
-1. **Activity Status**: Verify if this resource is active, inactive, or deprecated
-2. **Category**: Confirm the resource category is correct
-3. **Description**: Expand and improve the description
-4. **Homepage URL**: Verify and update if needed
-5. **Products**: Add specific data products/files/APIs offered by this resource
-6. **Contacts**: Add contact information
-7. **Publications**: Add relevant publications
-8. **Domains**: Add relevant domain tags
-9. **Repository**: Add code repository if applicable
-
-## Additional Notes

--- a/resource/pgxmine/pgxmine.viewer.md
+++ b/resource/pgxmine/pgxmine.viewer.md
@@ -1,12 +1,17 @@
 ---
 category: GraphicalInterface
-description: Interactive Shiny web application for browsing and filtering text-mined pharmacogenomic associations
+description: Interactive Shiny web application for browsing and filtering text-mined
+  pharmacogenomic associations
 format: http
 id: pgxmine.viewer
 name: PGxMine Shiny Viewer
 original_source:
-  - source: pgxmine
-    relation_type: prov:hadPrimarySource
+- relation_type: prov:hadPrimarySource
+  source: pgxmine
 product_url: https://pgxmine.pharmgkb.org/
+warnings:
+- Host pgxmine.pharmgkb.org did not resolve when checked on 2026-09-02 (connection
+  failure). No ClinPGx equivalent is known. The Shiny viewer can be run locally from
+  the code repository.
 layout: product_detail
 ---

--- a/resource/pharmgkb/pharmgkb.md
+++ b/resource/pharmgkb/pharmgkb.md
@@ -1,18 +1,22 @@
 ---
-activity_status: active
+activity_status: inactive
 category: Resource
 contacts:
 - category: Organization
   contact_details:
   - contact_type: email
     value: feedback@pharmgkb.org
+  - contact_type: email
+    value: feedback@clinpgx.org
   label: PharmGKB
 creation_date: '2025-05-01T00:00:00Z'
-description: PharmGKB collects, curates and disseminates knowledge about clinically
-  actionable gene-drug associations and genotype-phenotype relationships. As of 2025-07-30
-  PharmGKB is delivered through ClinPGx, which unifies PharmGKB, CPIC and PharmCAT;
-  pharmgkb.org URLs now redirect to their clinpgx.org equivalents and downloads are
-  served from api.clinpgx.org.
+description: PharmGKB collected, curated and disseminated knowledge about clinically
+  actionable gene-drug associations and genotype-phenotype relationships. On 2025-07-30
+  PharmGKB was succeeded by ClinPGx (registry id clinpgx), which unifies PharmGKB,
+  CPIC and PharmCAT; pharmgkb.org URLs redirect to their clinpgx.org equivalents and
+  the downloads listed here are served from api.clinpgx.org. This page is kept because
+  many registry resources cite pharmgkb as a provenance source. Use clinpgx for the
+  current resource.
 domains:
 - biomedical
 - chemistry and biochemistry
@@ -22,7 +26,7 @@ domains:
 homepage_url: https://www.clinpgx.org/
 id: pharmgkb
 infores_id: pharmgkb
-last_modified_date: '2026-09-01T00:00:00Z'
+last_modified_date: '2026-09-02T00:00:00Z'
 layout: resource_detail
 license:
   id: https://creativecommons.org/licenses/by-sa/4.0/
@@ -2215,6 +2219,32 @@ products:
     source: wikidata
   - relation_type: prov:wasInfluencedBy
     source: wikipathways
+- category: GraphicalInterface
+  description: ClinPGx web portal for browsing genes, variants, drugs, clinical annotations,
+    drug labels, pathways and CPIC guidelines, integrating PharmGKB and CPIC content
+  id: clinpgx.portal
+  is_public: true
+  name: ClinPGx Portal
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: clinpgx
+  - relation_type: prov:wasDerivedFrom
+    source: pharmgkb
+  - relation_type: prov:wasDerivedFrom
+    source: cpic
+  product_url: https://www.clinpgx.org/
+- category: DocumentationProduct
+  description: Downloads page listing the bulk data files (formerly the PharmGKB downloads),
+    with data usage policy and file descriptions
+  id: clinpgx.downloads
+  is_public: true
+  name: ClinPGx Downloads
+  original_source:
+  - relation_type: prov:hadPrimarySource
+    source: clinpgx
+  - relation_type: prov:wasDerivedFrom
+    source: pharmgkb
+  product_url: https://www.clinpgx.org/downloads
 publications:
 - authors:
   - Whirl-Carrillo M
@@ -2234,12 +2264,25 @@ publications:
 repository: https://www.clinpgx.org/downloads
 taxon:
 - NCBITaxon:9606
+use_instead:
+- clinpgx
 ---
-PharmGKB is a pharmacogenomics knowledge resource covering clinically actionable
+PharmGKB was a pharmacogenomics knowledge resource covering clinically actionable
 gene-drug associations and genotype-phenotype relationships.
 
-PharmGKB is now delivered through [ClinPGx](https://www.clinpgx.org/), which brings
-PharmGKB together with CPIC and PharmCAT under one resource. Since 2025-07-30 all
-pharmgkb.org links redirect to their ClinPGx equivalents, and the bulk download files
-listed here are served from `api.clinpgx.org` on the same paths they previously used
-on `api.pharmgkb.org`, which no longer resolves.
+## Redirect notice
+
+PharmGKB is now [ClinPGx](clinpgx). ClinPGx brings PharmGKB together with CPIC and
+PharmCAT under one resource. Since 2025-07-30 all pharmgkb.org links redirect to their
+ClinPGx equivalents, and the bulk download files listed here are served from
+`api.clinpgx.org` on the same paths they previously used on `api.pharmgkb.org`, which
+no longer resolves. The feedback address is now feedback@clinpgx.org.
+
+This page is kept on purpose. Many resources in this registry name `pharmgkb` as a
+provenance source, and downstream consumers may still refer to PharmGKB rather than to
+ClinPGx. The `pharmgkb` identifier therefore stays stable, the page is marked inactive,
+and `use_instead` points to `clinpgx`. The download products remain listed here because
+they are the same files under the same paths.
+
+The INFORES catalog had no ClinPGx identifier as of 2026-09-02, so `infores_id`
+remains `pharmgkb`. That is deliberate.


### PR DESCRIPTION
Closes #708. Follows the decision in the issue comment: keep `pharmgkb`, add a redirect note pointing at the new resource.

## Changes

- **New `clinpgx` resource** (`resource/clinpgx/clinpgx.md`) with portal, downloads page and API products, plus `org/clinpgx/clinpgx.md`. License CC-BY-SA-4.0, taken from the `LICENSE.txt` inside a ClinPGx download archive.
- **`pharmgkb`** kept. Marked `inactive` with `use_instead: [clinpgx]`, which is the field the site renders as a "Use instead" banner and which the registry docs reserve for non-active resources. Description and body explain the redirect and why the identifier stays. `infores_id: pharmgkb` stays because INFORES has no ClinPGx entry as of 2026-09-02, and the body says so. Added `feedback@clinpgx.org` beside the old contact address.
- **`cpic`** stays active. Seven product URLs, the homepage and the contact URL are repointed to the exact targets `cpicpgx.org` redirects to. Three files remain on CPIC hosts with no redirect (`api.cpicpgx.org`, the slides on `files.cpicpgx.org`, the one-pager under `wp-content`). They answered normally on 2026-09-02 and the page names them as the next to break.
- **`pgxmine`** marked `inactive`. `pgxmine.pharmgkb.org` does not resolve, the code last moved in November 2022, and the Zenodo record and repository still work. Homepage now points at the repository, the viewer product carries a warning, and a leftover INFORES stub trailer is removed from the body.
- Product detail pages for the new products were generated with the concat build step. The ClinPGx portal and downloads propagate onto the PharmGKB and CPIC pages through their `wasDerivedFrom` links.

## Not done

- Item 6 of the issue: `pharmcat` and `pharmvar` remain candidate entries and are left for a separate decision.
- Item 5: whether `feedback@pharmgkb.org` and `contact@cpicpgx.org` still route is unverified.

## Caveat

ClinPGx is a single-page app and returns 200 for any path, including nonsense. The CPIC repoints rest on the redirect targets the CPIC site itself issues, not on ClinPGx status codes.

## Verification

- `validate-file` passes on all four resource pages; `validate-org-file` passes on the org page.
- `uv run pytest tests/ -m "not network"`: 146 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5GAZwwFEgYQhJQ8Soy9Hb
