### PR TITLE
Replace or remove the 85 'Not specified' placeholder licenses

### DIFF
--- a/resource/aao/aao.md
+++ b/resource/aao/aao.md
@@ -16,11 +16,8 @@ domains:
 - anatomy and development
 homepage_url: http://github.com/seger/aao
 id: aao
-last_modified_date: '2026-06-17T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Amphibian gross anatomy
 products:
 - category: OntologyProduct

--- a/resource/adw/adw.md
+++ b/resource/adw/adw.md
@@ -16,11 +16,8 @@ domains:
 - organisms
 homepage_url: http://www.animaldiversity.org
 id: adw
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Animal natural history and life history
 products:
 - category: OntologyProduct

--- a/resource/araport/araport.md
+++ b/resource/araport/araport.md
@@ -26,11 +26,8 @@ domains:
 - agriculture
 homepage_url: https://www.araport.org/
 id: araport
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Araport (Arabidopsis Information Portal)
 products:
 - category: DataSource

--- a/resource/ato/ato.md
+++ b/resource/ato/ato.md
@@ -17,11 +17,8 @@ domains:
 - biological systems
 homepage_url: http://www.amphibanat.org
 id: ato
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Amphibian taxonomy
 products:
 - category: OntologyProduct

--- a/resource/bila/bila.md
+++ b/resource/bila/bila.md
@@ -18,11 +18,8 @@ domains:
 - anatomy and development
 homepage_url: http://4dx.embl.de/4DXpress
 id: bila
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Bilateria anatomy
 products:
 - category: OntologyProduct

--- a/resource/bluesky/bluesky.md
+++ b/resource/bluesky/bluesky.md
@@ -22,11 +22,8 @@ domains:
 - information technology
 homepage_url: https://www.airfire.org/
 id: bluesky
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: BlueSky Smoke Modeling Framework
 products:
 - category: GraphicalInterface

--- a/resource/bootstrep/bootstrep.md
+++ b/resource/bootstrep/bootstrep.md
@@ -15,11 +15,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.ebi.ac.uk/Rebholz-srv/GRO/GRO.html
 id: bootstrep
-last_modified_date: '2026-06-17T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Gene Regulation Ontology
 products:
 - category: OntologyProduct

--- a/resource/ccre/ccre.md
+++ b/resource/ccre/ccre.md
@@ -23,11 +23,11 @@ domains:
 - systems biology
 homepage_url: https://screen.encodeproject.org/
 id: ccre
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: ENCODE cCRE Registry (SCREEN)
 products:
 - category: GraphicalInterface

--- a/resource/chembank/chembank.md
+++ b/resource/chembank/chembank.md
@@ -24,11 +24,8 @@ domains:
 homepage_url: http://chembank.broadinstitute.org/
 id: chembank
 infores_id: chembank
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: ChemBank
 products:
 - category: DocumentationProduct

--- a/resource/cmf/cmf.md
+++ b/resource/cmf/cmf.md
@@ -16,11 +16,8 @@ domains:
 - biomedical
 homepage_url: https://code.google.com/p/craniomaxillofacial-ontology/
 id: cmf
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: CranioMaxilloFacial ontology
 products:
 - category: OntologyProduct

--- a/resource/cureid/cureid.md
+++ b/resource/cureid/cureid.md
@@ -22,11 +22,8 @@ domains:
 - public health
 homepage_url: https://cure.ncats.io/
 id: cureid
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: CURE ID
 products:
 - category: GraphicalInterface

--- a/resource/dbvar/dbvar.md
+++ b/resource/dbvar/dbvar.md
@@ -24,11 +24,11 @@ domains:
 - biomedical
 homepage_url: https://www.ncbi.nlm.nih.gov/dbvar/
 id: dbvar
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://www.ncbi.nlm.nih.gov/home/about/policies/
+  label: Public Domain (U.S. Government work; NCBI and NLM Data Usage Policies)
 name: dbVar
 products:
 - category: GraphicalInterface

--- a/resource/dc_cl/dc_cl.md
+++ b/resource/dc_cl/dc_cl.md
@@ -16,11 +16,8 @@ domains:
 - anatomy and development
 homepage_url: http://www.dukeontologygroup.org/Projects.html
 id: dc_cl
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Dendritic cell
 products:
 - category: OntologyProduct

--- a/resource/dcdb/dcdb.md
+++ b/resource/dcdb/dcdb.md
@@ -14,11 +14,8 @@ domains:
 - clinical
 homepage_url: http://www.cls.zju.edu.cn/dcdb/
 id: dcdb
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Drug Combination Database
 products:
 - category: DocumentationProduct

--- a/resource/decipher/decipher.md
+++ b/resource/decipher/decipher.md
@@ -23,11 +23,11 @@ domains:
 - precision medicine
 homepage_url: https://www.deciphergenomics.org/
 id: decipher
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://www.deciphergenomics.org/files/pdfs/DECIPHER_Terms_of_Use.pdf
+  label: DECIPHER Terms of Use (restrictions on use and redistribution to protect patient privacy)
 name: DECIPHER
 products:
 - category: GraphicalInterface

--- a/resource/effas-kpi/effas-kpi.md
+++ b/resource/effas-kpi/effas-kpi.md
@@ -21,11 +21,11 @@ domains:
 - public health
 homepage_url: https://effas.com/
 id: effas-kpi
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://effas.com/legal-notice/
+  label: EFFAS legal notice (all rights reserved; reproduction or distribution requires written consent)
 name: EFFAS KPIs for ESG
 products:
 - category: DocumentationProduct

--- a/resource/ehda/ehda.md
+++ b/resource/ehda/ehda.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: http://genex.hgu.mrc.ac.uk/
 id: ehda
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Human developmental anatomy, timed version
 products:
 - category: GraphProduct

--- a/resource/ehdaa/ehdaa.md
+++ b/resource/ehdaa/ehdaa.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: https://obofoundry.org/ontology/ehdaa
 id: ehdaa
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Human developmental anatomy, abstract version
 products:
 - category: OntologyProduct

--- a/resource/emap/emap.md
+++ b/resource/emap/emap.md
@@ -19,11 +19,8 @@ domains:
 - anatomy and development
 homepage_url: http://emouseatlas.org
 id: emap
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Mouse gross anatomy and development, timed
 products:
 - category: OntologyProduct

--- a/resource/endb/endb.md
+++ b/resource/endb/endb.md
@@ -23,11 +23,8 @@ domains:
 - biomedical
 homepage_url: http://www.licpathway.net/ENdb/
 id: endb
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: ENdb
 products:
 - category: GraphicalInterface

--- a/resource/enhanceratlas/enhanceratlas.md
+++ b/resource/enhanceratlas/enhanceratlas.md
@@ -22,11 +22,8 @@ domains:
 - biological systems
 homepage_url: http://www.enhanceratlas.org/
 id: enhanceratlas
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: EnhancerAtlas
 products:
 - category: DataProduct

--- a/resource/epo/epo.md
+++ b/resource/epo/epo.md
@@ -11,11 +11,8 @@ domains:
 - biomedical
 homepage_url: https://code.google.com/p/epidemiology-ontology/
 id: epo
-last_modified_date: '2026-04-15T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Epidemiology Ontology
 products:
 - category: OntologyProduct

--- a/resource/ev/ev.md
+++ b/resource/ev/ev.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: https://obofoundry.org/ontology/ev
 id: ev
-last_modified_date: '2026-06-01T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: eVOC (Expressed Sequence Annotation for Humans)
 products:
 - category: OntologyProduct

--- a/resource/fbsp/fbsp.md
+++ b/resource/fbsp/fbsp.md
@@ -20,11 +20,8 @@ domains:
 - organisms
 homepage_url: http://www.flybase.org/
 id: fbsp
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Fly taxonomy
 products:
 - category: OntologyProduct

--- a/resource/fire/fire.md
+++ b/resource/fire/fire.md
@@ -28,11 +28,11 @@ domains:
 - biomedical
 homepage_url: https://doi.org/10.1016/j.celrep.2016.10.061
 id: fire
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://www.gnu.org/licenses/gpl-3.0.en.html
+  label: GPL-3.0 (FIREcaller R package)
 name: FIRE (Frequently Interacting REgions)
 products:
 - category: DataSource

--- a/resource/fix/fix.md
+++ b/resource/fix/fix.md
@@ -12,11 +12,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.ebi.ac.uk/chebi
 id: fix
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Physico-chemical methods and properties
 products:
 - category: OntologyProduct

--- a/resource/flu/flu.md
+++ b/resource/flu/flu.md
@@ -15,11 +15,8 @@ domains:
 - biomedical
 homepage_url: http://purl.obolibrary.org/obo/flu/
 id: flu
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Influenza Ontology
 products:
 - category: OntologyProduct

--- a/resource/gad/gad.md
+++ b/resource/gad/gad.md
@@ -15,11 +15,8 @@ domains:
 - phenotype
 homepage_url: https://geneticassociationdb.nih.gov/
 id: gad
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Genetic Association Database
 products:
 - category: DocumentationProduct

--- a/resource/gomapman/gomapman.md
+++ b/resource/gomapman/gomapman.md
@@ -26,11 +26,11 @@ domains:
 - systems biology
 homepage_url: https://gomapman.nib.si/
 id: gomapman
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by-nc-sa/3.0/
+  label: CC BY-NC-SA 3.0
 name: GoMapMan
 products:
 - category: GraphicalInterface

--- a/resource/gp-kg/gp-kg.md
+++ b/resource/gp-kg/gp-kg.md
@@ -18,7 +18,7 @@ layout: resource_detail
 license:
   display_note: 'No license is declared for this resource. This is the most restrictive
     license (custom) among its sources: goa, gtex, umls. Not accounted for, no known
-    license: faers, phenomebrowser, treatkb.'
+    license: faers, treatkb.'
   id: https://www.ebi.ac.uk/about/terms-of-use
   inferred_from:
   - goa
@@ -29,7 +29,6 @@ license:
   status: inferred
   unresolved_sources:
   - faers
-  - phenomebrowser
   - treatkb
 name: GP-KG
 products:

--- a/resource/greenclaims/greenclaims.md
+++ b/resource/greenclaims/greenclaims.md
@@ -15,11 +15,11 @@ domains:
 - literature
 homepage_url: https://github.com/DizzyPanda1/GreenwashingDetectionDataset
 id: greenclaims
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://opensource.org/license/mit/
+  label: MIT
 name: GreenClaims
 products:
 - category: DataDump

--- a/resource/gro/gro.md
+++ b/resource/gro/gro.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: http://www.gramene.org/plant_ontology/
 id: gro
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Cereal Plant Gross Anatomy
 products: []
 publications: []

--- a/resource/habronattus/habronattus.md
+++ b/resource/habronattus/habronattus.md
@@ -17,11 +17,8 @@ domains:
 - biological systems
 homepage_url: http://www.mesquiteproject.org/ontology/Habronattus/index.html
 id: habronattus
-last_modified_date: '2026-07-03T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Habronattus courtship
 products: []
 publications: []

--- a/resource/hifld/hifld.md
+++ b/resource/hifld/hifld.md
@@ -23,11 +23,8 @@ domains:
 - information technology
 homepage_url: https://hifld-geoplatform.hub.arcgis.com/
 id: hifld
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Homeland Infrastructure Foundation-Level Data (HIFLD)
 products:
 - category: Product

--- a/resource/iev/iev.md
+++ b/resource/iev/iev.md
@@ -10,11 +10,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.inoh.org
 id: iev
-last_modified_date: '2026-06-24T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Event (INOH pathway ontology)
 products:
 - category: OntologyProduct

--- a/resource/imr/imr.md
+++ b/resource/imr/imr.md
@@ -4,15 +4,12 @@ name: Molecule role (INOH Protein name/family name ontology)
 description: Description unavailable.
 activity_status: inactive
 homepage_url: http://www.inoh.org
-license:
-  id: ''
-  label: Not specified
 collection:
 - obo-foundry
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-07-10T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 domains:
 - chemistry and biochemistry
 contacts:

--- a/resource/inxight-drugs/inxight-drugs.md
+++ b/resource/inxight-drugs/inxight-drugs.md
@@ -27,11 +27,11 @@ domains:
 homepage_url: https://drugs.ncats.io
 id: inxight-drugs
 infores_id: inxight-drugs
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://drugs.ncats.io/
+  label: Public Domain (NCATS states all facts in these datasets are in the public domain)
 name: 'Inxight: Drugs'
 products:
 - category: DataProduct

--- a/resource/ipr/ipr.md
+++ b/resource/ipr/ipr.md
@@ -4,15 +4,12 @@ name: Protein Domains
 description: Description unavailable.
 activity_status: inactive
 homepage_url: http://www.ebi.ac.uk/interpro/index.html
-license:
-  id: ''
-  label: Not specified
 collection:
 - obo-foundry
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 domains:
 - chemistry and biochemistry
 contacts:

--- a/resource/kentucky-cancer-registry/kentucky-cancer-registry.md
+++ b/resource/kentucky-cancer-registry/kentucky-cancer-registry.md
@@ -22,11 +22,11 @@ domains:
 - biomedical
 homepage_url: https://www.kcr.uky.edu/
 id: kentucky-cancer-registry
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://www.kcr.uky.edu/research/how.php
+  label: KCR data use agreement (application and confidentiality assurances required; IRB approval for identifiable data)
 name: Kentucky Cancer Registry
 products:
 - category: GraphicalInterface

--- a/resource/lipro/lipro.md
+++ b/resource/lipro/lipro.md
@@ -16,11 +16,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: https://obofoundry.org/ontology/lipro.html
 id: lipro
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Lipid Ontology
 products:
 - category: OntologyProduct

--- a/resource/loggerhead/loggerhead.md
+++ b/resource/loggerhead/loggerhead.md
@@ -4,15 +4,12 @@ name: Loggerhead nesting
 description: Description unavailable.
 activity_status: inactive
 homepage_url: http://www.mesquiteproject.org/ontology/Loggerhead/index.html
-license:
-  id: ''
-  label: Not specified
 collection:
 - obo-foundry
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-07-10T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 domains:
 - biological systems
 - organisms

--- a/resource/louisiana-tumor-registry/louisiana-tumor-registry.md
+++ b/resource/louisiana-tumor-registry/louisiana-tumor-registry.md
@@ -22,11 +22,11 @@ domains:
 - biomedical
 homepage_url: https://publichealth.lsuhsc.edu/louisiana-tumor-registry/
 id: louisiana-tumor-registry
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://publichealth.lsuhsc.edu/louisiana-tumor-registry/data-usestatistics/data-request.aspx
+  label: LTR data request terms (data released by application; IRB approval for case-specific data)
 name: Louisiana Tumor Registry
 products:
 - category: GraphicalInterface

--- a/resource/maizegdb/maizegdb.md
+++ b/resource/maizegdb/maizegdb.md
@@ -23,11 +23,8 @@ domains:
 - agriculture
 homepage_url: https://www.maizegdb.org
 id: maizegdb
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: MaizeGDB
 products:
 - category: DataProduct

--- a/resource/mao/mao.md
+++ b/resource/mao/mao.md
@@ -4,15 +4,12 @@ name: Multiple alignment
 description: Description unavailable.
 activity_status: inactive
 homepage_url: http://www-igbmc.u-strasbg.fr/BioInfo/MAO/mao.html
-license:
-  id: ''
-  label: Not specified
 collection:
 - obo-foundry
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 domains:
 - chemistry and biochemistry
 contacts:

--- a/resource/mat/mat.md
+++ b/resource/mat/mat.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: https://obofoundry.org/ontology/mat.html
 id: mat
-last_modified_date: '2026-09-01T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Minimal anatomical terminology
 products:
 - category: GraphProduct

--- a/resource/matador/matador.md
+++ b/resource/matador/matador.md
@@ -14,11 +14,11 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://matador.embl.de/
 id: matador
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by-nc-sa/3.0/
+  label: CC BY-NC-SA 3.0 (commercial use by separate license)
 name: MATADOR
 products:
 - category: DocumentationProduct

--- a/resource/mfo/mfo.md
+++ b/resource/mfo/mfo.md
@@ -19,11 +19,8 @@ domains:
 - anatomy and development
 homepage_url: https://obofoundry.org/ontology/mfo.html
 id: mfo
-last_modified_date: '2026-09-01T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Medaka fish anatomy and development
 products:
 - category: OntologyProduct

--- a/resource/miro/miro.md
+++ b/resource/miro/miro.md
@@ -16,11 +16,8 @@ domains:
 - environment
 homepage_url: http://purl.obolibrary.org/obo/miro.owl
 id: miro
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Mosquito insecticide resistance
 products:
 - category: OntologyProduct

--- a/resource/mmrrc/mmrrc.md
+++ b/resource/mmrrc/mmrrc.md
@@ -23,11 +23,11 @@ domains:
 - biomedical
 homepage_url: https://www.mmrrc.org/
 id: mmrrc
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://www.mmrrc.org/methods/data_download.php
+  label: MMRRC data download terms (attribution required; all rights reserved)
 name: Mutant Mouse Resource and Research Centers
 products:
 - category: Database

--- a/resource/mo/mo.md
+++ b/resource/mo/mo.md
@@ -18,11 +18,8 @@ domains:
 - general
 homepage_url: http://mged.sourceforge.net/ontologies/MGEDontology.php
 id: mo
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Microarray experimental conditions
 products:
 - category: OntologyProduct

--- a/resource/motifmap/motifmap.md
+++ b/resource/motifmap/motifmap.md
@@ -17,11 +17,11 @@ domains:
 - biomedical
 homepage_url: https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-12-495
 id: motifmap
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://web.archive.org/web/20160112094556/http://motifmap.ics.uci.edu/
+  label: Free for academic use; commercial license by contact (archived site)
 name: MotifMap
 products:
 - category: GraphicalInterface

--- a/resource/mtbs/mtbs.md
+++ b/resource/mtbs/mtbs.md
@@ -20,11 +20,8 @@ domains:
 - general
 homepage_url: https://www.mtbs.gov/
 id: mtbs
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Monitoring Trends in Burn Severity
 products:
 - category: Product

--- a/resource/nif_cell/nif_cell.md
+++ b/resource/nif_cell/nif_cell.md
@@ -4,15 +4,12 @@ name: NIF Cell
 description: Neuronal cell types
 activity_status: inactive
 homepage_url: http://neuinfo.org/
-license:
-  id: ''
-  label: Not specified
 collection:
 - obo-foundry
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 domains:
 - anatomy and development
 contacts:

--- a/resource/nif_dysfunction/nif_dysfunction.md
+++ b/resource/nif_dysfunction/nif_dysfunction.md
@@ -16,11 +16,8 @@ domains:
 - biomedical
 homepage_url: http://neuinfo.org/
 id: nif_dysfunction
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: NIF Dysfunction
 products:
 - category: OntologyProduct

--- a/resource/nif_grossanatomy/nif_grossanatomy.md
+++ b/resource/nif_grossanatomy/nif_grossanatomy.md
@@ -4,15 +4,12 @@ name: NIF Gross Anatomy
 description: Description unavailable.
 activity_status: inactive
 homepage_url: http://neuinfo.org/
-license:
-  id: ''
-  label: Not specified
 collection:
 - obo-foundry
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 domains:
 - anatomy and development
 contacts:

--- a/resource/nmr/nmr.md
+++ b/resource/nmr/nmr.md
@@ -17,11 +17,8 @@ domains:
 - general
 homepage_url: http://msi-ontology.sourceforge.net/
 id: nmr
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: NMR-instrument specific component of metabolomics investigations
 products:
 - category: OntologyProduct

--- a/resource/obo_rel/obo_rel.md
+++ b/resource/obo_rel/obo_rel.md
@@ -4,15 +4,12 @@ name: OBO relationship types (legacy)
 description: Description unavailable.
 activity_status: inactive
 homepage_url: http://www.obofoundry.org/ro
-license:
-  id: ''
-  label: Not specified
 collection:
 - obo-foundry
 layout: resource_detail
 category: Ontology
 creation_date: '2025-09-29T00:00:00Z'
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 domains:
 - biological systems
 - general

--- a/resource/ogi/ogi.md
+++ b/resource/ogi/ogi.md
@@ -19,11 +19,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: https://code.google.com/p/ontology-for-genetic-interval/
 id: ogi
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Ontology for genetic interval
 products:
 - category: OntologyProduct

--- a/resource/oreganno/oreganno.md
+++ b/resource/oreganno/oreganno.md
@@ -15,11 +15,11 @@ domains:
 - systems biology
 homepage_url: https://genome.ucsc.edu/cgi-bin/hgTrackUi?org=Human&g=oreganno
 id: oreganno
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://www.gnu.org/licenses/lgpl.html
+  label: LGPL (stated by ORegAnno for its data and web application)
 name: ORegAnno
 products:
 - category: DataProduct

--- a/resource/pao/pao.md
+++ b/resource/pao/pao.md
@@ -18,11 +18,11 @@ domains:
 - anatomy and development
 homepage_url: http://www.plantontology.org
 id: pao
-last_modified_date: '2026-07-10T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: Plant Anatomy Ontology
 products:
 - category: OntologyProduct

--- a/resource/pd_st/pd_st.md
+++ b/resource/pd_st/pd_st.md
@@ -18,11 +18,8 @@ domains:
 - anatomy and development
 homepage_url: http://4dx.embl.de/platy
 id: pd_st
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Platynereis stage ontology
 products: []
 publications:

--- a/resource/pgdso/pgdso.md
+++ b/resource/pgdso/pgdso.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: http://www.plantontology.org
 id: pgdso
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Plant Growth and Development Stage
 products:
 - category: OntologyProduct

--- a/resource/pharmdb/pharmdb.md
+++ b/resource/pharmdb/pharmdb.md
@@ -15,7 +15,7 @@ layout: resource_detail
 license:
   display_note: 'No license is declared for this resource. This is the most restrictive
     license (custom) among its sources: ctd, dip. Not accounted for, no known license:
-    dcdb, gad, matador, t3db.'
+    dcdb, gad.'
   id: https://ctdbase.org/about/legal.jsp
   inferred_from:
   - ctd
@@ -26,8 +26,6 @@ license:
   unresolved_sources:
   - dcdb
   - gad
-  - matador
-  - t3db
 name: PharmDB
 products:
 - category: GraphicalInterface

--- a/resource/phenomebrowser/phenomebrowser.md
+++ b/resource/phenomebrowser/phenomebrowser.md
@@ -15,11 +15,11 @@ domains:
 - systems biology
 homepage_url: http://phenomebrowser.net/
 id: phenomebrowser
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: PhenomeBrowser
 products:
 - category: GraphicalInterface

--- a/resource/planteome/planteome.md
+++ b/resource/planteome/planteome.md
@@ -26,11 +26,11 @@ domains:
 - phenotype
 homepage_url: https://planteome.org
 id: planteome
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: Planteome
 products:
 - category: GraphicalInterface

--- a/resource/plo/plo.md
+++ b/resource/plo/plo.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: http://www.sanger.ac.uk/Users/mb4/PLO/
 id: plo
-last_modified_date: '2026-07-10T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Plasmodium life cycle
 products:
 - category: OntologyProduct

--- a/resource/probe-miner/probe-miner.md
+++ b/resource/probe-miner/probe-miner.md
@@ -23,11 +23,11 @@ domains:
 homepage_url: https://probeminer.icr.ac.uk
 id: probe-miner
 infores_id: probe-miner
-last_modified_date: '2026-06-27T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://creativecommons.org/licenses/by/4.0/
+  label: CC BY 4.0
 name: Probe Miner
 products:
 - category: GraphicalInterface

--- a/resource/propreo/propreo.md
+++ b/resource/propreo/propreo.md
@@ -15,11 +15,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://lsdis.cs.uga.edu/projects/glycomics/propreo/
 id: propreo
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Proteomics data and process provenance
 products:
 - category: OntologyProduct

--- a/resource/rapdb/rapdb.md
+++ b/resource/rapdb/rapdb.md
@@ -25,11 +25,8 @@ domains:
 - agriculture
 homepage_url: https://rapdb.dna.affrc.go.jp/
 id: rapdb
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Rice Annotation Project Database
 products:
 - category: GraphicalInterface

--- a/resource/resid/resid.md
+++ b/resource/resid/resid.md
@@ -16,11 +16,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.ebi.ac.uk/RESID/
 id: resid
-last_modified_date: '2026-05-31T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Protein covalent bond
 products:
 - category: OntologyProduct

--- a/resource/rex/rex.md
+++ b/resource/rex/rex.md
@@ -11,11 +11,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://purl.obolibrary.org/obo/rex.owl
 id: rex
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Physico-chemical process
 products:
 - category: OntologyProduct

--- a/resource/sao/sao.md
+++ b/resource/sao/sao.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: http://ccdb.ucsd.edu/CCDBWebSite/sao.html
 id: sao
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Subcellular anatomy ontology
 products:
 - category: OntologyProduct

--- a/resource/semrep/semrep.md
+++ b/resource/semrep/semrep.md
@@ -22,11 +22,11 @@ domains:
 - information technology
 homepage_url: https://lhncbc.nlm.nih.gov/ii/tools/SemRep_SemMedDB_SKR.html
 id: semrep
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: https://uts.nlm.nih.gov/license.html
+  label: UMLS Metathesaurus License Agreement (SemMedDB downloads require a UTS account)
 name: SemRep
 products:
 - category: GraphicalInterface

--- a/resource/sep/sep.md
+++ b/resource/sep/sep.md
@@ -17,11 +17,8 @@ domains:
 - general
 homepage_url: http://psidev.info/index.php?q=node/312
 id: sep
-last_modified_date: '2026-06-05T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Sample processing and separation techniques
 products:
 - category: OntologyProduct

--- a/resource/sopharm/sopharm.md
+++ b/resource/sopharm/sopharm.md
@@ -15,11 +15,8 @@ domains:
 - chemistry and biochemistry
 homepage_url: http://www.loria.fr/~coulet/sopharm2.0_description.php
 id: sopharm
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Suggested Ontology for Pharmacogenomics
 products:
 - category: OntologyProduct

--- a/resource/sri-reference-kg/sri-reference-kg.md
+++ b/resource/sri-reference-kg/sri-reference-kg.md
@@ -21,12 +21,13 @@ infores_id: sri-reference-kg
 layout: resource_detail
 license:
   display_note: 'No license is declared for this resource. This is the most restrictive
-    license (custom) among its sources: alliance, ctd, goa, xenbase. Not accounted
-    for, no known license: cureid, decipher, dictybase, icd11, mmrrc, panther, rgd.'
+    license (custom) among its sources: alliance, ctd, decipher, goa, xenbase. Not
+    accounted for, no known license: cureid, dictybase, icd11, panther, rgd.'
   id: https://www.alliancegenome.org/privacy-warranty-licensing
   inferred_from:
   - alliance
   - ctd
+  - decipher
   - goa
   - xenbase
   label: Alliance Data Licensing & Privacy
@@ -34,10 +35,8 @@ license:
   status: inferred
   unresolved_sources:
   - cureid
-  - decipher
   - dictybase
   - icd11
-  - mmrrc
   - panther
   - rgd
 name: SRI-Reference KG

--- a/resource/synlethdb/synlethdb.md
+++ b/resource/synlethdb/synlethdb.md
@@ -24,11 +24,8 @@ domains:
 - drug discovery
 homepage_url: https://synlethdb.sist.shanghaitech.edu.cn/
 id: synlethdb
-last_modified_date: '2026-07-01T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: SynLethDB
 products:
 - category: Product

--- a/resource/t3db/t3db.md
+++ b/resource/t3db/t3db.md
@@ -16,11 +16,11 @@ domains:
 - pharmacology
 homepage_url: http://www.t3db.ca/
 id: t3db
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
 license:
-  id: ''
-  label: Not specified
+  id: http://www.t3db.ca/downloads
+  label: T3DB terms (free for non-commercial use; commercial use or redistribution requires permission)
 name: Toxin and Toxin Target Database
 products:
 - category: GraphicalInterface

--- a/resource/tahe/tahe.md
+++ b/resource/tahe/tahe.md
@@ -15,11 +15,8 @@ domains:
 - anatomy and development
 homepage_url: https://obofoundry.org/ontology/tahe
 id: tahe
-last_modified_date: '2026-06-01T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Terminology of Anatomy of Human Embryology
 products:
 - category: OntologyProduct

--- a/resource/tahh/tahh.md
+++ b/resource/tahh/tahh.md
@@ -15,11 +15,8 @@ domains:
 - biomedical
 homepage_url: https://obofoundry.org/ontology/tahh
 id: tahh
-last_modified_date: '2026-06-01T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Terminology of Anatomy of Human Histology
 products:
 - category: OntologyProduct

--- a/resource/tfacts/tfacts.md
+++ b/resource/tfacts/tfacts.md
@@ -16,11 +16,8 @@ domains:
 - pathways
 homepage_url: http://www.tfacts.org/
 id: tfacts
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: TFactS
 products:
 - category: DocumentationProduct

--- a/resource/treatkb/treatkb.md
+++ b/resource/treatkb/treatkb.md
@@ -22,11 +22,8 @@ domains:
 - pharmacology
 homepage_url: http://nlp.case.edu/public/data/treatKB/
 id: treatkb
-last_modified_date: '2026-07-02T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: TreatKB
 products:
 - category: DocumentationProduct

--- a/resource/tred/tred.md
+++ b/resource/tred/tred.md
@@ -17,11 +17,8 @@ domains:
 - biological systems
 homepage_url: https://rulai.cshl.edu/TRED/
 id: tred
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Transcriptional Regulatory Element Database
 products:
 - category: DocumentationProduct

--- a/resource/usdm/usdm.md
+++ b/resource/usdm/usdm.md
@@ -23,11 +23,8 @@ domains:
 - public health
 homepage_url: https://droughtmonitor.unl.edu/
 id: usdm
-last_modified_date: '2026-06-18T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: U.S. Drought Monitor
 products:
 - category: GraphicalInterface

--- a/resource/vhog/vhog.md
+++ b/resource/vhog/vhog.md
@@ -10,11 +10,8 @@ domains:
 - anatomy and development
 homepage_url: https://obofoundry.org/ontology/vhog.html
 id: vhog
-last_modified_date: '2026-09-01T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Vertebrate Homologous Ontology Group Ontology
 products:
 - category: OntologyProduct

--- a/resource/vsao/vsao.md
+++ b/resource/vsao/vsao.md
@@ -16,11 +16,8 @@ domains:
 - anatomy and development
 homepage_url: https://www.nescent.org/phenoscape/Main_Page
 id: vsao
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Vertebrate Skeletal Anatomy Ontology-
 products:
 - category: OntologyProduct

--- a/resource/ypo/ypo.md
+++ b/resource/ypo/ypo.md
@@ -17,11 +17,8 @@ domains:
 - biological systems
 homepage_url: http://www.yeastgenome.org/
 id: ypo
-last_modified_date: '2026-06-25T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Yeast phenotypes
 products: []
 publications: []

--- a/resource/zea/zea.md
+++ b/resource/zea/zea.md
@@ -16,11 +16,8 @@ domains:
 - anatomy and development
 homepage_url: http://www.maizemap.org/
 id: zea
-last_modified_date: '2026-08-06T00:00:00Z'
+last_modified_date: '2026-09-08T00:00:00Z'
 layout: resource_detail
-license:
-  id: ''
-  label: Not specified
 name: Maize gross anatomy
 products:
 - category: GraphProduct

--- a/tests/test_obo_sync_merge.py
+++ b/tests/test_obo_sync_merge.py
@@ -283,3 +283,47 @@ def test_merge_resource_metadata_keeps_curated_license_label_for_same_url(tmp_pa
 
     filled = syncer.merge_resource_metadata({"id": "hp"}, {"id": "hp", "license": synced_same})
     assert filled["license"] == synced_same
+
+
+def test_transform_obo_omits_license_when_upstream_has_none(tmp_path):
+    """An ontology without a license upstream gets no license block.
+
+    A placeholder such as ``label: Not specified`` counts as missing on the
+    quality dashboard and in license inference, and it hides the gap on the
+    page (#719). No block is the honest shape.
+    """
+    syncer = OBOFoundrySync(registry_root=str(tmp_path / "resource"))
+
+    for upstream in ({"id": "aao", "title": "AAO"},
+                     {"id": "aao", "title": "AAO", "license": {}},
+                     {"id": "aao", "title": "AAO", "license": None},
+                     {"id": "aao", "title": "AAO", "license": ""}):
+        resource = syncer.transform_obo_to_kg_registry(upstream)
+        assert "license" not in resource, upstream
+        page = syncer.create_resource_markdown(resource)
+        assert "license" not in page.split("---")[1]
+
+    with_license = syncer.transform_obo_to_kg_registry(
+        {
+            "id": "go",
+            "title": "Gene Ontology",
+            "license": {"url": "https://creativecommons.org/licenses/by/4.0/", "label": "CC BY 4.0"},
+        }
+    )
+    assert with_license["license"] == {
+        "id": "https://creativecommons.org/licenses/by/4.0/",
+        "label": "CC BY 4.0",
+    }
+
+    label_only = syncer.transform_obo_to_kg_registry(
+        {"id": "x", "title": "X", "license": {"label": "CC BY 3.0"}}
+    )
+    assert label_only["license"] == {"id": "", "label": "CC BY 3.0"}
+
+
+def test_merge_resource_metadata_keeps_curated_license_when_sync_has_none(tmp_path):
+    syncer = OBOFoundrySync(registry_root=str(tmp_path / "resource"))
+    curated = {"id": "https://creativecommons.org/licenses/by/4.0/", "label": "CC BY 4.0"}
+
+    merged = syncer.merge_resource_metadata({"id": "pao", "license": curated}, {"id": "pao"})
+    assert merged["license"] == curated

--- a/tests/test_obo_sync_merge.py
+++ b/tests/test_obo_sync_merge.py
@@ -294,10 +294,12 @@ def test_transform_obo_omits_license_when_upstream_has_none(tmp_path):
     """
     syncer = OBOFoundrySync(registry_root=str(tmp_path / "resource"))
 
-    for upstream in ({"id": "aao", "title": "AAO"},
-                     {"id": "aao", "title": "AAO", "license": {}},
-                     {"id": "aao", "title": "AAO", "license": None},
-                     {"id": "aao", "title": "AAO", "license": ""}):
+    for upstream in (
+        {"id": "aao", "title": "AAO"},
+        {"id": "aao", "title": "AAO", "license": {}},
+        {"id": "aao", "title": "AAO", "license": None},
+        {"id": "aao", "title": "AAO", "license": ""},
+    ):
         resource = syncer.transform_obo_to_kg_registry(upstream)
         assert "license" not in resource, upstream
         page = syncer.create_resource_markdown(resource)
@@ -307,7 +309,10 @@ def test_transform_obo_omits_license_when_upstream_has_none(tmp_path):
         {
             "id": "go",
             "title": "Gene Ontology",
-            "license": {"url": "https://creativecommons.org/licenses/by/4.0/", "label": "CC BY 4.0"},
+            "license": {
+                "url": "https://creativecommons.org/licenses/by/4.0/",
+                "label": "CC BY 4.0",
+            },
         }
     )
     assert with_license["license"] == {

--- a/util/sync_obo_foundry.py
+++ b/util/sync_obo_foundry.py
@@ -253,6 +253,26 @@ class OBOFoundrySync:
 
             raise
 
+    @staticmethod
+    def _license_from_obo(license_info: Any) -> Optional[Dict[str, Any]]:
+        """Build a License object from an OBO Foundry license entry.
+
+        Returns None when the entry names no license, so that the page
+        carries no license block rather than a placeholder.
+        """
+        if isinstance(license_info, dict):
+            url = (license_info.get('url') or '').strip()
+            label = (license_info.get('label') or '').strip()
+            if not url and not label:
+                return None
+            license_obj: Dict[str, Any] = {'id': url, 'label': label or url}
+            if license_info.get('logo'):
+                license_obj['logo'] = license_info['logo']
+            return license_obj
+        if license_info:
+            return {'id': '', 'label': str(license_info).strip()}
+        return None
+
     def transform_obo_to_kg_registry(self, obo_ontology: Dict[str, Any]) -> Dict[str, Any]:
         """Transform OBO Foundry ontology metadata to KG-Registry format"""
 
@@ -278,20 +298,11 @@ class OBOFoundrySync:
         # Get repository
         repository = obo_ontology.get('repository')
 
-        # Get license information - format as License object
-        license_info = obo_ontology.get('license', {})
-        if isinstance(license_info, dict):
-            license_obj = {
-                'id': license_info.get('url', ''),
-                'label': license_info.get('label', 'Not specified')
-            }
-            if license_info.get('logo'):
-                license_obj['logo'] = license_info['logo']
-        else:
-            license_obj = {
-                'id': '',
-                'label': str(license_info) if license_info else 'Not specified'
-            }
+        # Get license information - format as License object. An ontology
+        # with no license upstream gets no license block at all. A placeholder
+        # ("Not specified") would count as missing on the quality dashboard
+        # and hide the gap from the page (#719).
+        license_obj = self._license_from_obo(obo_ontology.get('license'))
 
         # Enhancement 1: Transform contact information to Contact class objects
         contacts = []
@@ -463,7 +474,6 @@ class OBOFoundrySync:
             'activity_status': activity_status,
             'homepage_url': homepage_url,
             'repository': repository,
-            'license': license_obj,
             'domains': domains,  # Use 'domains' (plural) as per schema
             'contacts': contacts,
             'products': products,
@@ -472,6 +482,8 @@ class OBOFoundrySync:
             'layout': 'resource_detail',
             'category': 'Ontology'  # Set category to Ontology for OBO Foundry ontologies
         }
+        if license_obj:
+            kg_resource['license'] = license_obj
 
         # Add tags if available
         if tags:
@@ -847,7 +859,7 @@ class OBOFoundrySync:
             'activity_status': resource_data['activity_status'],
             'homepage_url': resource_data.get('homepage_url'),
             'repository': resource_data.get('repository'),
-            'license': resource_data['license'],
+            'license': resource_data.get('license'),
             'collection': resource_data['collection'],
             'layout': resource_data['layout'],
             'category': resource_data['category']


### PR DESCRIPTION
Closes #719.

Each of the 85 placeholder license blocks became a real license or nothing. The count of `label: Not specified` under `resource/` is now zero.

## Source of the placeholder

`util/sync_obo_foundry.py` wrote `id: '' / label: Not specified` for every ontology the OBO Foundry registry lists without a license. It now writes no license key in that case, and a sync without a license leaves a curated one alone. Before this fix the placeholder overwrote a curated license on the next sync, because its empty URL never matched the curated one. Two tests cover the new behavior.

## How the 85 split

| Outcome | Pages |
|---|---|
| Removed: inactive or orphaned OBO ontology with no upstream license | 48 |
| Removed: data source whose site (or archived copy) states no license | 17 |
| Set to a license stated by the resource | 20 |

Removed data sources: araport, bluesky, chembank, cureid, dcdb, endb, enhanceratlas, gad, hifld, maizegdb, mtbs, rapdb, synlethdb, tfacts, tred, treatkb, usdm.

Set:

- CC BY 4.0: ccre (ENCODE data policy), pao, phenomebrowser, planteome, probe-miner
- CC BY-NC-SA 3.0: gomapman, matador
- MIT: greenclaims
- GPL-3.0: fire (FIREcaller package DESCRIPTION)
- LGPL: oreganno (stated by the project for its data and web application)
- Public domain: dbvar (NCBI policy page, matching clinvar), inxight-drugs (NCATS statement on the site)
- Custom terms: decipher, effas-kpi, kentucky-cancer-registry, louisiana-tumor-registry, mmrrc, motifmap, semrep, t3db

Every license set came from a statement on the resource's own site, repo, or an archived copy where the site is gone. Six rest on archived pages: matador, motifmap, oreganno, probe-miner, semrep, t3db. Nothing was inferred from institution type; USDM, GAD, and MTBS carry no public-domain statement and were removed.

## Downstream

Inferred licenses on gp-kg, pharmdb, and sri-reference-kg were regenerated. Only their source notes changed; no tier moved. The quality dashboard will report 65 more missing licenses, since those pages no longer hide the gap.

## Checks

- All 85 pages pass `extract-metadata.py validate`.
- `pytest tests` passes (170 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYK9cjNDKGkTiGGjYKDunL
