### PR TITLE
Memoize declared-license lookups and retire infer_license()

### DIFF
--- a/tests/test_license_inference.py
+++ b/tests/test_license_inference.py
@@ -514,3 +514,39 @@ def test_nested_walks_are_memoized_and_cycles_are_not():
     assert index.infer(resources[4])["restrictiveness"] == "non-commercial"
     assert "x" not in index._inferred
     assert "y" not in index._inferred
+
+
+def test_declared_license_lookup_is_memoized_per_resource():
+    """A source referenced many times is classified once, with the same answer."""
+    leaf = _resource(
+        "leaf",
+        products=[
+            _product("leaf.a", license=CC_BY),
+            _product("leaf.b", license=CC_BY_SA),
+        ],
+    )
+    resources = [leaf] + [
+        _resource(
+            f"kg{n}", category="KnowledgeGraph", products=[_product(f"kg{n}.graph", ["leaf"])]
+        )
+        for n in range(5)
+    ]
+    index = LicenseIndex(resources)
+
+    tiers = {r["id"]: index.infer(r)["restrictiveness"] for r in resources[1:]}
+    # The most restrictive product license of the unlicensed source wins.
+    assert set(tiers.values()) == {"copyleft"}
+    # Five references, one walk of the source's products.
+    assert index._declared == {"leaf": (CC_BY_SA, "copyleft")}
+
+
+def test_declared_memo_records_a_source_with_nothing_to_declare():
+    """A source with no license anywhere is remembered as such, not re-walked."""
+    resources = [
+        _resource("bare", products=[_product("bare.data")]),
+        _resource("kg", category="KnowledgeGraph", products=[_product("kg.graph", ["bare"])]),
+    ]
+    index = LicenseIndex(resources)
+
+    assert index.infer(resources[1]) is None
+    assert index._declared == {"bare": None}

--- a/util/license_inference.py
+++ b/util/license_inference.py
@@ -73,7 +73,6 @@ __all__ = [
     "most_restrictive",
     "upstream_sources",
     "LicenseIndex",
-    "infer_license",
     "apply_inferred_licenses",
     "LicenseWriteRefused",
     "write_report",
@@ -419,6 +418,7 @@ class LicenseIndex:
                 if isinstance(product_id, str) and resource_owns_product(resource_id, product_id):
                     self.products.setdefault(product_id.strip(), product)
         self._inferred: dict[str, Optional[dict[str, Any]]] = {}
+        self._declared: dict[str, Optional[tuple[Any, str]]] = {}
 
     # -- single-source resolution ------------------------------------------
 
@@ -444,28 +444,10 @@ class LicenseIndex:
         resource = self.resources.get(resource_id)
         if resource is None:
             return None, None, False
-        tier = classify_license(resource.get("license"))
-        if tier is not None:
-            return resource.get("license"), tier, False
-
-        best_license, best_tier = None, None
-        products = resource.get("products")
-        if isinstance(products, list):
-            for product in products:
-                if not isinstance(product, Mapping):
-                    continue
-                product_id = product.get("id")
-                if not (
-                    isinstance(product_id, str) and resource_owns_product(resource_id, product_id)
-                ):
-                    continue
-                tier = classify_license(product.get("license"))
-                if tier is not None and (
-                    best_tier is None or TIER_RANK[tier] > TIER_RANK[best_tier]
-                ):
-                    best_license, best_tier = product.get("license"), tier
-        if best_tier is not None:
-            return best_license, best_tier, False
+        declared = self._declared_license(resource_id, resource)
+        if declared is not None:
+            license_obj, tier = declared
+            return license_obj, tier, False
 
         if resource_id in visiting:
             return None, None, True
@@ -474,6 +456,48 @@ class LicenseIndex:
             license_obj = {"id": inferred["id"], "label": inferred["label"]}
             return license_obj, inferred["restrictiveness"], truncated
         return None, None, truncated
+
+    def _declared_license(
+        self, resource_id: str, resource: Mapping[str, Any]
+    ) -> Optional[tuple[Any, str]]:
+        """Return (license_obj, tier) from the resource itself, or None.
+
+        The resource's own declared license wins; failing that, the most
+        restrictive license among the products it owns. Neither reads the
+        provenance graph, so the answer is the same for every caller and is
+        memoized unconditionally. None means the resource declares nothing
+        and its products carry nothing either.
+        """
+        if resource_id in self._declared:
+            return self._declared[resource_id]
+
+        result: Optional[tuple[Any, str]] = None
+        tier = classify_license(resource.get("license"))
+        if tier is not None:
+            result = (resource.get("license"), tier)
+        else:
+            best_license, best_tier = None, None
+            products = resource.get("products")
+            if isinstance(products, list):
+                for product in products:
+                    if not isinstance(product, Mapping):
+                        continue
+                    product_id = product.get("id")
+                    if not (
+                        isinstance(product_id, str)
+                        and resource_owns_product(resource_id, product_id)
+                    ):
+                        continue
+                    tier = classify_license(product.get("license"))
+                    if tier is not None and (
+                        best_tier is None or TIER_RANK[tier] > TIER_RANK[best_tier]
+                    ):
+                        best_license, best_tier = product.get("license"), tier
+            if best_tier is not None:
+                result = (best_license, best_tier)
+
+        self._declared[resource_id] = result
+        return result
 
     # -- whole-resource inference ------------------------------------------
 
@@ -560,13 +584,6 @@ def _choose_license(licenses: Iterable[Any]) -> tuple[str, str]:
     if label_only:
         return "", sorted(label_only, key=lambda lab: (-label_only[lab], lab))[0]
     return "", ""
-
-
-def infer_license(
-    resource: Mapping[str, Any], resources: Iterable[Mapping[str, Any]]
-) -> Optional[dict[str, Any]]:
-    """Convenience wrapper: build an index and infer for one resource."""
-    return LicenseIndex(resources).infer(resource)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #722. Both leftovers from the review of #715.

## Memoize the declared-license lookup

`LicenseIndex.resolve_source` re-walked a source resource's product list and re-classified each product license on every reference — `go` was resolved 39 times, and each time the same drawer got re-read.

That branch (the resource's own declared license, else the most restrictive license among the products it owns) never touches the provenance graph, so the answer is the same for every caller and can be cached unconditionally. It moves into `_declared_license(resource_id, resource)`, memoized by resource ID in `self._declared`. The cycle-guard branch below it is untouched — that result still may be truncated and still isn't cached.

Measured against the current `main` on the real registry (1027 resources, 226 inheriting):

```
old: classify_license=2798  time=65.7ms
new: classify_license=1257  time=42.5ms
identical results: True
```

"identical results" is the load-bearing line: the full `infer()` output was diffed per-resource against the pre-change module, not just the summary counts. `util/infer_licenses.py --dry-run` still reports the same 60 inferred / 6 unresolved / 49 conflict / 69 no-upstream split and the same tier histogram.

## Retire `infer_license()`

`infer_license(resource, resources)` built a whole `LicenseIndex` for one answer and had no callers anywhere — not the CLI, not the build, not the tests. It is deleted outright rather than just dropped from `__all__`, so no future caller can loop it over the registry and pay the index build 226 times. `LicenseIndex(resources).infer(resource)` is the same call and reuses the index.

## Tests

Two added to `tests/test_license_inference.py`, alongside the existing `test_nested_walks_are_memoized_and_cycles_are_not`:

- five references to one shared source produce a single memo entry carrying the right tier
- a source with no license anywhere is remembered as `None` rather than re-walked

`tests/test_license_inference.py` is 18/18 and `black --check` is clean. The full suite is 167 passed / 3 failed; the three are `tests/test_ftp_url_checker.py` failing on `[Errno 97] Address family not supported by protocol` (no FTP egress in the sandbox) — unrelated to this change and failing before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Exd48jqmmmMA6HkpMhCYKZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Exd48jqmmmMA6HkpMhCYKZ)_